### PR TITLE
[deploy] Fix "runtime error: invalid memory address or nil pointer dereference"

### DIFF
--- a/cmd/werf/deploy/main.go
+++ b/cmd/werf/deploy/main.go
@@ -214,6 +214,10 @@ func runDeploy() error {
 		}
 	}
 
+	if imagesRepoManager == nil {
+		imagesRepoManager = &common.ImagesRepoManager{}
+	}
+
 	release, err := common.GetHelmRelease(*CommonCmdData.Release, *CommonCmdData.Environment, werfConfig)
 	if err != nil {
 		return err


### PR DESCRIPTION
Error occurs during deployment without werf images. Images repo manager is used in service values preparation.