### PR TITLE
[deploy] Pass secret values as a separate argument to values-merger and fix masking of secret values

### DIFF
--- a/pkg/deploy/helm/lint.go
+++ b/pkg/deploy/helm/lint.go
@@ -14,7 +14,7 @@ type LintOptions struct {
 	Strict bool
 }
 
-func Lint(out io.Writer, chartPath, namespace string, values, set, setString []string, opts LintOptions) error {
+func Lint(out io.Writer, chartPath, namespace string, values []string, secretValues []map[string]interface{}, set, setString []string, opts LintOptions) error {
 	var lowestTolerance int
 	if opts.Strict {
 		lowestTolerance = support.WarningSev
@@ -24,7 +24,7 @@ func Lint(out io.Writer, chartPath, namespace string, values, set, setString []s
 
 	var total int
 	var failures int
-	if linter, err := lintChart(chartPath, namespace, values, set, setString); err != nil {
+	if linter, err := lintChart(chartPath, namespace, values, secretValues, set, setString); err != nil {
 		fmt.Fprintln(out, "==> Skipping", chartPath)
 		fmt.Fprintln(out, err)
 	} else {
@@ -55,7 +55,7 @@ func Lint(out io.Writer, chartPath, namespace string, values, set, setString []s
 	return nil
 }
 
-func lintChart(chartPath string, namespace string, values, set, setString []string) (support.Linter, error) {
+func lintChart(chartPath string, namespace string, values []string, secretValues []map[string]interface{}, set, setString []string) (support.Linter, error) {
 	linter := support.Linter{}
 
 	// Using abs path to get directory context
@@ -64,13 +64,13 @@ func lintChart(chartPath string, namespace string, values, set, setString []stri
 	linter.ChartDir = chartDir
 
 	rules.Values(&linter)
-	templatesRules(&linter, chartPath, namespace, values, set, setString)
+	templatesRules(&linter, chartPath, namespace, values, secretValues, set, setString)
 
 	return linter, nil
 }
 
-func templatesRules(linter *support.Linter, chartPath, namespace string, values, set, setString []string) {
-	templates, err := GetTemplatesFromChart(chartPath, "RELEASE_NAME", namespace, values, set, setString)
+func templatesRules(linter *support.Linter, chartPath, namespace string, values []string, secretValues []map[string]interface{}, set, setString []string) {
+	templates, err := GetTemplatesFromChart(chartPath, "RELEASE_NAME", namespace, values, secretValues, set, setString)
 	linter.RunLinterRule(support.ErrorSev, chartPath, err)
 
 	for _, template := range templates {

--- a/pkg/deploy/helm/release.go
+++ b/pkg/deploy/helm/release.go
@@ -158,9 +158,10 @@ func doPurgeHelmRelease(releaseName, namespace string, withNamespace, withHooks 
 }
 
 type ChartValuesOptions struct {
-	Set       []string
-	SetString []string
-	Values    []string
+	SecretValues []map[string]interface{}
+	Set          []string
+	SetString    []string
+	Values       []string
 }
 
 type ChartOptions struct {
@@ -410,6 +411,7 @@ func doDeployHelmChart(chartPath, releaseName, namespace string, opts ChartOptio
 				chartPath,
 				releaseName,
 				opts.Values,
+				opts.SecretValues,
 				opts.Set,
 				opts.SetString,
 				opts.ThreeWayMergeMode,
@@ -453,6 +455,7 @@ func doDeployHelmChart(chartPath, releaseName, namespace string, opts ChartOptio
 				releaseName,
 				namespace,
 				opts.Values,
+				opts.SecretValues,
 				opts.Set,
 				opts.SetString,
 				opts.ThreeWayMergeMode,
@@ -474,7 +477,7 @@ func doDeployHelmChart(chartPath, releaseName, namespace string, opts ChartOptio
 		var templatesFromChart ChartTemplates
 
 		if err := logboek.LogProcessInline("Getting chart templates", logboek.LogProcessInlineOptions{}, func() error {
-			templatesFromChart, err = GetTemplatesFromChart(chartPath, releaseName, namespace, opts.Values, opts.Set, opts.SetString)
+			templatesFromChart, err = GetTemplatesFromChart(chartPath, releaseName, namespace, opts.Values, opts.SecretValues, opts.Set, opts.SetString)
 			return err
 		}); err != nil {
 			return err

--- a/pkg/deploy/helm/templates.go
+++ b/pkg/deploy/helm/templates.go
@@ -98,8 +98,8 @@ func GetTemplatesFromReleaseRevision(releaseName string, revision int32) (ChartT
 	return chartTemplates, nil
 }
 
-func GetTemplatesFromChart(chartPath, releaseName, namespace string, values, set, setString []string) (ChartTemplates, error) {
-	rawTemplates, err := getRawTemplatesFromChart(chartPath, releaseName, namespace, values, set, setString)
+func GetTemplatesFromChart(chartPath, releaseName, namespace string, values []string, secretValues []map[string]interface{}, set, setString []string) (ChartTemplates, error) {
+	rawTemplates, err := getRawTemplatesFromChart(chartPath, releaseName, namespace, values, secretValues, set, setString)
 	if err != nil {
 		return nil, err
 	}
@@ -112,14 +112,14 @@ func GetTemplatesFromChart(chartPath, releaseName, namespace string, values, set
 	return chartTemplates, nil
 }
 
-func getRawTemplatesFromChart(chartPath, releaseName, namespace string, values, set, setString []string) (string, error) {
+func getRawTemplatesFromChart(chartPath, releaseName, namespace string, values []string, secretValues []map[string]interface{}, set, setString []string) (string, error) {
 	out := &bytes.Buffer{}
 
 	renderOptions := RenderOptions{
 		ShowNotes: false,
 	}
 
-	if err := Render(out, chartPath, releaseName, namespace, values, set, setString, renderOptions); err != nil {
+	if err := Render(out, chartPath, releaseName, namespace, values, secretValues, set, setString, renderOptions); err != nil {
 		return "", err
 	}
 

--- a/pkg/deploy/render.go
+++ b/pkg/deploy/render.go
@@ -62,7 +62,7 @@ func RunRender(out io.Writer, projectDir string, werfConfig *config.WerfConfig, 
 		ShowNotes: false,
 	}
 
-	helm.WerfTemplateEngine.InitWerfEngineExtraTemplatesFunctions(werfChart.DecodedSecretFiles)
+	helm.WerfTemplateEngine.InitWerfEngineExtraTemplatesFunctions(werfChart.DecodedSecretFilesData)
 	patchLoadChartfile(werfChart.Name)
 
 	return helm.WerfTemplateEngineWithExtraAnnotationsAndLabels(werfChart.ExtraAnnotations, werfChart.ExtraLabels, func() error {
@@ -72,6 +72,7 @@ func RunRender(out io.Writer, projectDir string, werfConfig *config.WerfConfig, 
 			opts.ReleaseName,
 			opts.Namespace,
 			append(werfChart.Values, opts.Values...),
+			werfChart.SecretValues,
 			append(werfChart.Set, opts.Set...),
 			append(werfChart.SetString, opts.SetString...),
 			renderOptions)

--- a/pkg/util/secretvalues/mask.go
+++ b/pkg/util/secretvalues/mask.go
@@ -1,0 +1,66 @@
+package secretvalues
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"strings"
+)
+
+func MaskSecretValuesInString(secretValues []string, targetStr string) string {
+	for _, secretValue := range secretValues {
+		targetStr = strings.ReplaceAll(targetStr, secretValue, "***")
+	}
+	return targetStr
+}
+
+func ExtractSecretValuesFromMap(data map[string]interface{}) []string {
+	queue := []interface{}{data}
+	maskedValues := []string{}
+
+	for len(queue) > 0 {
+		var elemI interface{}
+		elemI, queue = queue[0], queue[1:]
+
+		switch reflect.TypeOf(elemI).Kind() {
+		case reflect.Slice, reflect.Array:
+			elem := reflect.ValueOf(elemI)
+			for i := 0; i < elem.Len(); i++ {
+				value := elem.Index(i)
+				queue = append(queue, value.Interface())
+			}
+		case reflect.Map:
+			elem := reflect.ValueOf(elemI)
+			for _, key := range elem.MapKeys() {
+				value := elem.MapIndex(key)
+				queue = append(queue, value.Interface())
+			}
+		default:
+			elemStr := fmt.Sprintf("%v", elemI)
+			if len(elemStr) >= 4 {
+				maskedValues = append(maskedValues, elemStr)
+			}
+			for _, line := range strings.Split(elemStr, "\n") {
+				if len(line) >= 4 {
+					maskedValues = append(maskedValues, line)
+				}
+			}
+
+			dataMap := map[string]interface{}{}
+			if err := json.Unmarshal([]byte(elemStr), &dataMap); err == nil {
+				for _, v := range dataMap {
+					queue = append(queue, v)
+				}
+			}
+
+			dataArr := []interface{}{}
+			if err := json.Unmarshal([]byte(elemStr), &dataArr); err == nil {
+				for _, v := range dataArr {
+					queue = append(queue, v)
+				}
+			}
+		}
+	}
+
+	return maskedValues
+}


### PR DESCRIPTION
 - Mask errors in deploy and lint commands, render is not masked.
 - Optionally generate masks for json-values in the secret itself.
 - Mask errors in service release-log of tiller.
