### PR TITLE
Added note about bash limitations

### DIFF
--- a/docs/_includes/readme/installation.md
+++ b/docs/_includes/readme/installation.md
@@ -41,6 +41,9 @@ curl -L https://raw.githubusercontent.com/flant/multiwerf/master/get.sh | bash
 source <(multiwerf use 1.0 beta)
 ```
 
+> _Note:_ If you are using bash versions before 4.0 (e.g. 3.2 is default for MacOS users), you must use `source /dev/stdin <<<"$(multiwerf use 1.0 beta)"` enstead of `source <(multiwerf use 1.0 beta)`
+
+
 ### Method 2: download binary
 
 The latest release can be reached via [this page](https://bintray.com/flant/werf/werf/_latestVersion)


### PR DESCRIPTION
Added note about bash limitations for users with versions before 4, for example, it can be MacOS users with default bash or gitlab-runner mounted from MacOS