### PR TITLE
Docs: fix reference config article

### DIFF
--- a/docs/_data/sidebars/reference.yml
+++ b/docs/_data/sidebars/reference.yml
@@ -3,11 +3,11 @@
 entries:
   f:
 
+  - title: Config
+    url: /reference/config.html
+
   - title: Build
     sf:
-
-    - title: Config
-      url: /reference/build/config.html
 
     - title: Stages
       url: /reference/build/stages.html

--- a/docs/_data/topnav.yml
+++ b/docs/_data/topnav.yml
@@ -10,7 +10,7 @@ topnav:
 
   - title: Reference
     directory: /reference/
-    url: /reference/build/config.html
+    url: /reference/config.html
 
   - title: Publications
     url: /publications.html

--- a/docs/pages/how_to/artifacts.md
+++ b/docs/pages/how_to/artifacts.md
@@ -22,6 +22,9 @@ The example application is the [Hotel Booking Example](https://github.com/revel/
 Create a `booking` directory and place the following `werf.yaml` in the `booking` directory:
 {% raw %}
 ```yaml
+project: hotel-booking
+---
+
 dimg: go-booking
 from: golang
 ansible:
@@ -114,6 +117,9 @@ Replace `werf.yaml` with the following content:
 
 {% raw %}
 ```yaml
+project: hotel-booking
+---
+
 artifact: booking-app
 from: golang
 ansible:

--- a/docs/pages/how_to/deploy_into_kubernetes.md
+++ b/docs/pages/how_to/deploy_into_kubernetes.md
@@ -9,7 +9,7 @@ author: Timofey Kirillov <timofey.kirillov@flant.com>
 
 How to deploy application into Kubernetes using Werf.
 
-Werf uses helm with some additions to deploy applications into Kubernetes. In this article we will create a simple web application, build all needed images, write helm templates and run it on your kubernetes cluster.
+Werf uses Helm with some additions to deploy applications into Kubernetes. In this article we will create a simple web application, build all needed images, write helm templates and run it on your kubernetes cluster.
 
 ## Requirements
 
@@ -64,6 +64,9 @@ cd myapp
 We need to prepare main application image with a web server. Create the following `werf.yaml` in the root of the application directory:
 
 ```yaml
+project: myapp
+---
+
 dimg: ~
 from: python:alpine
 ansible:

--- a/docs/pages/how_to/getting_started.md
+++ b/docs/pages/how_to/getting_started.md
@@ -18,7 +18,7 @@ In this tutorial, we will build an image of simple PHP [Symfony application](htt
 1. Setting up the IP address that the web server will listen to. This is done with a setting in `/opt/start.sh`, which will run when the container starts.
 1. Making custom setup actions. As an illustration for the setup stage, we will write current date to `version.txt`.
 
-Also, we will check that the application works and push the image in a docker registry. 
+Also, we will check that the application works and push the image in a docker registry.
 
 ## Requirements
 
@@ -45,6 +45,9 @@ To implement these steps and requirements with werf we will add a special file c
     <div id="Ansible" class="tabcontent active" markdown="1">
       {% raw %}
       ```yaml
+      project: symfony-demo
+      ---
+
       dimg: ~
       from: ubuntu:16.04
       docker:
@@ -132,13 +135,16 @@ To implement these steps and requirements with werf we will add a special file c
         to: /app
         owner: app
         group: app
-      ```   
+      ```
       {% endraw %}
     </div>
 
     <div id="Shell" class="tabcontent" markdown="1">
       {% raw %}
       ```yaml
+      project: symfony-demo
+      ---
+
       dimg: ~
       from: ubuntu:16.04
       docker:

--- a/docs/pages/how_to/mounts.md
+++ b/docs/pages/how_to/mounts.md
@@ -18,6 +18,9 @@ The example application is the [Hotel Booking Example](https://github.com/revel/
 Create a `booking` directory and place the following `werf.yaml` in the `booking` directory:
 {% raw %}
 ```yaml
+project: hotel-booking
+---
+
 {{ $_ := set . "GoDlPath" "https://dl.google.com/go/" }}
 {{ $_ := set . "GoTarball" "go1.11.1.linux-amd64.tar.gz" }}
 {{ $_ := set . "GoTarballChecksum" "sha256:2871270d8ff0c8c69f161aaae42f9f28739855ff5c5204752a8d92a1c9f63993" }}
@@ -193,6 +196,9 @@ Add the following to mount directives into config:
 
 {% raw %}
 ```yaml
+project: hotel-booking
+---
+
 {{ $_ := set . "GoDlPath" "https://dl.google.com/go/" }}
 {{ $_ := set . "GoTarball" "go1.11.1.linux-amd64.tar.gz" }}
 {{ $_ := set . "GoTarballChecksum" "sha256:2871270d8ff0c8c69f161aaae42f9f28739855ff5c5204752a8d92a1c9f63993" }}

--- a/docs/pages/how_to/multi_images.md
+++ b/docs/pages/how_to/multi_images.md
@@ -215,6 +215,9 @@ To build an application with all of its components create the following `werf.ya
 
 {% raw %}
 ```yaml
+project: atsea-shop
+---
+
 artifact: storefront
 from: node:latest
 git:

--- a/docs/pages/reference/build/assembly_instructions.md
+++ b/docs/pages/reference/build/assembly_instructions.md
@@ -6,12 +6,12 @@ summary: |
   <a class="google-drawings" href="https://docs.google.com/drawings/d/e/2PACX-1vQcjW39mf0TUxI7yqNzKPq4_9ffzg2IsMxQxu1Uk1-M0V_Wq5HxZCQJ6x-iD-33u2LN25F1nbk_1Yx5/pub?w=2031&amp;h=144" data-featherlight="image">
       <img src="https://docs.google.com/drawings/d/e/2PACX-1vQcjW39mf0TUxI7yqNzKPq4_9ffzg2IsMxQxu1Uk1-M0V_Wq5HxZCQJ6x-iD-33u2LN25F1nbk_1Yx5/pub?w=1016&amp;h=72">
   </a>
-  
+
   <div class="tab">
     <button class="tablinks active" onclick="openTab(event, 'shell')">Shell</button>
     <button class="tablinks" onclick="openTab(event, 'ansible')">Ansible</button>
   </div>
-  
+
   <div id="shell" class="tabcontent active">
     <div class="language-yaml highlighter-rouge"><pre class="highlight"><code><span class="na">shell</span><span class="pi">:</span>
     <span class="na">beforeInstall</span><span class="pi">:</span>
@@ -29,7 +29,7 @@ summary: |
     <span class="na">setupCacheVersion</span><span class="pi">:</span> <span class="s">&lt;arbitrary string&gt;</span></code></pre>
     </div>
   </div>
-  
+
   <div id="ansible" class="tabcontent">
     <div class="language-yaml highlighter-rouge"><pre class="highlight"><code><span class="na">ansible</span><span class="pi">:</span>
     <span class="na">beforeInstall</span><span class="pi">:</span>
@@ -47,10 +47,10 @@ summary: |
     <span class="na">setupCacheVersion</span><span class="pi">:</span> <span class="s">&lt;arbitrary string&gt;</span></code></pre>
       </div>
   </div>
-  
+
   <br/>
   <b>Running assembly instructions with git</b>
-  
+
   <a class="google-drawings" href="https://docs.google.com/drawings/d/e/2PACX-1vRv56S-dpoTSzLC_24ifLqJHQoHdmJ30l1HuAS4dgqBgUzZdNQyA1balT-FwK16pBbbXqlLE3JznYDk/pub?w=1956&amp;h=648" data-featherlight="image">
     <img src="https://docs.google.com/drawings/d/e/2PACX-1vRv56S-dpoTSzLC_24ifLqJHQoHdmJ30l1HuAS4dgqBgUzZdNQyA1balT-FwK16pBbbXqlLE3JznYDk/pub?w=622&amp;h=206">
   </a>
@@ -89,7 +89,7 @@ repository can cause a rebuild of different _user stages_.
 
 ### More build tools: shell, ansible, ...
 
-_Shell_ is a familiar and well-known build tool. Ansible is a newer tool and it 
+_Shell_ is a familiar and well-known build tool. Ansible is a newer tool and it
 needs some time for learning.
 
 If you need prototype as soon as possible then _the shell_ is enough — it works
@@ -181,7 +181,7 @@ Builder directives also contain ***cacheVersion  directives*** that are user-def
 
 ## Shell
 
-Syntax for _user stages_ with _shell assembly instructions_: 
+Syntax for _user stages_ with _shell assembly instructions_:
 
 ```yaml
 shell:
@@ -225,7 +225,7 @@ bash -ec 'eval $(echo YXB0LWdldCB1cGRhdGUgJiYgYXB0LWdldCBpbnN0YWxsIC15IGJ1aWxkLW
 
 ## Ansible
 
-Syntax for _user stages_ with _ansible assembly instructions_: 
+Syntax for _user stages_ with _ansible assembly instructions_:
 
 ```yaml
 ansible:
@@ -366,7 +366,7 @@ Werf renders that snippet as go template and then transforms it into this `playb
 ```yaml
 - hosts: all
   gather_facts: no
-  tasks:   
+  tasks:
     install:
     - copy:
         content: |
@@ -500,7 +500,7 @@ Build for the next commit renders _beforeInstall command_ into:
 
 ```bash
 echo "Commands on the Before Install stage for 36e907f8b6a639bd99b4ea812dae7a290e84df27"
-``` 
+```
 
 Using `CI_COMMIT_SHA` assembly instructions text changes every commit.
 So this configuration rebuilds _before_install user stage_ on every commit.
@@ -610,7 +610,7 @@ This image can be used as base image for multiple applications if images from hu
 
 ### External dependency example
 
-_CacheVersion directives_ can be used with [go templates]({{ site.baseurl }}/reference/build/config.html#go-templates) to define _user stage_ dependency on files, not in the git tree. 
+_CacheVersion directives_ can be used with [go templates]({{ site.baseurl }}/reference/config.html#go-templates) to define _user stage_ dependency on files, not in the git tree.
 
 {% raw %}
 ```yaml

--- a/docs/pages/reference/deploy/deploy_to_kubernetes.md
+++ b/docs/pages/reference/deploy/deploy_to_kubernetes.md
@@ -7,6 +7,10 @@ author: Timofey Kirillov <timofey.kirillov@flant.com>
 
 Werf uses [helm](https://helm.sh/) kubernetes package manager to deploy applications into kubernetes.
 
+[Link to installation: helm should be installed at the moment.]
+
+[Naming templates: defaults and how to configure, link to main config page]
+
 ## Installing helm
 
 Before using werf for deploy, you should install [helm](https://docs.helm.sh/using_helm/#installing-helm) and its back-end part — [tiller](https://docs.helm.sh/using_helm/#installing-tiller).

--- a/pkg/config/parser.go
+++ b/pkg/config/parser.go
@@ -55,7 +55,7 @@ func ParseWerfConfig(werfConfigPath string) (*WerfConfig, error) {
 			"project: %s\n" +
 			"---\n" +
 			"```\n\n" +
-			"Read more about meta doc here, https://flant.github.io/werf/reference/build/werf_config.html"
+			"Read more about meta doc here, https://flant.github.io/werf/reference/config.html#meta-configuration-doc"
 
 		return nil, fmt.Errorf(format, defaultProjectName)
 	}

--- a/pkg/config/raw_meta.go
+++ b/pkg/config/raw_meta.go
@@ -1,5 +1,11 @@
 package config
 
+import (
+	"fmt"
+
+	"github.com/flant/werf/pkg/slug"
+)
+
 type rawMeta struct {
 	Project         *string            `yaml:"project,omitempty"`
 	DeployTemplates rawDeployTemplates `yaml:"deploy,omitempty"`
@@ -24,6 +30,10 @@ func (c *rawMeta) UnmarshalYAML(unmarshal func(interface{}) error) error {
 
 	if c.Project != nil && *c.Project == "" {
 		return newDetailedConfigError("project field cannot be empty!", nil, c.doc)
+	}
+
+	if err := slug.ValidateProject(*c.Project); err != nil {
+		return newDetailedConfigError(fmt.Sprintf("bad project name '%s' specified in config: %s", *c.Project, err), nil, c.doc)
 	}
 
 	return nil


### PR DESCRIPTION
* Describe meta config.
* Move config article onto toplevel reference.
* Fix howto's werf.yaml to include meta configuration doc with project name.
