### PR TITLE
Fix 'werf ci-env' + 'werf deploy' gives error 'exactly one tag should be specified for deploy'

### DIFF
--- a/cmd/werf/ci_env/ci_env.go
+++ b/cmd/werf/ci_env/ci_env.go
@@ -11,6 +11,7 @@ import (
 	"github.com/flant/werf/pkg/docker"
 	"github.com/flant/werf/pkg/docker_registry"
 	"github.com/flant/werf/pkg/lock"
+	"github.com/flant/werf/pkg/slug"
 	"github.com/flant/werf/pkg/tmp_manager"
 	"github.com/flant/werf/pkg/werf"
 )
@@ -135,9 +136,7 @@ func generateGitlabEnvs() error {
 		ciGitTag = os.Getenv("CI_BUILD_TAG")
 	} else if os.Getenv("CI_COMMIT_TAG") != "" {
 		ciGitTag = os.Getenv("CI_COMMIT_TAG")
-	}
-
-	if os.Getenv("CI_BUILD_REF_NAME") != "" {
+	} else if os.Getenv("CI_BUILD_REF_NAME") != "" {
 		ciGitBranch = os.Getenv("CI_BUILD_REF_NAME")
 	} else if os.Getenv("CI_COMMIT_REF_NAME") != "" {
 		ciGitBranch = os.Getenv("CI_COMMIT_REF_NAME")
@@ -150,8 +149,12 @@ func generateGitlabEnvs() error {
 	printExportCommand("WERF_IMAGES_REPO", imagesRepo)
 
 	printHeader("TAGGING", true)
-	printExportCommand("WERF_TAG_GIT_TAG", ciGitTag)
-	printExportCommand("WERF_TAG_GIT_BRANCH", ciGitBranch)
+	if ciGitTag != "" {
+		printExportCommand("WERF_TAG_GIT_TAG", slug.DockerTag(ciGitTag))
+	}
+	if ciGitBranch != "" {
+		printExportCommand("WERF_TAG_GIT_BRANCH", slug.DockerTag(ciGitBranch))
+	}
 
 	printHeader("DEPLOY", true)
 	printExportCommand("WERF_ENV", os.Getenv("CI_ENVIRONMENT_SLUG"))

--- a/cmd/werf/ci_env/ci_env.go
+++ b/cmd/werf/ci_env/ci_env.go
@@ -88,10 +88,7 @@ func generateGitlabEnvs() error {
 		dockerConfigPath = filepath.Join(os.Getenv("HOME"), ".docker")
 	}
 
-	// First init needed for tmp_manager GC
-	if err := docker.Init(""); err != nil {
-		return err
-	}
+	tmp_manager.AutoGCEnabled = false
 
 	dockerConfig, err := tmp_manager.CreateDockerConfigDir(dockerConfigPath)
 	if err != nil {

--- a/cmd/werf/common/tags.go
+++ b/cmd/werf/common/tags.go
@@ -62,25 +62,40 @@ func GetTagOptions(cmdData *CmdData, opts TagOptionsGetterOptions) (build.TagOpt
 	for _, tag := range *cmdData.TagCustom {
 		err := slug.ValidateDockerTag(tag)
 		if err != nil {
-			return build.TagOptions{}, fmt.Errorf("bad --tag parameter '%s' specified: %s", tag, err)
+			return build.TagOptions{}, fmt.Errorf("bad --tag-custom parameter '%s' specified: %s", tag, err)
 		}
 
 		res.CustomTags = append(res.CustomTags, tag)
 		emptyTags = false
 	}
 
-	if *cmdData.TagGitBranch != "" {
-		res.TagsByGitBranch = append(res.TagsByGitBranch, slug.DockerTag(*cmdData.TagGitBranch))
+	if tag := *cmdData.TagGitBranch; tag != "" {
+		err := slug.ValidateDockerTag(tag)
+		if err != nil {
+			return build.TagOptions{}, fmt.Errorf("bad --tag-git-branch paramter '%s' specified: %s", tag, err)
+		}
+
+		res.TagsByGitBranch = append(res.TagsByGitBranch)
 		emptyTags = false
 	}
 
-	if *cmdData.TagGitTag != "" {
-		res.TagsByGitTag = append(res.TagsByGitTag, slug.DockerTag(*cmdData.TagGitTag))
+	if tag := *cmdData.TagGitTag; tag != "" {
+		err := slug.ValidateDockerTag(tag)
+		if err != nil {
+			return build.TagOptions{}, fmt.Errorf("bad --tag-git-tag paramter '%s' specified: %s", tag, err)
+		}
+
+		res.TagsByGitTag = append(res.TagsByGitTag, tag)
 		emptyTags = false
 	}
 
-	if *cmdData.TagGitCommit != "" {
-		res.TagsByGitCommit = append(res.TagsByGitCommit, *cmdData.TagGitCommit)
+	if tag := *cmdData.TagGitCommit; tag != "" {
+		err := slug.ValidateDockerTag(tag)
+		if err != nil {
+			return build.TagOptions{}, fmt.Errorf("bad --tag-git-commit paramter '%s' specified: %s", tag, err)
+		}
+
+		res.TagsByGitCommit = append(res.TagsByGitCommit, tag)
 		emptyTags = false
 	}
 

--- a/pkg/tmp_manager/gc.go
+++ b/pkg/tmp_manager/gc.go
@@ -12,6 +12,10 @@ import (
 	"github.com/flant/werf/pkg/logger"
 )
 
+var (
+	AutoGCEnabled = true
+)
+
 func runGC() error {
 	return lock.WithLock("gc", lock.LockOptions{}, func() error {
 		return GC(false)
@@ -19,6 +23,10 @@ func runGC() error {
 }
 
 func checkShouldRunGC() (bool, error) {
+	if !AutoGCEnabled {
+		return false, nil
+	}
+
 	releasedProjectsDir := filepath.Join(GetReleasedTmpDirs(), projectsServiceDir)
 	if _, err := os.Stat(releasedProjectsDir); !os.IsNotExist(err) {
 		var err error


### PR DESCRIPTION
\+ Do apply docker-tag werf slug automatically only in 'werf ci-env' command and do not apply this algorithm for the specified parameters --tag-git-branch, --tag-git-tag and --tag-git-commit.
