### PR TITLE
[deploy] Do not show errors for deleted old pods

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -35,7 +35,7 @@ require (
 	github.com/docker/swarmkit v0.0.0-20180705210007-199cf49cd996
 	github.com/fatih/color v1.7.0
 	github.com/flant/go-containerregistry v0.0.0-20190712094650-0cfc503dc51a
-	github.com/flant/kubedog v0.3.5-0.20191128170454-bd02f0299551
+	github.com/flant/kubedog v0.3.5-0.20191202160405-76ed6dcd3e59
 	github.com/flant/logboek v0.2.6-0.20190918091020-d00ba619a349
 	github.com/flynn-archive/go-shlex v0.0.0-20150515145356-3f9db97f8568
 	github.com/ghodss/yaml v0.0.0-20180820084758-c7ce16629ff4

--- a/go.sum
+++ b/go.sum
@@ -185,6 +185,8 @@ github.com/flant/kubedog v0.3.5-0.20191115094125-b86378ba389b h1:G4d9ZWX43b8x2KK
 github.com/flant/kubedog v0.3.5-0.20191115094125-b86378ba389b/go.mod h1:mQ0PeK5cntODe4lWEhrhIFtNZHAG/AiI7KmRpLSEKDk=
 github.com/flant/kubedog v0.3.5-0.20191128170454-bd02f0299551 h1:X5mZ2zdV3Zv1rywRVkFExE4TBeGXbAxzIaUy9b9zds8=
 github.com/flant/kubedog v0.3.5-0.20191128170454-bd02f0299551/go.mod h1:mQ0PeK5cntODe4lWEhrhIFtNZHAG/AiI7KmRpLSEKDk=
+github.com/flant/kubedog v0.3.5-0.20191202160405-76ed6dcd3e59 h1:FNHwQ8W5RhABSh4Ro7UVGc9GVW98w+eYJedRo+pYZUo=
+github.com/flant/kubedog v0.3.5-0.20191202160405-76ed6dcd3e59/go.mod h1:mQ0PeK5cntODe4lWEhrhIFtNZHAG/AiI7KmRpLSEKDk=
 github.com/flant/logboek v0.0.0-20190416104940-91fee3a3fc8d/go.mod h1:WirgB39yMTvPGKqrAE3zlsG/02of4rr5lXh1EiwO5P0=
 github.com/flant/logboek v0.2.6-0.20190726104558-c32b60bb4a37/go.mod h1:eEQXX0UOWpyC8iaA9QOvzx8drZ64u0SRESiwQKnxF+I=
 github.com/flant/logboek v0.2.6-0.20190918091020-d00ba619a349 h1:ANKnp53Kl4sspROTuIai9aAVRed4ZEX/dZI9Tj0gEPE=


### PR DESCRIPTION
Support for "deleted resource" state of the tracker: do not show "resource deleted" error

https://github.com/flant/kubedog/pull/152