### PR TITLE
Revert "Fix multi-images howto: use portable syntax for artifacts imports"

### DIFF
--- a/docs/pages/how_to/multi_images.md
+++ b/docs/pages/how_to/multi_images.md
@@ -56,7 +56,7 @@ import:
   after: install
 - artifact: appserver
   add: /usr/src/atsea/target/AtSea-0.0.1-SNAPSHOT.jar
-  to: /app/AtSea-0.0.1-SNAPSHOT.jar
+  to: /app
   after: install
 ```
 
@@ -284,7 +284,7 @@ import:
   after: install
 - artifact: appserver
   add: /usr/src/atsea/target/AtSea-0.0.1-SNAPSHOT.jar
-  to: /app/AtSea-0.0.1-SNAPSHOT.jar
+  to: /app
   after: install
 ---
 image: reverse_proxy


### PR DESCRIPTION
This reverts commit 80ee500ef1bbffbe7b5b7a238121c651994490f8.

refs #1561