### PR TITLE
Update kubedog

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -35,7 +35,7 @@ require (
 	github.com/docker/swarmkit v0.0.0-20180705210007-199cf49cd996
 	github.com/fatih/color v1.7.0
 	github.com/flant/go-containerregistry v0.0.0-20190712094650-0cfc503dc51a
-	github.com/flant/kubedog v0.3.5-0.20191115094125-b86378ba389b
+	github.com/flant/kubedog v0.3.5-0.20191128170454-bd02f0299551
 	github.com/flant/logboek v0.2.6-0.20190918091020-d00ba619a349
 	github.com/flynn-archive/go-shlex v0.0.0-20150515145356-3f9db97f8568
 	github.com/ghodss/yaml v0.0.0-20180820084758-c7ce16629ff4

--- a/go.sum
+++ b/go.sum
@@ -181,6 +181,8 @@ github.com/flant/helm v0.0.0-20191113092127-64b7551164d6 h1:tjw08kbV1icd2jU65RUu
 github.com/flant/helm v0.0.0-20191113092127-64b7551164d6/go.mod h1:8HfWC34vJLVKWk1DLpU9CS0nKa8k6N6H3coDnrX1Loo=
 github.com/flant/kubedog v0.3.5-0.20191115094125-b86378ba389b h1:G4d9ZWX43b8x2KKJgzXFWJ3S5LaAp/OW7ImVk5XO6/c=
 github.com/flant/kubedog v0.3.5-0.20191115094125-b86378ba389b/go.mod h1:mQ0PeK5cntODe4lWEhrhIFtNZHAG/AiI7KmRpLSEKDk=
+github.com/flant/kubedog v0.3.5-0.20191128170454-bd02f0299551 h1:X5mZ2zdV3Zv1rywRVkFExE4TBeGXbAxzIaUy9b9zds8=
+github.com/flant/kubedog v0.3.5-0.20191128170454-bd02f0299551/go.mod h1:mQ0PeK5cntODe4lWEhrhIFtNZHAG/AiI7KmRpLSEKDk=
 github.com/flant/logboek v0.0.0-20190416104940-91fee3a3fc8d/go.mod h1:WirgB39yMTvPGKqrAE3zlsG/02of4rr5lXh1EiwO5P0=
 github.com/flant/logboek v0.2.6-0.20190726104558-c32b60bb4a37/go.mod h1:eEQXX0UOWpyC8iaA9QOvzx8drZ64u0SRESiwQKnxF+I=
 github.com/flant/logboek v0.2.6-0.20190918091020-d00ba619a349 h1:ANKnp53Kl4sspROTuIai9aAVRed4ZEX/dZI9Tj0gEPE=


### PR DESCRIPTION
1. Fix 'timeout waiting for the condition' in job tracker

Kubedog uses context cancel function to terminate working tracker of subordinary pod's of the resource.

Kubernetes waiting function `watchtools.UntilWithSync` returns 'timeout waiting for the condition' error
when context actually has been cancelled (bad code in the watchtools!).

Kubedog now suppresses 'timeout waiting for the condition' from `watchtools.UntilWithSync`, because kubedog by itself handles timeouts.

2. Fix job backoff limit; fix Pod status indicator: show red Error pod status.

https://github.com/flant/kubedog/pull/150
https://github.com/flant/kubedog/pull/151