### PR TITLE
Fixes: allow spaces in git files, patch stage with binary files

### DIFF
--- a/pkg/build/initialization_phase.go
+++ b/pkg/build/initialization_phase.go
@@ -184,8 +184,10 @@ func generateStages(imageInterfaceConfig config.ImageInterface, c *Conveyor) ([]
 	}
 
 	gitPatchStageOptions := &stage.NewGitPatchStageOptions{
-		PatchesDir:          getImagePatchesDir(imageName, c),
-		ContainerPatchesDir: getImagePatchesContainerDir(c),
+		PatchesDir:           getImagePatchesDir(imageName, c),
+		ArchivesDir:          getImageArchivesDir(imageName, c),
+		ContainerPatchesDir:  getImagePatchesContainerDir(c),
+		ContainerArchivesDir: getImageArchivesContainerDir(c),
 	}
 
 	gitPaths, err := generateGitPaths(imageBaseConfig, c)

--- a/pkg/build/stage/git_patch.go
+++ b/pkg/build/stage/git_patch.go
@@ -8,14 +8,18 @@ import (
 )
 
 type NewGitPatchStageOptions struct {
-	PatchesDir          string
-	ContainerPatchesDir string
+	PatchesDir           string
+	ArchivesDir          string
+	ContainerPatchesDir  string
+	ContainerArchivesDir string
 }
 
 func newGitPatchStage(name StageName, gitPatchStageOptions *NewGitPatchStageOptions, baseStageOptions *NewBaseStageOptions) *GitPatchStage {
 	s := &GitPatchStage{
-		PatchesDir:          gitPatchStageOptions.PatchesDir,
-		ContainerPatchesDir: gitPatchStageOptions.ContainerPatchesDir,
+		PatchesDir:           gitPatchStageOptions.PatchesDir,
+		ArchivesDir:          gitPatchStageOptions.ArchivesDir,
+		ContainerPatchesDir:  gitPatchStageOptions.ContainerPatchesDir,
+		ContainerArchivesDir: gitPatchStageOptions.ContainerArchivesDir,
 	}
 	s.GitStage = newGitStage(name, baseStageOptions)
 	return s
@@ -24,8 +28,10 @@ func newGitPatchStage(name StageName, gitPatchStageOptions *NewGitPatchStageOpti
 type GitPatchStage struct {
 	*GitStage
 
-	PatchesDir          string
-	ContainerPatchesDir string
+	PatchesDir           string
+	ArchivesDir          string
+	ContainerPatchesDir  string
+	ContainerArchivesDir string
 }
 
 func (s *GitPatchStage) IsEmpty(c Conveyor, prevBuiltImage image.ImageInterface) (bool, error) {
@@ -101,6 +107,7 @@ func (s *GitPatchStage) prepareImage(c Conveyor, prevBuiltImage, image image.Ima
 
 	image.Container().RunOptions().AddVolumeFrom(gitArtifactContainerName)
 	image.Container().RunOptions().AddVolume(fmt.Sprintf("%s:%s:ro", s.PatchesDir, s.ContainerPatchesDir))
+	image.Container().RunOptions().AddVolume(fmt.Sprintf("%s:%s:ro", s.ArchivesDir, s.ContainerArchivesDir))
 
 	return nil
 }

--- a/pkg/true_git/diff_parser.go
+++ b/pkg/true_git/diff_parser.go
@@ -215,9 +215,23 @@ func (p *diffParser) handleDiffLine(line string) error {
 }
 
 func (p *diffParser) handleDiffBegin(line string) error {
-	lineParts := strings.Split(line, " ")
+	var lineParts []string
+	var aAndBParts []string
+	var a, b string
 
-	a, b := lineParts[2], lineParts[3]
+	lineParts = strings.SplitN(line, " \"a/", 2)
+	if len(lineParts) == 2 {
+		aAndBParts = strings.SplitN(lineParts[1], " \"b/", 2)
+		a, b = fmt.Sprintf("\"a/%s", aAndBParts[0]), fmt.Sprintf("\"b/%s", aAndBParts[1])
+	} else {
+		lineParts = strings.SplitN(line, " a/", 2)
+		if len(lineParts) == 2 {
+			aAndBParts = strings.SplitN(lineParts[1], " b/", 2)
+			a, b = fmt.Sprintf("a/%s", aAndBParts[0]), fmt.Sprintf("b/%s", aAndBParts[1])
+		} else {
+			return fmt.Errorf("unexpected diff begin line: %#v", line)
+		}
+	}
 
 	trimmedPaths := make(map[string]string)
 


### PR DESCRIPTION
Patch stage could apply archive instead of patch, if patch contains binary files. Mount host archives dir for the patches stage.