### PR TITLE
[deploy] Verbose parsing helm template error

### DIFF
--- a/pkg/deploy/helm/release.go
+++ b/pkg/deploy/helm/release.go
@@ -203,7 +203,7 @@ func doDeployHelmChart(chartPath, releaseName, namespace string, opts ChartOptio
 			templates, err = GetTemplatesFromChart(chartPath, releaseName, namespace, opts.Values, opts.Set, opts.SetString)
 			return err
 		}); err != nil {
-			return fmt.Errorf("unable to get templates of chart %s: %s", chartPath, err)
+			return err
 		}
 
 		return nil

--- a/pkg/deploy/helm/templates.go
+++ b/pkg/deploy/helm/templates.go
@@ -172,11 +172,11 @@ func (e *WerfEngine) Render(chrt *chart.Chart, values chartutil.Values) (map[str
 		}
 
 		var resultManifests []string
-		for _, manifest := range releaseutil.SplitManifests(fileContent) {
+		for _, manifestContent := range releaseutil.SplitManifests(fileContent) {
 			var t Template
-			err := yaml.Unmarshal([]byte(manifest), &t)
+			err := yaml.Unmarshal([]byte(manifestContent), &t)
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("parsing file %s failed: %s\n\n%s\n", fileName, err, util.NumerateLines(manifestContent, 1))
 			}
 
 			if len(t.Metadata.Annotations) == 0 {


### PR DESCRIPTION
```
Error: parsing file .helm/templates/hooks.yaml failed: yaml: line 7: found a tab character that violates indentation

     1  apiVersion: batch/v1
     2  kind: Job
     3  metadata:
     4    name: test-job
     5    annotations:
     6      "helm.sh/hook": post-install,post-upgrade
     7  	"helm.sh/hook-weight": "1"
     8      # "werf/track": "false"
     9      # "werf/track": "till_done"
    10  spec:
    11    #activeDeadlineSeconds: 10
    12    template:
    13      metadata:
    14        name: test-job
    15      spec:
    16        restartPolicy: OnFailure
    17        containers:
    18        - name: main
    19          image: ubuntu:16.04
    20          command: [ '/bin/bash', '-l', '-c', 'for i in {1..3}; do date; sleep 1; done' ]
```