### PR TITLE
[backport to v1.0.4][3-way-merge] Update option to use 3 way merge patch, ability to adopt existing resources

### DIFF
--- a/cmd/werf/common/common.go
+++ b/cmd/werf/common/common.go
@@ -73,6 +73,8 @@ type CmdData struct {
 	LogColorMode     *string
 	LogProjectDir    *bool
 	LogTerminalWidth *int64
+
+	ThreeWayMergeMode *string
 }
 
 const (
@@ -397,6 +399,29 @@ func allStagesNames() []string {
 	}
 
 	return stageNames
+}
+
+func SetupThreeWayMergeMode(cmdData *CmdData, cmd *cobra.Command) {
+	cmdData.ThreeWayMergeMode = new(string)
+
+	modeEnvironmentValue := os.Getenv("WERF_THREE_WAY_MERGE_MODE")
+
+	defaultValue := ""
+	if modeEnvironmentValue != "" {
+		defaultValue = modeEnvironmentValue
+	}
+
+	cmd.Flags().StringVarP(cmdData.ThreeWayMergeMode, "three-way-merge-mode", "", defaultValue, `Set three way merge mode for release.
+Supported 'enabled', 'disabled' and 'onlyNewReleases', see docs for more info https://werf.io/documentation/reference/deploy_process/experimental_three_way_merge.html`)
+}
+
+func GetThreeWayMergeMode(threeWayMergeModeParam string) (helm.ThreeWayMergeModeType, error) {
+	switch threeWayMergeModeParam {
+	case "enabled", "disabled", "onlyNewReleases", "":
+		return helm.ThreeWayMergeModeType(threeWayMergeModeParam), nil
+	}
+
+	return "", fmt.Errorf("bad three-way-merge-mode '%s': enabled, disabled or  onlyNewReleases modes can be specified", threeWayMergeModeParam)
 }
 
 func GetBoolEnvironment(environmentName string) bool {

--- a/cmd/werf/deploy/main.go
+++ b/cmd/werf/deploy/main.go
@@ -100,6 +100,8 @@ Read more info about Helm chart structure, Helm Release name, Kubernetes Namespa
 	common.SetupSecretValues(&CommonCmdData, cmd)
 	common.SetupIgnoreSecretKey(&CommonCmdData, cmd)
 
+	common.SetupThreeWayMergeMode(&CommonCmdData, cmd)
+
 	cmd.Flags().IntVarP(&CmdData.Timeout, "timeout", "t", 0, "Resources tracking timeout in seconds")
 
 	return cmd
@@ -119,6 +121,11 @@ func runDeploy() error {
 	}
 
 	helmReleaseStorageType, err := common.GetHelmReleaseStorageType(*CommonCmdData.HelmReleaseStorageType)
+	if err != nil {
+		return err
+	}
+
+	threeWayMergeMode, err := common.GetThreeWayMergeMode(*CommonCmdData.ThreeWayMergeMode)
 	if err != nil {
 		return err
 	}
@@ -254,5 +261,6 @@ func runDeploy() error {
 		UserExtraAnnotations: userExtraAnnotations,
 		UserExtraLabels:      userExtraLabels,
 		IgnoreSecretKey:      *CommonCmdData.IgnoreSecretKey,
+		ThreeWayMergeMode:    threeWayMergeMode,
 	})
 }

--- a/cmd/werf/helm/deploy_chart/main.go
+++ b/cmd/werf/helm/deploy_chart/main.go
@@ -80,6 +80,8 @@ If specified Helm chart is a Werf chart with additional values and contains werf
 	common.SetupSetString(&CommonCmdData, cmd)
 	common.SetupValues(&CommonCmdData, cmd)
 
+	common.SetupThreeWayMergeMode(&CommonCmdData, cmd)
+
 	helm_common.SetupHelmHome(&HelmCmdData, cmd)
 
 	f := cmd.Flags()
@@ -113,6 +115,11 @@ func runDeployChart(chartDirOrChartReference string, releaseName string) error {
 	}
 
 	helmReleaseStorageType, err := common.GetHelmReleaseStorageType(*CommonCmdData.HelmReleaseStorageType)
+	if err != nil {
+		return err
+	}
+
+	threeWayMergeMode, err := common.GetThreeWayMergeMode(*CommonCmdData.ThreeWayMergeMode)
 	if err != nil {
 		return err
 	}
@@ -190,6 +197,7 @@ func runDeployChart(chartDirOrChartReference string, releaseName string) error {
 			SetString: *CommonCmdData.SetString,
 			Values:    *CommonCmdData.Values,
 		},
