### PR TITLE
Suppress klog INFO and WARNING streams to disable excess messages from client-go

### DIFF
--- a/cmd/werf/common/kubedog.go
+++ b/cmd/werf/common/kubedog.go
@@ -1,11 +1,24 @@
 package common
 
 import (
+	"flag"
+	"io/ioutil"
+
 	"github.com/flant/kubedog/pkg/display"
 	"github.com/flant/logboek"
+	"k8s.io/klog"
 )
 
 func InitKubedog() error {
+	// set flag.Parsed() for glog
+	flag.CommandLine.Parse([]string{})
+
+	// Suppress info and warnings from client-go reflector
+	klog.SetOutputBySeverity("INFO", ioutil.Discard)
+	klog.SetOutputBySeverity("WARNING", ioutil.Discard)
+	klog.SetOutputBySeverity("ERROR", logboek.GetErrStream())
+	klog.SetOutputBySeverity("FATAL", logboek.GetErrStream())
+
 	display.SetOut(logboek.GetOutStream())
 	display.SetErr(logboek.GetErrStream())
 


### PR DESCRIPTION
refs https://github.com/flant/kubedog/issues/134
closes #1703