### PR TITLE
[stapel image] Fix CMD and ENTRYPOINT logic

### DIFF
--- a/pkg/config/raw_docker.go
+++ b/pkg/config/raw_docker.go
@@ -72,6 +72,10 @@ func (c *rawDocker) toDirective() (docker *Docker, err error) {
 		docker.Entrypoint = entrypoint
 	}
 
+	if docker.Entrypoint != "" && docker.Cmd == "" {
+		docker.Cmd = "[]"
+	}
+
 	if c.StopSignal != nil {
 		docker.StopSignal = fmt.Sprintf("%v", c.StopSignal)
 	}
@@ -100,7 +104,12 @@ func prepareCommand(stringOrArray interface{}, configSection interface{}, doc *d
 					return cmd, newDetailedConfigError(fmt.Sprintf("single string or array of strings expected, got `%v`!", stringOrArray), configSection, doc)
 				}
 			}
-			cmd = fmt.Sprintf("[\"%s\"]", strings.Join(stringArray, "\", \""))
+
+			if len(stringArray) == 0 {
+				cmd = "[]"
+			} else {
+				cmd = fmt.Sprintf("[\"%s\"]", strings.Join(stringArray, "\", \""))
+			}
 		} else {
 			return cmd, newDetailedConfigError(fmt.Sprintf("single string or array of strings expected, got `%v`!", stringOrArray), configSection, doc)
 		}

--- a/pkg/image/stage_image_container.go
+++ b/pkg/image/stage_image_container.go
@@ -234,8 +234,13 @@ func (c *StageImageContainer) prepareInheritedCommitOptions() (*StageImageContai
 		return nil, err
 	}
 
-	inheritedOptions.Entrypoint = fmt.Sprintf("[\"%s\"]", strings.Join(fromImageInspect.Config.Entrypoint, "\", \""))
-	inheritedOptions.Cmd = fmt.Sprintf("[\"%s\"]", strings.Join(fromImageInspect.Config.Cmd, "\", \""))
+	if len(fromImageInspect.Config.Cmd) != 0 {
+		inheritedOptions.Cmd = fmt.Sprintf("[\"%s\"]", strings.Join(fromImageInspect.Config.Cmd, "\", \""))
+	}
+
+	if len(fromImageInspect.Config.Entrypoint) != 0 {
+		inheritedOptions.Entrypoint = fmt.Sprintf("[\"%s\"]", strings.Join(fromImageInspect.Config.Entrypoint, "\", \""))
+	}
 
 	inheritedOptions.User = fromImageInspect.Config.User
 	if fromImageInspect.Config.WorkingDir != "" {


### PR DESCRIPTION
* force reset CMD if a user specifies ENTRYPOINT (to ignore inherited CMD value from base image)
* reset CMD only with "[]" for all docker versions
* skip auto-resetting CMD if ENTRYPOINT is inherited or specified

close https://github.com/flant/werf/issues/1709