### PR TITLE
Fix 0.36 dappfile-yml exec argument: support spaces and other specialsymbols in the project name

### DIFF
--- a/lib/dapp/dapp/dappfile.rb
+++ b/lib/dapp/dapp/dappfile.rb
@@ -92,7 +92,7 @@ module Dapp
           end
         end
 
-        cmd_res = shellout "#{dappfile_yml_bin_path} -dappfile #{dappfile_path}"
+        cmd_res = shellout dappfile_yml_bin_path, "-dappfile", dappfile_path
 
         raw_json_response = nil
         if cmd_res.exitstatus == 0


### PR DESCRIPTION
Without fix:

```
distorhead@werf:~/workspace/eh" lo' $dollar!$ bundle exec dapp dimg build
Running time 0.0 seconds
Stacktrace dumped to /tmp/dapp-stacktrace-e44e910a-09b8-4e2f-a87a-eb48a0f6bedb.out
>>> START STREAM
Expected process to exit with [0], but received '2'
---- Begin output of /home/distorhead/go/bin/dappfile-yml -dappfile /home/distorhead/workspace/eh" lo' $dollar!/dappfile.yml ----
STDOUT: 
STDERR: sh: 1: Syntax error: Unterminated quoted string
---- End output of /home/distorhead/go/bin/dappfile-yml -dappfile /home/distorhead/workspace/eh" lo' $dollar!/dappfile.yml ----
Ran /home/distorhead/go/bin/dappfile-yml -dappfile /home/distorhead/workspace/eh" lo' $dollar!/dappfile.yml returned 2
>>> END STREAM
```

With fix:

```
distorhead@werf:~/workspace/eh" lo' $dollar!$ bundle exec dapp dimg build
nameless: calculating stages signatures                                                                               [RUNNING]
nameless: calculating stages signatures                                                                                    [OK] 0.16 sec
From                                                                                                              [USING CACHE]
  signature: dimgstage-eh-lo-dollar-f26449ca:43ab74083dbc3da317431295808c62f1e63e66d56e915eefef27ed9ceb65566a
  date: 2019-07-05 14:13:05 +0300
  size: 64.184 MB
Running time 1.95 seconds
```