### PR TITLE
`werf_container_env` always returns block with DOCKER_IMAGE_ID variable

### DIFF
--- a/docs/pages/reference/deploy/chart_configuration.md
+++ b/docs/pages/reference/deploy/chart_configuration.md
@@ -74,7 +74,7 @@ An example of using a template in case a single unnamed image exists in the conf
 
 ### The `werf_container_env` template
 
-Enables streamlining the release process if the image remains unchanged. Generates a block with the `DOCKER_IMAGE_ID` environment variable for the pod container, but only if `.Values.global.werf.is_branch=true`, because in this case the image for an appropriate docker tag might have been updated through its name remained unchanged. The `DOCKER_IMAGE_ID` variable contains a new id docker for an image, which forces kubernetes to update an asset. The template may return multiple strings, which is why it must be used together with `indent`.
+Enables streamlining the release process if the image remains unchanged. Generates a block with the `DOCKER_IMAGE_ID` environment variable for the pod container. Image id will be set to real value only if `.Values.global.werf.is_branch=true`, because in this case the image for an appropriate docker tag might have been updated through its name remained unchanged. The `DOCKER_IMAGE_ID` variable contains a new id docker for an image, which forces kubernetes to update an asset. The template may return multiple strings, which is why it must be used together with `indent`.
 
 An example of using a template in case multiple images exist in the `werf.yaml` config:
 * `tuple <image-name> . | include "werf_container_env" | indent <N-spaces>`

--- a/pkg/deploy/werf_chart_helpers.go
+++ b/pkg/deploy/werf_chart_helpers.go
@@ -108,6 +108,9 @@ image: {{ tuple $name $context | include "_image2" }}
 {{-   if $context.Values.global.werf.ci.is_branch -}}
 - name: DOCKER_IMAGE_ID
   value: {{ tuple $context | include "_image_id" }}
+{{-   else -}}
+- name: DOCKER_IMAGE_ID
+  value: "-"
 {{-   end -}}
 {{- end -}}
 
@@ -117,6 +120,9 @@ image: {{ tuple $name $context | include "_image2" }}
 {{-   if $context.Values.global.werf.ci.is_branch -}}
 - name: DOCKER_IMAGE_ID
   value: {{ tuple $name $context | include "_image_id2" }}
+{{-   else -}}
+- name: DOCKER_IMAGE_ID
+  value: "-"
 {{-   end -}}
 {{- end -}}
 


### PR DESCRIPTION
closes #1114