### PR TITLE
Fix unexpected signature change when using stageDependencies with '*' pattern

### DIFF
--- a/pkg/true_git/archive.go
+++ b/pkg/true_git/archive.go
@@ -64,7 +64,7 @@ func writeArchive(out io.Writer, gitDir, workTreeDir string, withSubmodules bool
 		}
 	}
 
-	err = switchWorkTree(gitDir, workTreeDir, opts.Commit)
+	err = switchWorkTree(gitDir, workTreeDir, opts.Commit, withSubmodules)
 	if err != nil {
 		return nil, fmt.Errorf("cannot reset work tree `%s` to commit `%s`: %s", workTreeDir, opts.Commit, err)
 	}

--- a/pkg/true_git/patch.go
+++ b/pkg/true_git/patch.go
@@ -81,7 +81,7 @@ func writePatch(out io.Writer, gitDir, workTreeDir string, withSubmodules bool, 
 	if withSubmodules {
 		var err error
 
-		err = switchWorkTree(gitDir, workTreeDir, opts.ToCommit)
+		err = switchWorkTree(gitDir, workTreeDir, opts.ToCommit, withSubmodules)
 		if err != nil {
 			return nil, fmt.Errorf("cannot reset work tree `%s` to commit `%s`: %s", workTreeDir, opts.ToCommit, err)
 		}

--- a/pkg/true_git/work_tree.go
+++ b/pkg/true_git/work_tree.go
@@ -36,7 +36,7 @@ func prepareWorkTree(gitDir, workTreeDir string, commit string, withSubmodules b
 		}
 	}
 
-	err = switchWorkTree(gitDir, workTreeDir, commit)
+	err = switchWorkTree(gitDir, workTreeDir, commit, withSubmodules)
 	if err != nil {
 		return fmt.Errorf("cannot reset work tree `%s` to commit `%s`: %s", workTreeDir, commit, err)
 	}
@@ -58,13 +58,44 @@ func prepareWorkTree(gitDir, workTreeDir string, commit string, withSubmodules b
 	return nil
 }
 
-func switchWorkTree(repoDir, workTreeDir string, commit string) error {
+func switchWorkTree(repoDir, workTreeDir string, commit string, withSubmodules bool) error {
 	var err error
+
+	err = os.RemoveAll(workTreeDir)
+	if err != nil {
+		return fmt.Errorf("unable to remove old work tree dir %s: %s", workTreeDir, err)
+	}
 
 	err = os.MkdirAll(workTreeDir, os.ModePerm)
 	if err != nil {
-		return err
+		return fmt.Errorf("unable to create work tree dir %s: %s", workTreeDir, err)
 	}
+
+	// TODO: to allow caching of work trees we need a way to switch worktrees safely
+
+	//// NOTE: git clean -dffx does not clean .git files: so delete files manually
+	//servicePathsToRemove := []string{}
+	//err = filepath.Walk(workTreeDir, func(path string, info os.FileInfo, pathErr error) error {
+	//	if pathErr != nil {
+	//		return fmt.Errorf("error accessing path %s: %s", path, pathErr)
+	//	}
+	//
+	//	if info.Name() == ".git" {
+	//		servicePathsToRemove = append(servicePathsToRemove, path)
+	//	}
+	//
+	//	return nil
+	//})
+	//if err != nil {
+	//	return fmt.Errorf("error walking the path %s: %s", workTreeDir, err)
+	//}
+	//
+	//for _, path := range servicePathsToRemove {
+	//	logboek.LogF("Removing old service file %s\n", path)
+	//	if err := os.RemoveAll(path); err != nil {
+	//		fmt.Errorf("error removing %s: %s", path, err)
+	//	}
+	//}
 
 	var cmd *exec.Cmd
 	var output *bytes.Buffer
@@ -79,15 +110,47 @@ func switchWorkTree(repoDir, workTreeDir string, commit string) error {
 		return fmt.Errorf("git reset failed: %s\n%s", err, output.String())
 	}
 
-	cmd = exec.Command(
-		"git", "--git-dir", repoDir, "--work-tree", workTreeDir,
-		"clean", "-d", "-f", "-f", "-x",
-	)
-	output = setCommandRecordingLiveOutput(cmd)
-	err = cmd.Run()
-	if err != nil {
-		return fmt.Errorf("git clean failed: %s\n%s", err, output.String())
-	}
+	//if withSubmodules {
+	//	cmd = exec.Command(
+	//		"git", "--git-dir", repoDir, "--work-tree", workTreeDir,
+	//		"submodule", "foreach", "--recursive",
+	//		"git", "reset", "--hard", commit,
+	//	)
+	//
+	//	cmd.Dir = workTreeDir // required for `git submodule` to work
+	//
+	//	output = setCommandRecordingLiveOutput(cmd)
+	//	err = cmd.Run()
+	//	if err != nil {
+	//		return fmt.Errorf("git submodules reset failed: %s\n%s", err, output.String())
+	//	}
+	//}
+	//
+	//cmd = exec.Command(
+	//	"git", "--git-dir", repoDir, "--work-tree", workTreeDir,
+	//	"clean", "-d", "-f", "-f", "-x",
+	//)
+	//output = setCommandRecordingLiveOutput(cmd)
+	//err = cmd.Run()
+	//if err != nil {
+	//	return fmt.Errorf("git clean failed: %s\n%s", err, output.String())
+	//}
+	//
+	//if withSubmodules {
+	//	cmd = exec.Command(
+	//		"git", "--git-dir", repoDir, "--work-tree", workTreeDir,
+	//		"submodule", "foreach", "--recursive",
+	//		"git", "clean", "-d", "-f", "-f", "-x",
+	//	)
+	//
+	//	cmd.Dir = workTreeDir // required for `git submodule` to work
+	//
+	//	output = setCommandRecordingLiveOutput(cmd)
+	//	err = cmd.Run()
+	//	if err != nil {
+	//		return fmt.Errorf("git submodules clean failed: %s\n%s", err, output.String())
+	//	}
+	//}
 
 	return nil
 }


### PR DESCRIPTION
Do not use work tree caching for now in true-git when switching work tree to different commit.