### PR TITLE
Enable StatefulSet tracking (kubedog updated)

### DIFF
--- a/pkg/deploy/helm/release.go
+++ b/pkg/deploy/helm/release.go
@@ -151,9 +151,9 @@ func doDeployHelmChart(chartPath string, releaseName string, namespace string, o
 	if err := trackDeployments(templates, deployStartTime, namespace, opts); err != nil {
 		return err
 	}
-	// if err := trackStatefulSets(templates, deployStartTime, namespace, opts); err != nil {
-	// 	return err
-	// }
+	if err := trackStatefulSets(templates, deployStartTime, namespace, opts); err != nil {
+		return err
+	}
 	if err := trackDaemonSets(templates, deployStartTime, namespace, opts); err != nil {
 		return err
 	}


### PR DESCRIPTION
Kubedog changelog:

      fix: rollout track for sts hangs in particular situations
      - support for partition: 0, no hang in this situation
      - support for automatic actions in case of OnDelete, no error
      - debug messages for sts are more clearer
      - final status works in debug mode