### PR TITLE
[stapel] Downgrade ansible to 2.7.15

### DIFF
--- a/pkg/stapel/stapel.go
+++ b/pkg/stapel/stapel.go
@@ -11,7 +11,7 @@ import (
 	"github.com/flant/werf/pkg/docker"
 )
 
-const VERSION = "0.2.6"
+const VERSION = "0.3.1"
 
 func getVersion() string {
 	version := VERSION

--- a/stapel/omnibus/config/software/ansible.rb
+++ b/stapel/omnibus/config/software/ansible.rb
@@ -1,6 +1,6 @@
 name "ansible"
 
-ANSIBLE_GIT_TAG = "v2.8.5"
+ANSIBLE_GIT_TAG = "v2.7.15"
 
 dependency "python"
 dependency "pip"


### PR DESCRIPTION
Due to the issue with the config:

```
configVersion: 1
project: test
---
image: ~
from: alpine
ansible:
    install:
    - shell: |

        ls
```

Which works with the 2.7, but does not work with the 2.8 or 2.9.

Stapel image: flant/werf-stapel:0.3.1.