### PR TITLE
Fix GC panic in 'werf ci-env'

### DIFF
--- a/cmd/werf/ci_env/ci_env.go
+++ b/cmd/werf/ci_env/ci_env.go
@@ -85,6 +85,11 @@ func generateGitlabEnvs() error {
 		dockerConfigPath = filepath.Join(os.Getenv("HOME"), ".docker")
 	}
 
+	// First init needed for tmp_manager GC
+	if err := docker.Init(""); err != nil {
+		return err
+	}
+
 	dockerConfig, err := tmp_manager.CreateDockerConfigDir(dockerConfigPath)
 	if err != nil {
 		return fmt.Errorf("unable to create tmp docker config: %s", err)
@@ -94,6 +99,7 @@ func generateGitlabEnvs() error {
 		return err
 	}
 
+	// Init with new docker config dir
 	if err := docker.Init(dockerConfig); err != nil {
 		return err
 	}


### PR DESCRIPTION
Init docker twice: 1) before tmp_manager docker-config creation with default config; 2) after docker-config dir has been created in tmp_manager.