### PR TITLE
Git work tree switch strikes back: rework and speedup git work tree cache

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -51,6 +51,7 @@ github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d h1:licZJFw2RwpH
 github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d/go.mod h1:asat636LX7Bqt5lYEZ27JNDcqxfjdBQuJ/MM4CN/Lzo=
 github.com/agl/ed25519 v0.0.0-20170116200512-5312a6153412 h1:w1UutsfOrms1J05zt7ISrnJIXKzwaspym5BTKGx93EI=
 github.com/agl/ed25519 v0.0.0-20170116200512-5312a6153412/go.mod h1:WPjqKcmVOxf0XSf3YxCJs6N6AOSrOx3obionmG7T0y0=
+github.com/alcortesm/tgz v0.0.0-20161220082320-9c5fe88206d7 h1:uSoVVbwJiQipAclBbw+8quDsfcvFjOpI5iCf4p/cqCs=
 github.com/alcortesm/tgz v0.0.0-20161220082320-9c5fe88206d7/go.mod h1:6zEj6s6u/ghQa61ZWa/C2Aw3RkjiTBOix7dkqa1VLIs=
 github.com/alessio/shellescape v0.0.0-20190409004728-b115ca0f9053 h1:H/GMMKYPkEIC3DF/JWQz8Pdd+Feifov2EIgGfNpeogI=
 github.com/alessio/shellescape v0.0.0-20190409004728-b115ca0f9053/go.mod h1:xW8sBma2LE3QxFSzCnH9qe6gAE2yO9GvQaWwX89HxbE=
@@ -349,9 +350,11 @@ github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+o
 github.com/klauspost/cpuid v1.2.0/go.mod h1:Pj4uuM528wm8OyEC2QMXAi2YiTZ96dNQPGgoMS4s3ek=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGiHgQ4OO8tzTaLawm8vnODuwDk=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
+github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/pty v1.1.5/go.mod h1:9r2w37qlBe7rQ6e1fg1S/9xpWHSnaqNdHD3WcMdbPDA=
+github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kylelemons/godebug v0.0.0-20170820004349-d65d576e9348/go.mod h1:B69LEHPfb2qLo0BaaOLcbitczOKLWTsrBG9LczfCD4k=
 github.com/lib/pq v1.0.0 h1:X5PMW56eZitiTeO7tKzZxFCSpbFZJtkMMooicw2us9A=
@@ -675,6 +678,7 @@ google.golang.org/grpc v1.23.0 h1:AzbTB6ux+okLTzP8Ru1Xs41C303zdcfEht7MQnYJt5A=
 google.golang.org/grpc v1.23.0/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyacEbxg=
 gopkg.in/airbrake/gobrake.v2 v2.0.9/go.mod h1:/h5ZAUhDkGaJfjzjKLSjv6zCL6O0LLBxU4K+aSYdM/U=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/fsnotify.v1 v1.4.7 h1:xOHLXZwVvI9hhs+cLKq5+I5onOuwQLhQwiu63xxlHs4=
@@ -698,6 +702,7 @@ gopkg.in/src-d/go-billy.v4 v4.2.1/go.mod h1:tm33zBoOwxjYHZIE+OV8bxTWFMJLrconzFMd
 gopkg.in/src-d/go-billy.v4 v4.3.0 h1:KtlZ4c1OWbIs4jCv5ZXrTqG8EQocr0g/d4DjNg70aek=
 gopkg.in/src-d/go-billy.v4 v4.3.0/go.mod h1:tm33zBoOwxjYHZIE+OV8bxTWFMJLrconzFMd38aARFk=
 gopkg.in/src-d/go-git-fixtures.v3 v3.1.1/go.mod h1:dLBcvytrw/TYZsNTWCnkNF2DSIlzWYqTe3rJR56Ac7g=
+gopkg.in/src-d/go-git-fixtures.v3 v3.5.0 h1:ivZFOIltbce2Mo8IjzUHAFoq/IylO9WHhNOAJK+LsJg=
 gopkg.in/src-d/go-git-fixtures.v3 v3.5.0/go.mod h1:dLBcvytrw/TYZsNTWCnkNF2DSIlzWYqTe3rJR56Ac7g=
 gopkg.in/src-d/go-git.v4 v4.11.0 h1:cJwWgJ0DXifrNrXM6RGN1Y2yR60Rr1zQ9Q5DX5S9qgU=
 gopkg.in/src-d/go-git.v4 v4.11.0/go.mod h1:Vtut8izDyrM8BUVQnzJ+YvmNcem2J89EmfZYCkLokZk=

