### PR TITLE
[doc] fix YAML in the sidebar and the Three way merge article.

### DIFF
--- a/docs/_data/sidebars/documentation.yml
+++ b/docs/_data/sidebars/documentation.yml
@@ -74,7 +74,7 @@ entries:
           - title: Differences with Helm
             url: /documentation/reference/deploy_process/differences_with_helm.html
 
-          - title: Experimental: three way merge
+          - title: "Experimental: three way merge"
             url: /documentation/reference/deploy_process/experimental_three_way_merge.html
 
       - title: Cleaning Process

--- a/docs/pages/reference/deploy_process/experimental_three_way_merge.md
+++ b/docs/pages/reference/deploy_process/experimental_three_way_merge.md
@@ -1,5 +1,5 @@
 ---
-title: Experimental: three way merge
+title: "Experimental: three way merge"
 sidebar: documentation
 permalink: documentation/reference/deploy_process/experimental_three_way_merge.html
 author: Timofey Kirillov <timofey.kirillov@flant.com>


### PR DESCRIPTION
Incorrect YAML fixed in the sidebar and the Three way merge article.