### PR TITLE
Fix multi-images howto: use portable syntax for artifacts imports

### DIFF
--- a/docs/pages/how_to/multi_images.md
+++ b/docs/pages/how_to/multi_images.md
@@ -56,7 +56,7 @@ import:
   after: install
 - artifact: appserver
   add: /usr/src/atsea/target/AtSea-0.0.1-SNAPSHOT.jar
-  to: /app
+  to: /app/AtSea-0.0.1-SNAPSHOT.jar
   after: install
 ```
 
@@ -284,7 +284,7 @@ import:
   after: install
 - artifact: appserver
   add: /usr/src/atsea/target/AtSea-0.0.1-SNAPSHOT.jar
-  to: /app
+  to: /app/AtSea-0.0.1-SNAPSHOT.jar
   after: install
 ---
 image: reverse_proxy


### PR DESCRIPTION
Use exact path in `to`:

```
import:
- artifact: X
  add: PATH_TO_FILE
  to: PATH_TO_FILE
```

Non exact path will work only in 1.0.2 (which is alpha now).

refs #1561