+		ThreeWayMergeMode: threeWayMergeMode,
 	}); err != nil {
 		replaceOld := fmt.Sprintf("%s/", werfChart.Name)
 		replaceNew := fmt.Sprintf("%s/", strings.TrimRight(werfChart.ChartDir, "/"))

--- a/go.mod
+++ b/go.mod
@@ -106,7 +106,7 @@ require (
 	sigs.k8s.io/yaml v1.1.0
 )
 
-replace k8s.io/helm => github.com/flant/helm v0.0.0-20191017134624-c4061266c309
+replace k8s.io/helm => github.com/flant/helm v0.0.0-20191111155056-4a61afe6bf10
 
 replace k8s.io/api => k8s.io/api v0.0.0-20190918155943-95b840bb6a1f
 

--- a/go.sum
+++ b/go.sum
@@ -178,6 +178,14 @@ github.com/flant/helm v0.0.0-20191011121808-548765548d52 h1:upVBPaJI2x4A8P3yIxxE
 github.com/flant/helm v0.0.0-20191011121808-548765548d52/go.mod h1:FBJB9Ee3D1KsW2Q54spnyJAihmDmnHKRmVyKscC3++Y=
 github.com/flant/helm v0.0.0-20191017134624-c4061266c309 h1:OtFdJ4SsJezqFEpX2ft2Q/p6IJmWyZGPmiDKwhcVBX4=
 github.com/flant/helm v0.0.0-20191017134624-c4061266c309/go.mod h1:FBJB9Ee3D1KsW2Q54spnyJAihmDmnHKRmVyKscC3++Y=
+github.com/flant/helm v0.0.0-20191024160456-259c6308fddb h1:ZYuy/JPUzpEmTHTCR+ZWfeZx9umtextBoFi0z+X01aw=
+github.com/flant/helm v0.0.0-20191024160456-259c6308fddb/go.mod h1:FBJB9Ee3D1KsW2Q54spnyJAihmDmnHKRmVyKscC3++Y=
+github.com/flant/helm v0.0.0-20191101162241-c65586790869 h1:vMYLR6m7qQyYwK85G58MkQEo5LQnZo+hI2vS8MP+GUY=
+github.com/flant/helm v0.0.0-20191101162241-c65586790869/go.mod h1:FBJB9Ee3D1KsW2Q54spnyJAihmDmnHKRmVyKscC3++Y=
+github.com/flant/helm v0.0.0-20191111093205-70e6eda19a90 h1:xxluXV2xSwrXXLubeF+YuzQVXo3SWjK9UxMCeb5nKag=
+github.com/flant/helm v0.0.0-20191111093205-70e6eda19a90/go.mod h1:FBJB9Ee3D1KsW2Q54spnyJAihmDmnHKRmVyKscC3++Y=
+github.com/flant/helm v0.0.0-20191111155056-4a61afe6bf10 h1:f3VWpoT09EBq/8WYovzeBweCzJU0okoeENqunib9s24=
+github.com/flant/helm v0.0.0-20191111155056-4a61afe6bf10/go.mod h1:FBJB9Ee3D1KsW2Q54spnyJAihmDmnHKRmVyKscC3++Y=
 github.com/flant/kubedog v0.3.5-0.20190923111717-5fda2f77f960 h1:RQaVATHub/MgDkqhQ2Zrsumxi73cyvNQt3bW82HFHx4=
 github.com/flant/kubedog v0.3.5-0.20190923111717-5fda2f77f960/go.mod h1:o9cSuE3Z/kgxKhLCLUGUc9vPOFQgmY0B+7bdOQq++7o=
 github.com/flant/logboek v0.0.0-20190416104940-91fee3a3fc8d/go.mod h1:WirgB39yMTvPGKqrAE3zlsG/02of4rr5lXh1EiwO5P0=

--- a/pkg/deploy/deploy.go
+++ b/pkg/deploy/deploy.go
@@ -27,6 +27,7 @@ type DeployOptions struct {
 	UserExtraAnnotations map[string]string
 	UserExtraLabels      map[string]string
 	IgnoreSecretKey      bool
+	ThreeWayMergeMode    helm.ThreeWayMergeModeType
 }
 
 type ImagesRepoManager interface {
@@ -96,6 +97,7 @@ func Deploy(projectDir string, imagesRepoManager ImagesRepoManager, release, nam
 				SetString: opts.SetString,
 				Values:    opts.Values,
 			},
+			ThreeWayMergeMode: opts.ThreeWayMergeMode,
 		})
 	}); err != nil {
 		replaceOld := fmt.Sprintf("%s/", werfChart.Name)

--- a/pkg/deploy/helm/release.go
+++ b/pkg/deploy/helm/release.go
@@ -119,7 +119,7 @@ func doPurgeHelmRelease(releaseName, namespace string, withNamespace, withHooks 
 		}
 	}
 
