### PR TITLE
docs: more descriptive values for git summary section

### DIFF
--- a/docs/pages/reference/build/artifact.md
+++ b/docs/pages/reference/build/artifact.md
@@ -96,41 +96,41 @@ fromImage: <image_name>
 fromImageArtifact: <artifact_name>
 git:
 # local git
-- add: <absolute_path>
-  to: <absolute_path>
+- add: <absolute path in git repository>
+  to: <absolute path inside image>
   owner: <owner>
   group: <group>
   includePaths:
-  - <relative_path or glob>
+  - <path or glob relative to path in add>
   excludePaths:
-  - <relative_path or glob>
+  - <path or glob relative to path in add>
   stageDependencies:
     install:
-    - <relative_path or glob>
+    - <path or glob relative to path in add>
     beforeSetup:
-    - <relative_path or glob>
+    - <path or glob relative to path in add>
     setup:
-    - <relative_path or glob>
+    - <path or glob relative to path in add>
 # remote git
-- url: <git_repo_url>
-  branch: <branch_name>
+- url: <git repo url>
+  branch: <branch name>
   commit: <commit>
   tag: <tag>
-  add: <absolute_path>
-  to: <absolute_path>
+  add: <absolute path in git repository>
+  to: <absolute path inside image>
   owner: <owner>
   group: <group>
   includePaths:
-  - <relative_path or glob>
+  - <path or glob relative to path in add>
   excludePaths:
-  - <relative_path or glob>
+  - <path or glob relative to path in add>
   stageDependencies:
     install:
-    - <relative_path or glob>
+    - <path or glob relative to path in add>
     beforeSetup:
-    - <relative_path or glob>
+    - <path or glob relative to path in add>
     setup:
-    - <relative_path or glob>
+    - <path or glob relative to path in add>
 shell:
   beforeInstall:
   - <cmd>

--- a/docs/pages/reference/build/git_directive.md
+++ b/docs/pages/reference/build/git_directive.md
@@ -14,21 +14,21 @@ summary: |
 
   <div id="local" class="tabs__content active">
     <div class="language-yaml highlighter-rouge"><pre class="highlight"><code><span class="s">git</span><span class="pi">:</span>
-  <span class="pi">-</span> <span class="s">add</span><span class="pi">:</span> <span class="s">&lt;absolute path&gt;</span>
-    <span class="s">to</span><span class="pi">:</span> <span class="s">&lt;absolute path&gt;</span>
+  <span class="pi">-</span> <span class="s">add</span><span class="pi">:</span> <span class="s">&lt;absolute path in git repository&gt;</span>
+    <span class="s">to</span><span class="pi">:</span> <span class="s">&lt;absolute path inside image&gt;</span>
     <span class="s">owner</span><span class="pi">:</span> <span class="s">&lt;owner&gt;</span>
     <span class="s">group</span><span class="pi">:</span> <span class="s">&lt;group&gt;</span>
     <span class="s">includePaths</span><span class="pi">:</span>
-    <span class="pi">-</span> <span class="s">&lt;relative path or glob&gt;</span>
+    <span class="pi">-</span> <span class="s">&lt;path or glob relative to path in add&gt;</span>
     <span class="s">excludePaths</span><span class="pi">:</span>
-    <span class="pi">-</span> <span class="s">&lt;relative path or glob&gt;</span>
+    <span class="pi">-</span> <span class="s">&lt;path or glob relative to path in add&gt;</span>
     <span class="s">stageDependencies</span><span class="pi">:</span>
       <span class="s">install</span><span class="pi">:</span>
-      <span class="pi">-</span> <span class="s">&lt;relative path or glob&gt;</span>
+      <span class="pi">-</span> <span class="s">&lt;path or glob relative to path in add&gt;</span>
       <span class="s">beforeSetup</span><span class="pi">:</span>
-      <span class="pi">-</span> <span class="s">&lt;relative path or glob&gt;</span>
+      <span class="pi">-</span> <span class="s">&lt;path or glob relative to path in add&gt;</span>
       <span class="s">setup</span><span class="pi">:</span>
-      <span class="pi">-</span> <span class="s">&lt;relative path or glob&gt;</span></code></pre>
+      <span class="pi">-</span> <span class="s">&lt;path or glob relative to path in add&gt;</span></code></pre>
     </div>
   </div>
 
@@ -38,21 +38,21 @@ summary: |
     <span class="s">branch</span><span class="pi">:</span> <span class="s">&lt;branch name&gt;</span>
     <span class="s">commit</span><span class="pi">:</span> <span class="s">&lt;commit&gt;</span>
     <span class="s">tag</span><span class="pi">:</span> <span class="s">&lt;tag&gt;</span>