--- a/pkg/git_repo/base.go
+++ b/pkg/git_repo/base.go
@@ -11,11 +11,9 @@ import (
 	"regexp"
 	"sort"
 	"strings"
-	"time"
 
 	"github.com/bmatcuk/doublestar"
 	"github.com/flant/logboek"
-	"github.com/flant/werf/pkg/lock"
 	"github.com/flant/werf/pkg/true_git"
 	"gopkg.in/src-d/go-git.v4"
 	"gopkg.in/src-d/go-git.v4/plumbing"
@@ -130,11 +128,6 @@ func (repo *Base) isEmpty(repoPath string) (bool, error) {
 	return false, nil
 }
 
-func (repo *Base) withWorkTreeLock(workTree string, f func() error) error {
-	lockName := fmt.Sprintf("git_work_tree %s", workTree)
-	return lock.WithLock(lockName, lock.LockOptions{Timeout: 600 * time.Second}, f)
-}
-
 func (repo *Base) getReferenceForRepo(repoPath string) (*plumbing.Reference, error) {
 	var err error
 
@@ -168,7 +161,7 @@ func (repo *Base) GetName() string {
 	return repo.Name
 }
 
-func (repo *Base) createPatch(repoPath, gitDir, workTreeDir string, opts PatchOptions) (Patch, error) {
+func (repo *Base) createPatch(repoPath, gitDir, workTreeCacheDir string, opts PatchOptions) (Patch, error) {
 	repository, err := git.PlainOpen(repoPath)
 	if err != nil {
 		return nil, fmt.Errorf("cannot open repo `%s`: %s", repoPath, err)
@@ -219,12 +212,8 @@ func (repo *Base) createPatch(repoPath, gitDir, workTreeDir string, opts PatchOp
 	}
 
 	var desc *true_git.PatchDescriptor
-
 	if hasSubmodules {
-		err = repo.withWorkTreeLock(workTreeDir, func() error {
-			desc, err = true_git.PatchWithSubmodules(fileHandler, gitDir, workTreeDir, patchOpts)
-			return err
-		})
+		desc, err = true_git.PatchWithSubmodules(fileHandler, gitDir, workTreeCacheDir, patchOpts)
 	} else {
 		desc, err = true_git.Patch(fileHandler, gitDir, patchOpts)
 	}
@@ -254,9 +243,7 @@ func HasSubmodulesInCommit(commit *object.Commit) (bool, error) {
 	return true, nil
 }
 
-func (repo *Base) createArchive(repoPath, gitDir, workTreeDir string, opts ArchiveOptions) (Archive, error) {
-	logboek.LogF("Using work tree %s\n", workTreeDir)
-
+func (repo *Base) createArchive(repoPath, gitDir, workTreeCacheDir string, opts ArchiveOptions) (Archive, error) {
 	repository, err := git.PlainOpen(repoPath)
 	if err != nil {
 		return nil, fmt.Errorf("cannot open repo `%s`: %s", repoPath, err)
@@ -294,17 +281,10 @@ func (repo *Base) createArchive(repoPath, gitDir, workTreeDir string, opts Archi
 	}
 
 	var desc *true_git.ArchiveDescriptor
-
 	if hasSubmodules {
-		err = repo.withWorkTreeLock(workTreeDir, func() error {
-			desc, err = true_git.ArchiveWithSubmodules(fileHandler, gitDir, workTreeDir, archiveOpts)
-			return err
-		})
+		desc, err = true_git.ArchiveWithSubmodules(fileHandler, gitDir, workTreeCacheDir, archiveOpts)
 	} else {
-		err = repo.withWorkTreeLock(workTreeDir, func() error {
-			desc, err = true_git.Archive(fileHandler, gitDir, workTreeDir, archiveOpts)
-			return err
-		})
+		desc, err = true_git.Archive(fileHandler, gitDir, workTreeCacheDir, archiveOpts)
 	}
 
 	if err != nil {
@@ -421,7 +401,7 @@ func (repo *Base) remoteBranchesList(repoPath string) ([]string, error) {
 	return res, nil
 }
 
-func (repo *Base) checksum(repoPath, gitDir, workTreeDir string, opts ChecksumOptions) (Checksum, error) {
+func (repo *Base) checksum(repoPath, gitDir, workTreeCacheDir string, opts ChecksumOptions) (Checksum, error) {
 	repository, err := git.PlainOpen(repoPath)
 	if err != nil {
 		return nil, fmt.Errorf("cannot open repo `%s`: %s", repoPath, err)
@@ -447,19 +427,7 @@ func (repo *Base) checksum(repoPath, gitDir, workTreeDir string, opts ChecksumOp
 		Hash:         sha256.New(),
 	}
 
-	err = repo.withWorkTreeLock(workTreeDir, func() error {
-		if hasSubmodules {
-			err := true_git.PrepareWorkTreeWithSubmodules(gitDir, workTreeDir, opts.Commit)
-			if err != nil {
-				return err
-			}
-		} else {
-			err := true_git.PrepareWorkTree(gitDir, workTreeDir, opts.Commit)
-			if err != nil {
-				return err
-			}
-		}
-
+	err = true_git.WithWorkTree(gitDir, workTreeCacheDir, opts.Commit, true_git.WithWorkTreeOptions{HasSubmodules: hasSubmodules}, func(workTreeDir string) error {
 		paths := make([]string, 0)
 
 		for _, pathPattern := range opts.Paths {

--- a/pkg/git_repo/local.go
+++ b/pkg/git_repo/local.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/flant/werf/pkg/util"
+
 	"github.com/flant/logboek"
 	"gopkg.in/src-d/go-git.v4"
 	"gopkg.in/src-d/go-git.v4/plumbing"
@@ -46,15 +48,15 @@ func (repo *Local) HeadBranchName() (string, error) {
 }
 
 func (repo *Local) CreatePatch(opts PatchOptions) (Patch, error) {
-	return repo.createPatch(repo.Path, repo.GitDir, repo.getWorkTreeDir(), opts)
+	return repo.createPatch(repo.Path, repo.GitDir, repo.getRepoWorkTreeCacheDir(), opts)
 }
 
 func (repo *Local) CreateArchive(opts ArchiveOptions) (Archive, error) {
-	return repo.createArchive(repo.Path, repo.GitDir, repo.getWorkTreeDir(), opts)
+	return repo.createArchive(repo.Path, repo.GitDir, repo.getRepoWorkTreeCacheDir(), opts)
 }
 
 func (repo *Local) Checksum(opts ChecksumOptions) (Checksum, error) {
-	return repo.checksum(repo.Path, repo.GitDir, repo.getWorkTreeDir(), opts)
+	return repo.checksum(repo.Path, repo.GitDir, repo.getRepoWorkTreeCacheDir(), opts)
 }
 
 func (repo *Local) IsCommitExists(commit string) (bool, error) {
@@ -69,23 +71,16 @@ func (repo *Local) RemoteBranchesList() ([]string, error) {
 	return repo.remoteBranchesList(repo.Path)
 }
 
-func (repo *Local) getWorkTreeDir() string {
-	pathParts := make([]string, 0)
-
-	path := filepath.Clean(repo.Path)
-	for i := 0; i < 3; i++ {
-		var lastPart string
-		path, lastPart = filepath.Split(filepath.Clean(path))
-		pathParts = append([]string{lastPart}, pathParts...)
-		if path == "/" {
-			break
-		}
+func (repo *Local) getRepoWorkTreeCacheDir() string {
+	absPath, err := filepath.Abs(repo.Path)
+	if err != nil {
+		panic(err) // stupid interface of filepath.Abs
 	}
 
-	pathParts = append([]string{"local"}, pathParts...)
-	pathParts = append([]string{GetWorkTreeCacheDir()}, pathParts...)
+	fullPath := filepath.Clean(absPath)
+	repoId := util.Sha256Hash(fullPath)
 
-	return filepath.Join(pathParts...)
+	return filepath.Join(GetWorkTreeCacheDir(), "local", repoId)
 }
 
 func (repo *Local) IsBranchState() bool {

--- a/pkg/git_repo/work_tree.go
+++ b/pkg/git_repo/work_tree.go
@@ -6,7 +6,7 @@ import (
 	"github.com/flant/werf/pkg/werf"
 )
 
-const GitWorkTreeCacheVersion = "1"
+const GitWorkTreeCacheVersion = "3"
 
 func GetWorkTreeCacheDir() string {
 	return filepath.Join(werf.GetLocalCacheDir(), "git_worktrees", GitWorkTreeCacheVersion)

--- a/pkg/lock/base.go
+++ b/pkg/lock/base.go
@@ -59,20 +59,20 @@ func (lock *Base) Unlock(l locker) error {
 	return nil
 }
 
-func (lock *Base) WithLock(locker locker, f func() error) error {
-	var err error
-
-	err = lock.Lock(locker)
-	if err != nil {
+func (lock *Base) WithLock(locker locker, f func() error) (resErr error) {
+	if err := lock.Lock(locker); err != nil {
 		return err
 	}
 
-	resErr := f()
+	defer func() {
+		if err := lock.Unlock(locker); err != nil {
+			if resErr == nil {
+				resErr = err
+			}
+		}
+	}()
 
-	err = lock.Unlock(locker)
-	if err != nil {
-		return err
-	}
+	resErr = f()
 
-	return resErr
+	return
 }

--- a/pkg/true_git/patch.go
+++ b/pkg/true_git/patch.go
@@ -23,8 +23,16 @@ type PatchDescriptor struct {
 	BinaryPaths []string
 }
 
-func PatchWithSubmodules(out io.Writer, gitDir, workTreeDir string, opts PatchOptions) (*PatchDescriptor, error) {
-	return writePatch(out, gitDir, workTreeDir, true, opts)
+func PatchWithSubmodules(out io.Writer, gitDir, workTreeCacheDir string, opts PatchOptions) (*PatchDescriptor, error) {
+	var res *PatchDescriptor
+
+	err := withWorkTreeCacheLock(workTreeCacheDir, func() error {
+		writePatchRes, err := writePatch(out, gitDir, workTreeCacheDir, true, opts)
+		res = writePatchRes
+		return err
+	})
+
+	return res, err
 }
 
 func Patch(out io.Writer, gitDir string, opts PatchOptions) (*PatchDescriptor, error) {
@@ -35,17 +43,17 @@ func debugPatch() bool {
 	return os.Getenv("WERF_TRUE_GIT_DEBUG_PATCH") == "1"
 }
 
-func writePatch(out io.Writer, gitDir, workTreeDir string, withSubmodules bool, opts PatchOptions) (*PatchDescriptor, error) {
+func writePatch(out io.Writer, gitDir, workTreeCacheDir string, withSubmodules bool, opts PatchOptions) (*PatchDescriptor, error) {
 	var err error
 
 	gitDir, err = filepath.Abs(gitDir)
 	if err != nil {
-		return nil, fmt.Errorf("bad git dir `%s`: %s", gitDir, err)
+		return nil, fmt.Errorf("bad git dir %s: %s", gitDir, err)
 	}
 
-	workTreeDir, err = filepath.Abs(workTreeDir)
+	workTreeCacheDir, err = filepath.Abs(workTreeCacheDir)
 	if err != nil {
-		return nil, fmt.Errorf("bad work tree dir `%s`: %s", workTreeDir, err)
+		return nil, fmt.Errorf("bad work tree cache dir %s: %s", workTreeCacheDir, err)
 	}
 
 	if withSubmodules {
@@ -54,8 +62,8 @@ func writePatch(out io.Writer, gitDir, workTreeDir string, withSubmodules bool, 
 			return nil, err
 		}
 	}
-	if withSubmodules && workTreeDir == "" {
-		return nil, fmt.Errorf("provide work tree directory to enable submodules!")
+	if withSubmodules && workTreeCacheDir == "" {
+		return nil, fmt.Errorf("provide work tree cache directory to enable submodules!")
 	}
 
 	commonGitOpts := []string{
@@ -79,21 +87,9 @@ func writePatch(out io.Writer, gitDir, workTreeDir string, withSubmodules bool, 
 	var cmd *exec.Cmd
 
 	if withSubmodules {
-		var err error
-
-		err = switchWorkTree(gitDir, workTreeDir, opts.ToCommit, withSubmodules)
+		workTreeDir, err := prepareWorkTree(gitDir, workTreeCacheDir, opts.ToCommit, withSubmodules)
 		if err != nil {
-			return nil, fmt.Errorf("cannot reset work tree `%s` to commit `%s`: %s", workTreeDir, opts.ToCommit, err)
-		}
-
-		err = syncSubmodules(gitDir, workTreeDir)
-		if err != nil {
-			return nil, fmt.Errorf("cannot sync submodules: %s", err)
-		}
-
-		err = updateSubmodules(gitDir, workTreeDir)
-		if err != nil {
-			return nil, fmt.Errorf("cannot update submodules: %s", err)
+			return nil, fmt.Errorf("cannot prepare work tree in cache %s for commit %s: %s", workTreeCacheDir, opts.ToCommit, err)
 		}
 
 		gitArgs := append(commonGitOpts, "--work-tree", workTreeDir)
@@ -216,10 +212,10 @@ WaitForData:
 	if debugPatch() {
 		fmt.Printf("Patch paths count is %d, binary paths count is %d\n", len(desc.Paths), len(desc.BinaryPaths))
 		for _, path := range desc.Paths {
-			fmt.Printf("Patch path `%s`\n", path)
+			fmt.Printf("Patch path %s\n", path)
 		}
 		for _, path := range desc.BinaryPaths {
-			fmt.Printf("Binary patch path `%s`\n", path)
+			fmt.Printf("Binary patch path %s\n", path)
 		}
 	}
 

--- a/pkg/true_git/submodule.go
+++ b/pkg/true_git/submodule.go
@@ -3,6 +3,7 @@ package true_git
 import (
 	"fmt"
 	"os/exec"
+	"strings"
 
 	"github.com/flant/logboek"
 )
@@ -40,6 +41,10 @@ func syncSubmodules(repoDir, workTreeDir string) error {
 
 		output := setCommandRecordingLiveOutput(cmd)
 
+		if debugWorktreeSwitch() {
+			fmt.Printf("[DEBUG WORKTREE SWITCH] %s\n", strings.Join(append([]string{cmd.Path}, cmd.Args[1:]...), " "))
+		}
+
 		err := cmd.Run()
 		if err != nil {
 			return fmt.Errorf("`git submodule sync` failed: %s\n%s", err, output.String())
@@ -60,6 +65,10 @@ func updateSubmodules(repoDir, workTreeDir string) error {
 		cmd.Dir = workTreeDir // required for `git submodule` to work
 
 		output := setCommandRecordingLiveOutput(cmd)
+
+		if debugWorktreeSwitch() {
+			fmt.Printf("[DEBUG WORKTREE SWITCH] %s\n", strings.Join(append([]string{cmd.Path}, cmd.Args[1:]...), " "))
+		}
 
 		err := cmd.Run()
 		if err != nil {

--- a/pkg/true_git/work_tree.go
+++ b/pkg/true_git/work_tree.go
@@ -3,99 +3,129 @@ package true_git
 import (
 	"bytes"
 	"fmt"
+	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/flant/logboek"
+	"github.com/flant/werf/pkg/lock"
 )
 
-func PrepareWorkTree(gitDir, workTreeDir string, commit string) error {
-	return prepareWorkTree(gitDir, workTreeDir, commit, false)
+type WithWorkTreeOptions struct {
+	HasSubmodules bool
 }
 
-func PrepareWorkTreeWithSubmodules(gitDir, workTreeDir string, commit string) error {
-	return prepareWorkTree(gitDir, workTreeDir, commit, true)
-}
-
-func prepareWorkTree(gitDir, workTreeDir string, commit string, withSubmodules bool) error {
-	var err error
-
-	gitDir, err = filepath.Abs(gitDir)
-	if err != nil {
-		return fmt.Errorf("bad git dir `%s`: %s", gitDir, err)
-	}
-
-	workTreeDir, err = filepath.Abs(workTreeDir)
-	if err != nil {
-		return fmt.Errorf("bad work tree dir `%s`: %s", workTreeDir, err)
-	}
-
-	if withSubmodules {
-		err := checkSubmoduleConstraint()
-		if err != nil {
-			return err
-		}
-	}
-
-	err = switchWorkTree(gitDir, workTreeDir, commit, withSubmodules)
-	if err != nil {
-		return fmt.Errorf("cannot reset work tree `%s` to commit `%s`: %s", workTreeDir, commit, err)
-	}
-
-	if withSubmodules {
+func WithWorkTree(gitDir, workTreeCacheDir string, commit string, opts WithWorkTreeOptions, f func(workTreeDir string) error) error {
+	return withWorkTreeCacheLock(workTreeCacheDir, func() error {
 		var err error
 
-		err = syncSubmodules(gitDir, workTreeDir)
+		gitDir, err = filepath.Abs(gitDir)
 		if err != nil {
-			return fmt.Errorf("cannot sync submodules: %s", err)
+			return fmt.Errorf("bad git dir %s: %s", gitDir, err)
 		}
 
-		err = updateSubmodules(gitDir, workTreeDir)
+		workTreeCacheDir, err = filepath.Abs(workTreeCacheDir)
 		if err != nil {
-			return fmt.Errorf("cannot update submodules: %s", err)
+			return fmt.Errorf("bad work tree cache dir %s: %s", workTreeCacheDir, err)
+		}
+
+		if opts.HasSubmodules {
+			err := checkSubmoduleConstraint()
+			if err != nil {
+				return err
+			}
+		}
+
+		workTreeDir, err := prepareWorkTree(gitDir, workTreeCacheDir, commit, opts.HasSubmodules)
+		if err != nil {
+			return fmt.Errorf("cannot prepare worktree: %s", err)
+		}
+
+		return f(workTreeDir)
+	})
+}
+
+func withWorkTreeCacheLock(workTreeCacheDir string, f func() error) error {
+	lockName := fmt.Sprintf("git_work_tree_cache %s", workTreeCacheDir)
+	return lock.WithLock(lockName, lock.LockOptions{Timeout: 600 * time.Second}, f)
+}
+
+func prepareWorkTree(repoDir, workTreeCacheDir string, commit string, withSubmodules bool) (string, error) {
+	if err := os.MkdirAll(workTreeCacheDir, os.ModePerm); err != nil {
+		return "", fmt.Errorf("unable to create dir %s: %s", workTreeCacheDir, err)
+	}
+
+	gitDirPath := filepath.Join(workTreeCacheDir, "git_dir")
+	if _, err := os.Stat(gitDirPath); os.IsNotExist(err) {
+		if err := ioutil.WriteFile(gitDirPath, []byte(repoDir+"\n"), 0644); err != nil {
+			return "", fmt.Errorf("error writing %s: %s", gitDirPath)
+		}
+	} else if err != nil {
+		return "", fmt.Errorf("unable to access %s: %s", gitDirPath, err)
+	}
+
+	currentCommitPath := filepath.Join(workTreeCacheDir, "current_commit")
+	worktreePath := filepath.Join(workTreeCacheDir, "worktree")
+	currentCommit := ""
+
+	currentCommitExists := true
+	if _, err := os.Stat(currentCommitPath); os.IsNotExist(err) {
+		currentCommitExists = false
+	} else if err != nil {
+		return "", fmt.Errorf("unable to access %s: %s", currentCommitPath, err)
+	}
+	if currentCommitExists {
+		if data, err := ioutil.ReadFile(currentCommitPath); err == nil {
+			currentCommit = strings.TrimSpace(string(data))
+
+			if currentCommit == commit {
+				return worktreePath, nil
+			}
+		} else {
+			return "", fmt.Errorf("error reading %s: %s", currentCommitPath, err)
+		}
+
+		if err := os.RemoveAll(currentCommitPath); err != nil {
+			return "", fmt.Errorf("unable to remove %s: %s", currentCommitPath, err)
 		}
 	}
 
-	return nil
+	// Switch worktree state to the desired commit.
+	// If worktree already exists — it will be used as a cache.
+	workTreeDir := filepath.Join(workTreeCacheDir, "worktree")
+	logProcessMsg := fmt.Sprintf("Switch work tree %s to commit %s", workTreeDir, commit)
+	if err := logboek.LogProcess(logProcessMsg, logboek.LogProcessOptions{}, func() error {
+		logboek.LogInfoF("Work tree dir: %s\n", workTreeDir)
+		if currentCommit != "" {
+			logboek.LogInfoF("Current commit: %s\n", currentCommit)
+		}
+
+		return switchWorkTree(repoDir, workTreeDir, commit, withSubmodules)
+	}); err != nil {
+		return "", fmt.Errorf("unable to switch work tree %s to commit %s: %s", workTreeDir, commit, err)
+	}
+
+	if err := ioutil.WriteFile(currentCommitPath, []byte(commit+"\n"), 0644); err != nil {
+		return "", fmt.Errorf("error writing %s: %s", currentCommitPath, err)
+	}
+
+	return workTreeDir, nil
+}
+
+func debugWorktreeSwitch() bool {
+	return os.Getenv("WERF_TRUE_GIT_DEBUG_WORKTREE_SWITCH") == "1"
 }
 
 func switchWorkTree(repoDir, workTreeDir string, commit string, withSubmodules bool) error {
 	var err error
 
-	err = os.RemoveAll(workTreeDir)
-	if err != nil {
-		return fmt.Errorf("unable to remove old work tree dir %s: %s", workTreeDir, err)
-	}
-
 	err = os.MkdirAll(workTreeDir, os.ModePerm)
 	if err != nil {
 		return fmt.Errorf("unable to create work tree dir %s: %s", workTreeDir, err)
 	}
-
-	// TODO: to allow caching of work trees we need a way to switch worktrees safely
-
-	//// NOTE: git clean -dffx does not clean .git files: so delete files manually
-	//servicePathsToRemove := []string{}
-	//err = filepath.Walk(workTreeDir, func(path string, info os.FileInfo, pathErr error) error {
-	//	if pathErr != nil {
-	//		return fmt.Errorf("error accessing path %s: %s", path, pathErr)
-	//	}
-	//
-	//	if info.Name() == ".git" {
-	//		servicePathsToRemove = append(servicePathsToRemove, path)
-	//	}
-	//
-	//	return nil
-	//})
-	//if err != nil {
-	//	return fmt.Errorf("error walking the path %s: %s", workTreeDir, err)
-	//}
-	//
-	//for _, path := range servicePathsToRemove {
-	//	logboek.LogF("Removing old service file %s\n", path)
-	//	if err := os.RemoveAll(path); err != nil {
-	//		fmt.Errorf("error removing %s: %s", path, err)
-	//	}
-	//}
 
 	var cmd *exec.Cmd
 	var output *bytes.Buffer
@@ -105,52 +135,70 @@ func switchWorkTree(repoDir, workTreeDir string, commit string, withSubmodules b
 		"reset", "--hard", commit,
 	)
 	output = setCommandRecordingLiveOutput(cmd)
+	if debugWorktreeSwitch() {
+		fmt.Printf("[DEBUG WORKTREE SWITCH] %s\n", strings.Join(append([]string{cmd.Path}, cmd.Args[1:]...), " "))
+	}
 	err = cmd.Run()
 	if err != nil {
 		return fmt.Errorf("git reset failed: %s\n%s", err, output.String())
 	}
 
-	//if withSubmodules {
-	//	cmd = exec.Command(
-	//		"git", "--git-dir", repoDir, "--work-tree", workTreeDir,
-	//		"submodule", "foreach", "--recursive",
-	//		"git", "reset", "--hard", commit,
-	//	)
-	//
-	//	cmd.Dir = workTreeDir // required for `git submodule` to work
-	//
-	//	output = setCommandRecordingLiveOutput(cmd)
-	//	err = cmd.Run()
-	//	if err != nil {
-	//		return fmt.Errorf("git submodules reset failed: %s\n%s", err, output.String())
-	//	}
-	//}
-	//
-	//cmd = exec.Command(
-	//	"git", "--git-dir", repoDir, "--work-tree", workTreeDir,
-	//	"clean", "-d", "-f", "-f", "-x",
-	//)
-	//output = setCommandRecordingLiveOutput(cmd)
-	//err = cmd.Run()
-	//if err != nil {
-	//	return fmt.Errorf("git clean failed: %s\n%s", err, output.String())
-	//}
-	//
-	//if withSubmodules {
-	//	cmd = exec.Command(
-	//		"git", "--git-dir", repoDir, "--work-tree", workTreeDir,
-	//		"submodule", "foreach", "--recursive",
-	//		"git", "clean", "-d", "-f", "-f", "-x",
-	//	)
-	//
-	//	cmd.Dir = workTreeDir // required for `git submodule` to work
-	//
-	//	output = setCommandRecordingLiveOutput(cmd)
-	//	err = cmd.Run()
-	//	if err != nil {
-	//		return fmt.Errorf("git submodules clean failed: %s\n%s", err, output.String())
-	//	}
-	//}
+	cmd = exec.Command(
+		"git", "--git-dir", repoDir, "--work-tree", workTreeDir,
+		"clean", "-d", "-f", "-f", "-x",
+	)
+	output = setCommandRecordingLiveOutput(cmd)
+	if debugWorktreeSwitch() {
+		fmt.Printf("[DEBUG WORKTREE SWITCH] %s\n", strings.Join(append([]string{cmd.Path}, cmd.Args[1:]...), " "))
+	}
+	err = cmd.Run()
+	if err != nil {
+		return fmt.Errorf("git clean failed: %s\n%s", err, output.String())
+	}
+
+	if withSubmodules {
+		var err error
+
+		err = syncSubmodules(repoDir, workTreeDir)
+		if err != nil {
+			return fmt.Errorf("cannot sync submodules: %s", err)
+		}
+
+		err = updateSubmodules(repoDir, workTreeDir)
+		if err != nil {
+			return fmt.Errorf("cannot update submodules: %s", err)
+		}
+
+		cmd = exec.Command(
+			"git", "--git-dir", repoDir, "--work-tree", workTreeDir,
+			"submodule", "foreach", "--recursive",
+			"git", "reset", "--hard",
+		)
+		cmd.Dir = workTreeDir // required for `git submodule` to work
+		output = setCommandRecordingLiveOutput(cmd)
+		if debugWorktreeSwitch() {
+			fmt.Printf("[DEBUG WORKTREE SWITCH] %s\n", strings.Join(append([]string{cmd.Path}, cmd.Args[1:]...), " "))
+		}
+		err = cmd.Run()
+		if err != nil {
+			return fmt.Errorf("git submodules reset failed: %s\n%s", err, output.String())
+		}
+
+		cmd = exec.Command(
+			"git", "--git-dir", repoDir, "--work-tree", workTreeDir,
+			"submodule", "foreach", "--recursive",
+			"git", "clean", "-d", "-f", "-f", "-x",
+		)
+		cmd.Dir = workTreeDir // required for `git submodule` to work
+		output = setCommandRecordingLiveOutput(cmd)
+		if debugWorktreeSwitch() {
+			fmt.Printf("[DEBUG WORKTREE SWITCH] %s\n", strings.Join(append([]string{cmd.Path}, cmd.Args[1:]...), " "))
+		}
+		err = cmd.Run()
+		if err != nil {
+			return fmt.Errorf("git submodules clean failed: %s\n%s", err, output.String())
+		}
+	}
 
 	return nil
 }


### PR DESCRIPTION
Git work tree switch strikes back: rework and speedup git work tree cache

- One work tree belongs only to one git repo on localhost. Multiple repos (as in gitlab with parallel builds) will have multiple uniq work trees, one per repo.
- Optimized work tree switch procedure in the case when work tree is already in the desired commit state.
- New cache files structure:

```
~/.werf/local_cache/git_worktrees/2/local/REPO_ID_HASH/
    worktree # actual work tree directory in the state corresponding to some commit
    current_commit # file contains commit hash corresponding to the worktree state
    git_dir # path to the git dir to which this work tree belongs
```

REPO_ID is unique per each local repo clone.

During switch from OLD_COMMIT to NEW_COMMIT procedure ~/.werf/local_cache/git_worktrees/3/local/REPO_ID_HASH/current_commit file will be removed,
then worktree state will be switched in the dir /.werf/local_cache/git_worktrees/3/local/REPO_ID_HASH/worktree, then ~/.werf/local_cache/git_worktrees/3/local/REPO_ID_HASH/current_commit will be created with the NEW_COMMIT hash.

Only a single process can work with ~/.werf/local_cache/git_worktrees/3/local/REPO_ID_HASH cache at the same time.