-	if err := logboek.LogProcessInline("Deleting release", logboek.LogProcessInlineOptions{}, func() error {
+	if err := logboek.LogProcess("Deleting release", logboek.LogProcessOptions{}, func() error {
 		return releaseDelete(releaseName, releaseDeleteOptions{Purge: true})
 	}); err != nil {
 		return fmt.Errorf("release delete failed: %s", err)
@@ -144,8 +144,9 @@ type ChartValuesOptions struct {
 type ChartOptions struct {
 	Timeout time.Duration
 
-	DryRun bool
-	Debug  bool
+	DryRun            bool
+	Debug             bool
+	ThreeWayMergeMode ThreeWayMergeModeType
 
 	ChartValuesOptions
 }
@@ -169,6 +170,7 @@ func doDeployHelmChart(chartPath, releaseName, namespace string, opts ChartOptio
 		var latestReleaseRevisionStatus string
 		var releaseShouldBeDeleted bool
 		var releaseShouldBeRolledBack bool
+		var latestReleaseThreeWayMergeEnabled bool
 
 		logProcessOptions := logboek.LogProcessOptions{
 			SuccessInfoSectionFunc: func() {
@@ -207,6 +209,7 @@ func doDeployHelmChart(chartPath, releaseName, namespace string, opts ChartOptio
 
 				latestReleaseRevision = resp.Releases[0].Version
 				latestReleaseRevisionStatus = resp.Releases[0].Info.Status.Code.String()
+				latestReleaseThreeWayMergeEnabled = resp.Releases[0].ThreeWayMergeEnabled
 			}
 
 			switch latestReleaseRevisionStatus {
@@ -226,7 +229,13 @@ func doDeployHelmChart(chartPath, releaseName, namespace string, opts ChartOptio
 				if exist {
 					releaseShouldBeDeleted = true
 				} else if latestReleaseRevisionStatus == "FAILED" {
-					releaseShouldBeRolledBack = true
+					threeWayMergeMode := getActualThreeWayMergeMode(opts.ThreeWayMergeMode)
+
+					if threeWayMergeMode == threeWayMergeDisabled {
+						releaseShouldBeRolledBack = true
+					} else if threeWayMergeMode == threeWayMergeOnlyNewReleases && !latestReleaseThreeWayMergeEnabled {
+						releaseShouldBeRolledBack = true
+					}
 				}
 			default:
 				if exist, err := util.FileExists(autoPurgeTriggerFilePath(releaseName)); err != nil {
@@ -251,7 +260,7 @@ func doDeployHelmChart(chartPath, releaseName, namespace string, opts ChartOptio
 		}
 
 		if releaseShouldBeDeleted {
-			if err := logboek.LogProcessInline("Deleting release", logboek.LogProcessInlineOptions{}, func() error {
+			if err := logboek.LogProcess("Deleting release", logboek.LogProcessOptions{}, func() error {
 				return releaseDelete(releaseName, releaseDeleteOptions{Purge: true})
 			}); err != nil {
 				return fmt.Errorf("release delete failed: %s", err)
@@ -328,6 +337,7 @@ func doDeployHelmChart(chartPath, releaseName, namespace string, opts ChartOptio
 						err = ReleaseRollback(
 							releaseName,
 							latestSuccessfullyDeployedRevision,
+							opts.ThreeWayMergeMode,
 							releaseRollbackOpts,
 						)
 
@@ -380,6 +390,7 @@ func doDeployHelmChart(chartPath, releaseName, namespace string, opts ChartOptio
 				opts.Values,
 				opts.Set,
 				opts.SetString,
+				opts.ThreeWayMergeMode,
 				releaseUpdateOpts,
 			); err != nil {
 				if strings.HasSuffix(err.Error(), "has no deployed releases") {
@@ -422,6 +433,7 @@ func doDeployHelmChart(chartPath, releaseName, namespace string, opts ChartOptio
 				opts.Values,
 				opts.Set,
 				opts.SetString,
+				opts.ThreeWayMergeMode,
 				releaseInstallOpts,
 			); err != nil {
 				if err := createAutoPurgeTriggerFilePath(releaseName); err != nil {


### PR DESCRIPTION
 - 3wm modes dates: onlyNewReleases 15.11, enabled 5.12;
 - Helm updated to v2.16.0.