-    <span class="s">add</span><span class="pi">:</span> <span class="s">&lt;absolute path&gt;</span>
-    <span class="s">to</span><span class="pi">:</span> <span class="s">&lt;absolute path&gt;</span>
+    <span class="s">add</span><span class="pi">:</span> <span class="s">&lt;absolute path in git repository&gt;</span>
+    <span class="s">to</span><span class="pi">:</span> <span class="s">&lt;absolute path inside image&gt;</span>
     <span class="s">owner</span><span class="pi">:</span> <span class="s">&lt;owner&gt;</span>
     <span class="s">group</span><span class="pi">:</span> <span class="s">&lt;group&gt;</span>
     <span class="s">includePaths</span><span class="pi">:</span>
-    <span class="pi">-</span> <span class="s">&lt;relative path or glob&gt;</span>
+    <span class="pi">-</span> <span class="s">&lt;path or glob relative to path in add&gt;</span>
     <span class="s">excludePaths</span><span class="pi">:</span>
-    <span class="pi">-</span> <span class="s">&lt;relative path or glob&gt;</span>
+    <span class="pi">-</span> <span class="s">&lt;path or glob relative to path in add&gt;</span>
     <span class="s">stageDependencies</span><span class="pi">:</span>
       <span class="s">install</span><span class="pi">:</span>
-      <span class="pi">-</span> <span class="s">&lt;relative path or glob&gt;</span>
+      <span class="pi">-</span> <span class="s">&lt;path or glob relative to path in add&gt;</span>
       <span class="s">beforeSetup</span><span class="pi">:</span>
-      <span class="pi">-</span> <span class="s">&lt;relative path or glob&gt;</span>
+      <span class="pi">-</span> <span class="s">&lt;path or glob relative to path in add&gt;</span>
       <span class="s">setup</span><span class="pi">:</span>
-      <span class="pi">-</span> <span class="s">&lt;relative path or glob&gt;</span></code></pre>
+      <span class="pi">-</span> <span class="s">&lt;path or glob relative to path in add&gt;</span></code></pre>
       </div>
   </div>
 ---

--- a/docs/pages/reference/build/image_directives.md
+++ b/docs/pages/reference/build/image_directives.md
@@ -14,41 +14,41 @@ fromImage: <image name>
 fromImageArtifact: <artifact name>
 git:
 # local git
-- add: <absolute path>
-  to: <absolute path>
+- add: <absolute path in git repository>
+  to: <absolute path inside image>
   owner: <owner>
   group: <group>
   includePaths:
-  - <relative path or glob>
+  - <path or glob relative to path in add>
   excludePaths:
-  - <relative path or glob>
+  - <path or glob relative to path in add>
   stageDependencies:
     install:
-    - <relative path or glob>
+    - <path or glob relative to path in add>
     beforeSetup:
-    - <relative path or glob>
+    - <path or glob relative to path in add>
     setup:
-    - <relative path or glob>
+    - <path or glob relative to path in add>
 # remote git
 - url: <git repo url>
   branch: <branch name>
   commit: <commit>
   tag: <tag>
-  add: <absolute path>
-  to: <absolute path>
+  add: <absolute path in git repository>
+  to: <absolute path inside image>
   owner: <owner>
   group: <group>
   includePaths:
-  - <relative path or glob>
+  - <path or glob relative to path in add>
   excludePaths:
-  - <relative path or glob>
+  - <path or glob relative to path in add>
   stageDependencies:
     install:
-    - <relative path or glob>
+    - <path or glob relative to path in add>
     beforeSetup:
-    - <relative path or glob>
+    - <path or glob relative to path in add>
     setup:
-    - <relative path or glob>
+    - <path or glob relative to path in add>
 shell:
   beforeInstall:
   - <bash command>


### PR DESCRIPTION
Original
```
git:
- add: <absolute path>
  to: <absolute path>
  owner: <owner>
  group: <group>
  includePaths:
  - <relative path or glob>
  excludePaths:
  - <relative path or glob>
  stageDependencies:
    install:
    - <relative path or glob>
    beforeSetup:
    - <relative path or glob>
    setup:
    - <relative path or glob>
```

Changed:
```
git:
- add: <absolute path in git repository>
  to: <absolute path inside image>
  owner: <owner>
  group: <group>
  includePaths:
  - <path or glob relative to path in add>
  excludePaths:
  - <path or glob relative to path in add>
  stageDependencies:
    install:
    - <path or glob relative to path in add>
    beforeSetup:
    - <path or glob relative to path in add>
    setup:
    - <path or glob relative to path in add>
```

And same for the remote tab.