### PR TITLE
Fix /.werf/ansible-workdir/lib/werf/.logboek.so: cannot open shared: no such file

### DIFF
--- a/pkg/build/builder/ansible.go
+++ b/pkg/build/builder/ansible.go
@@ -70,6 +70,7 @@ func (b *Ansible) stage(userStageName string, container Container) error {
 			"LD_LIBRARY_PATH":           stapel.AnsibleLibsOverlayLDPATH(),
 			"LANG":                      "C.UTF-8",
 			"LC_ALL":                    "C.UTF-8",
+			"LOGBOEK_SO_PATH":           "/.werf/stapel/embedded/lib/python2.7/_logboek.so",
 		},
 	)
 


### PR DESCRIPTION
Old LOGBOEK_SO_PATH=/.werf/ansible-workdir/lib/werf/.logboek.so variable has been defined in the cached image layers.

The new default logboek.so location is: /.werf/stapel/embedded/lib/python2.7/_logboek.so.

So force setting of LOGBOEK_SO_PATH to /.werf/stapel/embedded/lib/python2.7/_logboek.so for compatibility with old stages cache.
