### PR TITLE
[docs] Removed telegram channel for English speaking users

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 <p align="center">
   <a href="https://cloud-native.slack.com/messages/CHY2THYUU"><img src="https://img.shields.io/badge/slack-EN%20chat-611f69.svg?logo=slack" alt="Slack chat EN"></a>
+  <a href="https://twitter.com/werf_io"><img src="https://img.shields.io/badge/twitter-EN-611f69.svg?logo=twitter" alt="Twitter EN"></a>
   <a href="https://t.me/werf_ru"><img src="https://img.shields.io/badge/telegram-RU%20chat-179cde.svg?logo=telegram" alt="Telegram chat RU"></a><br>
   <a href='https://bintray.com/flant/werf/werf/_latestVersion'><img src='https://api.bintray.com/packages/flant/werf/werf/images/download.svg'></a>
   <a href="https://godoc.org/github.com/flant/werf"><img src="https://godoc.org/github.com/flant/werf?status.svg" alt="GoDoc"></a>
@@ -287,7 +288,7 @@ Stability channels and frequent releases allow receiving continuous feedback on 
 
 [Make your first werf application](https://werf.io/documentation/guides/getting_started.html) or plunge into the complete [documentation](https://werf.io/).
 
-We are always in contact with the community through [Twitter](https://twitter.com/werf_io), [Slack](https://cloud-native.slack.com/messages/CHY2THYUU), and [Telegram](https://t.me/werf_io). Join us!
+We are always in contact with the community through [Twitter](https://twitter.com/werf_io) and [Slack](https://cloud-native.slack.com/messages/CHY2THYUU). Join us!
 
 > Russian-speaking users can reach us in [Telegram Chat](https://t.me/werf_ru)
 

--- a/README_ru.md
+++ b/README_ru.md
@@ -3,10 +3,13 @@
 </p>
 
 <p align="center">
+  <a href="https://t.me/werf_ru"><img src="https://img.shields.io/badge/telegram-RU%20chat-179cde.svg?logo=telegram" alt="Telegram chat RU"></a>
+  <a href="https://twitter.com/werf_io"><img src="https://img.shields.io/badge/twitter-EN-611f69.svg?logo=twitter" alt="Twitter EN"></a><br>
+  <a href="https://cloud-native.slack.com/messages/CHY2THYUU"><img src="https://img.shields.io/badge/slack-EN%20chat-611f69.svg?logo=slack" alt="Slack chat EN"></a>
   <a href='https://bintray.com/flant/werf/werf/_latestVersion'><img src='https://api.bintray.com/packages/flant/werf/werf/images/download.svg'></a>
   <a href="https://godoc.org/github.com/flant/werf"><img src="https://godoc.org/github.com/flant/werf?status.svg" alt="GoDoc"></a>
-  <a href="https://cloud-native.slack.com/messages/CHY2THYUU"><img src="https://img.shields.io/badge/slack-EN%20chat-611f69.svg?logo=slack" alt="Slack chat EN"></a>
-  <a href="https://t.me/werf_ru"><img src="https://img.shields.io/badge/telegram-RU%20chat-179cde.svg?logo=telegram" alt="Telegram chat RU"></a>
+  <a href="https://github.com/flant/werf/actions"><img src="https://github.com/flant/werf/workflows/Run%20tests/badge.svg?event=schedule"></a>
+  <a href="https://codeclimate.com/github/flant/werf/test_coverage"><img src="https://api.codeclimate.com/v1/badges/213fcda644a83581bf6e/test_coverage" /></a>
 </p>
 ___
 

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -18,7 +18,6 @@ social_links:
     slack_2: https://cloud-native.slack.com/messages/CHY2THYUU
   en:
     twitter: https://twitter.com/werf_io
-    telegram: https://t.me/werf_io
     slack_1: https://slack.cncf.io/
     slack_2: https://cloud-native.slack.com/messages/CHY2THYUU
 

--- a/docs/_includes/readme/docs_and_support.md
+++ b/docs/_includes/readme/docs_and_support.md
@@ -2,7 +2,7 @@
 
 [Make your first werf application](https://werf.io/documentation/guides/getting_started.html) or plunge into the complete [documentation](https://werf.io/).
 
-We are always in contact with the community through [Twitter](https://twitter.com/werf_io), [Slack](https://cloud-native.slack.com/messages/CHY2THYUU), and [Telegram](https://t.me/werf_io). Join us!
+We are always in contact with the community through [Twitter](https://twitter.com/werf_io) and [Slack](https://cloud-native.slack.com/messages/CHY2THYUU). Join us!
 
 > Russian-speaking users can reach us in [Telegram Chat](https://t.me/werf_ru)
 

--- a/docs/_includes/topnav.html
+++ b/docs/_includes/topnav.html
@@ -77,7 +77,6 @@
                 {% else %}
                 <li class="header__menu-icon"><a href="{{ site.social_links[site.site_lang].twitter }}" target="_blank" class="page__icon page__icon_twitter"></a></li>
                 <li class="header__menu-icon"><a href="#" data-open-popup="slack" target="_blank" class="page__icon page__icon_slack"></a></li>
-                <li class="header__menu-icon"><a href="{{ site.social_links[site.site_lang].telegram }}" target="_blank" class="page__icon page__icon_telegram"></a></li>
                 {% endif %}
                 <li class="header__menu-icon"><a href="https://github.com/flant/werf" target="_blank" class="page__icon page__icon_github"></a></li>
                 <li class="header__menu-icon header__menu-icon_search"><a href="javascript:void(0)" class="page__icon page__icon_search"></a></li>

--- a/docs/pages/index.md
+++ b/docs/pages/index.md
@@ -166,7 +166,7 @@ layout: default
     <div class="page__container">
         <div class="community__content">
             <div class="community__title">Friendly and growing community</div>
-            <div class="community__subtitle">werf’s developers are always in contact with the community<br/> in Twitter, Slack and Telegram.</div>
+            <div class="community__subtitle">werf’s developers are always in contact with the community<br/> in Twitter and Slack.</div>
             <div class="community__btns">
                 <a href="{{ site.social_links[page.lang].twitter }}" target="_blank" class="page__btn page__btn_w community__btn">
                     <span class="page__icon page__icon_twitter"></span>
@@ -175,10 +175,6 @@ layout: default
                 <a href="#" data-open-popup="slack" class="page__btn page__btn_w community__btn">
                     <span class="page__icon page__icon_slack"></span>
                     Join via Slack
-                </a>
-                <a href="{{ site.social_links[page.lang].telegram }}" target="_blank" class="page__btn page__btn_w community__btn">
-                    <span class="page__icon page__icon_telegram"></span>
-                    Join via Telegram
                 </a>
             </div>
         </div>


### PR DESCRIPTION
The telegram channel for English speaking users could be misleading, and we decided to delete it.

It will be more convenient to communicate in one place - CNCF slack. Please join!

Badges were also updated.