### PR TITLE
[tests] Coverage for all supported operating systems 

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,2 +1,0 @@
-exclude_patterns:
-- "pkg/testing/**/*.go"

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -1,4 +1,4 @@
-name: Deploy Site
+name: Site deployment
 on:
   pull_request:
     types: [labeled]

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,4 @@
-name: Run tests
+name: Running tests
 on:
   pull_request:
     types: [labeled]
@@ -18,7 +18,7 @@ jobs:
       run: echo "This job is used to prevent the workflow to fail when all other jobs are skipped."
 
   unlabel:
-    name: Unlabel
+    name: Unlabeling
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request' && github.event.label.id == 1745044226 # execute tests label
     steps:
@@ -29,11 +29,13 @@ jobs:
         script: |
           github.issues.removeLabel({...context.issue, name: '${{github.event.label.name}}'})
 
-  download_go_modules:
-    name: Download go modules
+  precompiled_tests_binaries:
+    name: Precompiled tests binaries
     strategy:
       fail-fast: false
-    runs-on: ubuntu-latest
+      matrix:
+        os: [ubuntu-latest, macOS-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     if: github.event_name == 'schedule' || (github.event_name == 'pull_request' && github.event.label.id == 1745044226) # execute tests label
     steps:
 
@@ -46,28 +48,84 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v1
 
-    - name: Download modules
+    - name: Download go modules
       run: go mod download
       shell: bash
 
-    - name: Pack go modules
-      run: tar -czvf go_modules.tar.gz -C $HOME/go/pkg/mod .
+    - name: Install upx (ubuntu-latest)
+      run: sudo apt-get install upx
+      if: matrix.os == 'ubuntu-latest'
+
+    - name: Install upx (macOS-latest)
+      run: brew install upx
+      if: matrix.os == 'macOS-latest'
+
+    - name: Install upx (windows-latest)
+      run: |
+        mkdir bin
+        echo "::add-path::$GITHUB_WORKSPACE/bin"
+
+        curl -LO https://github.com/upx/upx/releases/download/v3.95/upx-3.95-win64.zip
+        unzip upx-3.95-win64.zip
+        mv upx-3.95-win64/upx.exe bin
+      shell: bash
+      if: matrix.os == 'windows-latest'
+
+    - name: Compile tests binaries
+      run: |
+        # unit tests binaries
+        ./scripts/tests/precompiled_tests_binaries.sh ./cmd ./precompiled_tests_binaries/unit
+        ./scripts/tests/precompiled_tests_binaries.sh ./pkg ./precompiled_tests_binaries/unit
+
+        # integration tests binaries
+        ./scripts/tests/precompiled_tests_binaries.sh ./integration ./precompiled_tests_binaries/integration --tags integration
+
+        # integration_k8s tests binaries
+        ./scripts/tests/precompiled_tests_binaries.sh ./integration ./precompiled_tests_binaries/integration_k8s --tags integration_k8s
+
+        # werf with coverage binary
+        ./scripts/tests/werf_with_coverage.sh
       shell: bash
 
-    # FIXME: https://github.community/t5/GitHub-Actions/Caching-files-between-GitHub-Action-executions/m-p/30974#M630
-    - name: Upload go modules artifact
+    - name: Upload unit tests binaries
       uses: actions/upload-artifact@master
       with:
-        name: go_modules
-        path: go_modules.tar.gz
+        name: "${{ matrix.os }}_unit_tests_binaries"
+        path: precompiled_tests_binaries/unit
+
+    - name: Upload integration tests binaries
+      uses: actions/upload-artifact@master
+      with:
+        name: "${{ matrix.os }}_integration_tests_binaries"
+        path: precompiled_tests_binaries/integration
+
+    - name: Upload integration k8s tests binaries
+      uses: actions/upload-artifact@master
+      with:
+        name: "${{ matrix.os }}_integration_k8s_tests_binaries"
+        path: precompiled_tests_binaries/integration_k8s
+
+    - name: Upload werf with coverage binary (ubuntu-latest, macOS-latest)
+      uses: actions/upload-artifact@master
+      with:
+        name: "${{ matrix.os }}_werf_with_coverage"
+        path: bin/tests/werf_with_coverage
+      if: matrix.os != 'windows-latest'
+
+    - name: Upload werf with coverage binary (windows-latest)
+      uses: actions/upload-artifact@master
+      with:
+        name: "${{ matrix.os }}_werf_with_coverage"
+        path: bin/tests/werf_with_coverage.exe
+      if: matrix.os == 'windows-latest'
 
   unit_tests:
     name: Unit tests
-    needs: download_go_modules
+    needs: precompiled_tests_binaries
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest, macOS-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
 
@@ -80,25 +138,23 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v1
 
-    - name: Download go modules artifact
+    - name: Download unit tests binaries
       uses: actions/download-artifact@master
       with:
-        name: go_modules
+        name: "${{ matrix.os }}_unit_tests_binaries"
         path: .
-
-    - name: Unpack go modules
-      run: mkdir -p $HOME/go/pkg/mod && tar -xzvf go_modules.tar.gz -C $HOME/go/pkg/mod
-      shell: bash
 
     - name: Prepare environment
       run: |
         export WERF_TEST_COVERAGE_DIR=$GITHUB_WORKSPACE/tests_coverage/unit_tests/${{ matrix.os }}
         mkdir -p $WERF_TEST_COVERAGE_DIR
         echo ::set-env name=WERF_TEST_COVERAGE_DIR::$WERF_TEST_COVERAGE_DIR
+
+        find . -type f -name '*.test' -exec chmod +x {} \;
       shell: bash
 
     - name: Test
-      run: go test -tags "dfrunmount dfssh" -coverpkg=./... -coverprofile=$WERF_TEST_COVERAGE_DIR/coverage.out ./cmd/... ./pkg/...
+      run: ./scripts/ci/unit_tests_runner.sh
       shell: bash
 
     - name: Upload coverage artifact
@@ -109,7 +165,7 @@ jobs:
 
   integration_tests:
     name: Integration tests
-    needs: download_go_modules
+    needs: precompiled_tests_binaries
     strategy:
       fail-fast: false
       matrix:
@@ -126,15 +182,17 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v1
 
-    - name: Download go modules artifact
+    - name: Download integration tests binaries
       uses: actions/download-artifact@master
       with:
-        name: go_modules
+        name: "${{ matrix.os }}_integration_tests_binaries"
         path: .
 
-    - name: Unpack go modules
-      run: mkdir -p $HOME/go/pkg/mod && tar -xzvf go_modules.tar.gz -C $HOME/go/pkg/mod
-      shell: bash
+    - name: Download werf with coverage binary
+      uses: actions/download-artifact@master
+      with:
+        name: "${{ matrix.os }}_werf_with_coverage"
+        path: .
 
     - name: Prepare environment
       run: |
@@ -142,19 +200,18 @@ jobs:
         mkdir -p $WERF_TEST_COVERAGE_DIR
         echo ::set-env name=WERF_TEST_COVERAGE_DIR::$WERF_TEST_COVERAGE_DIR
 
-        ./scripts/ci/parallel.sh
         ./scripts/ci/git.sh
 
-        export GOBIN=$GITHUB_WORKSPACE/bin/tests
-        go install github.com/onsi/ginkgo/ginkgo
-        echo "::add-path::$GOBIN"
+        go build github.com/onsi/ginkgo/ginkgo
 
-        ./scripts/tests/werf_with_coverage.sh
+        chmod +x werf_with_coverage
+        find integration -type f -name '*.test' -exec chmod +x {} \;
       shell: bash
 
     - name: Test
       run: |
-        WERF_TEST_WERF_BINARY_PATH=$GITHUB_WORKSPACE/bin/tests/werf ginkgo -tags integration -r integration -p -keepGoing
+        test_binaries=$(find integration -type f -name '*.test')
+        WERF_TEST_BINARY_PATH=$GITHUB_WORKSPACE/werf_with_coverage ./ginkgo -p -keepGoing $test_binaries
       shell: bash
 
     - name: Upload coverage artifact
@@ -165,7 +222,7 @@ jobs:
 
   integration_k8s_tests:
     name: Integration k8s tests
-    needs: download_go_modules
+    needs: precompiled_tests_binaries
     strategy:
       fail-fast: false
       matrix:
@@ -184,15 +241,17 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v1
 
-    - name: Download go modules artifact
+    - name: Download integration k8s tests binaries
       uses: actions/download-artifact@master
       with:
-        name: go_modules
+        name: "${{ matrix.os }}_integration_k8s_tests_binaries"
         path: .
 
-    - name: Unpack go modules
-      run: mkdir -p $HOME/go/pkg/mod && tar -xzvf go_modules.tar.gz -C $HOME/go/pkg/mod
-      shell: bash
+    - name: Download werf with coverage binary
+      uses: actions/download-artifact@master
+      with:
+        name: "${{ matrix.os }}_werf_with_coverage"
+        path: .
 
     - name: Prepare environment
       run: |
@@ -202,11 +261,10 @@ jobs:
 
         ./scripts/ci/git.sh
 
-        export GOBIN=$GITHUB_WORKSPACE/bin/tests
-        go install github.com/onsi/ginkgo/ginkgo
-        echo "::add-path::$GOBIN"
+        go build github.com/onsi/ginkgo/ginkgo
 
-        ./scripts/tests/werf_with_coverage.sh
+        chmod +x werf_with_coverage
+        find integration -type f -name '*.test' -exec chmod +x {} \;
 
         echo ::set-env name=WERF_TEST_K8S_BASE64_KUBECONFIG::$(printenv WERF_TEST_K8S_BASE64_KUBECONFIG_$(echo ${{ matrix.k8s_version }} | tr . _))
       shell: bash
@@ -221,7 +279,8 @@ jobs:
     - name: Test
       run: |
         source ./scripts/ci/integration_k8s_tests_before_hook.sh
-        WERF_TEST_WERF_BINARY_PATH=$GITHUB_WORKSPACE/bin/tests/werf ginkgo -tags integration_k8s -r integration -p -keepGoing
+        test_binaries=$(find integration -type f -name '*.test')
+        WERF_TEST_BINARY_PATH=$GITHUB_WORKSPACE/werf_with_coverage ./ginkgo -p -keepGoing $test_binaries
       shell: bash
       env:
         WERF_TEST_K8S_DOCKER_REGISTRY: ${{ secrets.WERF_TEST_K8S_DOCKER_REGISTRY }}
@@ -236,11 +295,11 @@ jobs:
 
   integration_tests_on_self_hosted_runners:
     name: Integration tests
-    needs: download_go_modules
+    needs: precompiled_tests_binaries
     strategy:
       fail-fast: false
       matrix:
-        os: [macos, windows]
+        os: [macOS, windows]
     runs-on: [self-hosted, "${{ matrix.os }}"]
     steps:
 
@@ -253,26 +312,63 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v1
 
+    - name: Download integration tests binaries
+      uses: actions/download-artifact@master
+      with:
+        name: "${{ matrix.os }}-latest_integration_tests_binaries"
+        path: .
+
+    - name: Download werf with coverage binary
+      uses: actions/download-artifact@master
+      with:
+        name: "${{ matrix.os }}-latest_werf_with_coverage"
+        path: .
+
     - name: Prepare environment
       run: |
-        export GOBIN=$GITHUB_WORKSPACE/bin/tests
-        go install github.com/onsi/ginkgo/ginkgo
-        echo "::add-path::$GOBIN"
+        export WERF_TEST_COVERAGE_DIR=$GITHUB_WORKSPACE/tests_coverage/integration_tests/${{ matrix.os }}
+        mkdir -p $WERF_TEST_COVERAGE_DIR
+        echo ::set-env name=WERF_TEST_COVERAGE_DIR::$WERF_TEST_COVERAGE_DIR
 
-        ./scripts/ci/git.sh
+        go build github.com/onsi/ginkgo/ginkgo
+
+        chmod +x werf_with_coverage
+        test_binaries=$(find integration -type f -name '*.test')
+        for test_binary in $test_binaries; do chmod +x $test_binary; done
       shell: bash
 
-    - name: Test
-      run: ginkgo -tags integration -r integration -p -keepGoing
+    - name: Test (macOS)
+      run: |
+        test_binaries=$(find integration -type f -name '*.test')
+        WERF_TEST_BINARY_PATH=$GITHUB_WORKSPACE/werf_with_coverage ./ginkgo -p -keepGoing $test_binaries
       shell: bash
+      if: matrix.os == 'macOS'
+
+    # TODO: ginkgo CLI cannot run pre-compiled test package on windows (https://github.com/onsi/ginkgo/issues/529)
+    - name: Test (windows)
+      run: |
+        export WERF_TEST_BINARY_PATH=$GITHUB_WORKSPACE/werf_with_coverage
+        test_binaries=$(find $GITHUB_WORKSPACE/integration -type f -name '*.test')
+        for test_binary in $test_binaries; do
+          cd $(dirname "$test_binary")
+          $test_binary
+        done
+      shell: bash
+      if: matrix.os == 'windows'
+
+    - name: Upload coverage artifact
+      uses: actions/upload-artifact@master
+      with:
+        name: tests_coverage
+        path: tests_coverage
 
   integration_k8s_tests_on_self_hosted_runners:
     name: Integration k8s tests
-    needs: download_go_modules
+    needs: precompiled_tests_binaries
     strategy:
       fail-fast: false
       matrix:
-        os: [macos, windows]
+        os: [macOS, windows]
         k8s_version: [1.11, 1.12, 1.13, 1.14, 1.15, 1.16]
     runs-on: [self-hosted, "${{ matrix.os }}"]
     steps:
@@ -286,11 +382,29 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v1
 
+    - name: Download integration k8s tests binaries
+      uses: actions/download-artifact@master
+      with:
+        name: "${{ matrix.os }}-latest_integration_k8s_tests_binaries"
+        path: .
+
+    - name: Download werf with coverage binary
+      uses: actions/download-artifact@master
+      with:
+        name: "${{ matrix.os }}-latest_werf_with_coverage"
+        path: .
+
     - name: Prepare environment
       run: |
-        export GOBIN=$GITHUB_WORKSPACE/bin/tests
-        go install github.com/onsi/ginkgo/ginkgo
-        echo "::add-path::$GOBIN"
+        export WERF_TEST_COVERAGE_DIR=$GITHUB_WORKSPACE/tests_coverage/integration_k8s_tests/${{ matrix.os }}
+        mkdir -p $WERF_TEST_COVERAGE_DIR
+        echo ::set-env name=WERF_TEST_COVERAGE_DIR::$WERF_TEST_COVERAGE_DIR
+
+        go build github.com/onsi/ginkgo/ginkgo
+
+        chmod +x werf_with_coverage
+        test_binaries=$(find integration -type f -name '*.test')
+        for test_binary in $test_binaries; do chmod +x $test_binary; done
 
         echo ::set-env name=WERF_TEST_K8S_BASE64_KUBECONFIG::$(printenv WERF_TEST_K8S_BASE64_KUBECONFIG_$(echo ${{ matrix.k8s_version }} | tr . _))
       shell: bash
@@ -302,15 +416,40 @@ jobs:
         WERF_TEST_K8S_BASE64_KUBECONFIG_1_15: ${{ secrets.WERF_TEST_K8S_BASE64_KUBECONFIG_1_15 }}
         WERF_TEST_K8S_BASE64_KUBECONFIG_1_16: ${{ secrets.WERF_TEST_K8S_BASE64_KUBECONFIG_1_16 }}
 
-    - name: Test
+    - name: Test (macOS)
       run: |
         source ./scripts/ci/integration_k8s_tests_before_hook.sh
-        ginkgo -tags integration_k8s -r integration -nodes 2 -keepGoing
+        test_binaries=$(find integration -type f -name '*.test')
+        WERF_TEST_BINARY_PATH=$GITHUB_WORKSPACE/werf_with_coverage ./ginkgo -p -keepGoing $test_binaries
       shell: bash
       env:
         WERF_TEST_K8S_DOCKER_REGISTRY: ${{ secrets.WERF_TEST_K8S_DOCKER_REGISTRY }}
         WERF_TEST_K8S_DOCKER_REGISTRY_USERNAME: ${{ secrets.WERF_TEST_K8S_DOCKER_REGISTRY_USERNAME }}
         WERF_TEST_K8S_DOCKER_REGISTRY_PASSWORD: ${{ secrets.WERF_TEST_K8S_DOCKER_REGISTRY_PASSWORD }}
+      if: matrix.os == 'macOS'
+
+    # TODO: ginkgo CLI cannot run pre-compiled test package on windows (https://github.com/onsi/ginkgo/issues/529)
+    - name: Test (windows)
+      run: |
+        source ./scripts/ci/integration_k8s_tests_before_hook.sh
+        export WERF_TEST_BINARY_PATH=$GITHUB_WORKSPACE/werf_with_coverage
+        test_binaries=$(find $GITHUB_WORKSPACE/integration -type f -name '*.test')
+        for test_binary in $test_binaries; do
+          cd $(dirname "$test_binary")
+          $test_binary
+        done
+      shell: bash
+      env:
+        WERF_TEST_K8S_DOCKER_REGISTRY: ${{ secrets.WERF_TEST_K8S_DOCKER_REGISTRY }}
+        WERF_TEST_K8S_DOCKER_REGISTRY_USERNAME: ${{ secrets.WERF_TEST_K8S_DOCKER_REGISTRY_USERNAME }}
+        WERF_TEST_K8S_DOCKER_REGISTRY_PASSWORD: ${{ secrets.WERF_TEST_K8S_DOCKER_REGISTRY_PASSWORD }}
+      if: matrix.os == 'windows'
+
+    - name: Upload coverage artifact
+      uses: actions/upload-artifact@master
+      with:
+        name: tests_coverage
+        path: tests_coverage
 
   upload_coverage:
     name: Upload coverage
@@ -331,6 +470,18 @@ jobs:
       with:
         name: tests_coverage
         path: tests_coverage
+
+    # FIXME: determine problems with coverage records and remove the job
+    - name: Prepare coverage files
+      run: |
+        find tests_coverage -type f -exec \
+          sed -i -e "s|/home/runner/work/werf/werf|github.com/flant/werf|g" {} +
+
+        find tests_coverage -type f -exec \
+          sed -i -e "s|/Users/runner/runners/2.163.1/work/werf/werf|github.com/flant/werf|g" {} +
+
+        find tests_coverage -type f -exec \
+          sed -i -e 's|D:\\a\\werf\\werf\\cmd\\werf\\main.go|github.com/flant/werf/cmd/werf/main.go|g' {} +
 
     - name: Upload
       run: |

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
   <a href="https://t.me/werf_ru"><img src="https://img.shields.io/badge/telegram-RU%20chat-179cde.svg?logo=telegram" alt="Telegram chat RU"></a><br>
   <a href='https://bintray.com/flant/werf/werf/_latestVersion'><img src='https://api.bintray.com/packages/flant/werf/werf/images/download.svg'></a>
   <a href="https://godoc.org/github.com/flant/werf"><img src="https://godoc.org/github.com/flant/werf?status.svg" alt="GoDoc"></a>
-  <a href="https://github.com/flant/werf/actions"><img src="https://github.com/flant/werf/workflows/Run%20tests/badge.svg?event=schedule"></a>
+  <a href="https://github.com/flant/werf/actions"><img src="https://github.com/flant/werf/workflows/Running%20tests/badge.svg?event=schedule"></a>
   <a href="https://codeclimate.com/github/flant/werf/test_coverage"><img src="https://api.codeclimate.com/v1/badges/213fcda644a83581bf6e/test_coverage" /></a>
 </p>
 ___

--- a/README_ru.md
+++ b/README_ru.md
@@ -8,7 +8,7 @@
   <a href="https://cloud-native.slack.com/messages/CHY2THYUU"><img src="https://img.shields.io/badge/slack-EN%20chat-611f69.svg?logo=slack" alt="Slack chat EN"></a>
   <a href='https://bintray.com/flant/werf/werf/_latestVersion'><img src='https://api.bintray.com/packages/flant/werf/werf/images/download.svg'></a>
   <a href="https://godoc.org/github.com/flant/werf"><img src="https://godoc.org/github.com/flant/werf?status.svg" alt="GoDoc"></a>
-  <a href="https://github.com/flant/werf/actions"><img src="https://github.com/flant/werf/workflows/Run%20tests/badge.svg?event=schedule"></a>
+  <a href="https://github.com/flant/werf/actions"><img src="https://github.com/flant/werf/workflows/Running%20tests/badge.svg?event=schedule"></a>
   <a href="https://codeclimate.com/github/flant/werf/test_coverage"><img src="https://api.codeclimate.com/v1/badges/213fcda644a83581bf6e/test_coverage" /></a>
 </p>
 ___

--- a/cmd/werf/main_test.go
+++ b/cmd/werf/main_test.go
@@ -3,18 +3,63 @@
 package main
 
 import (
+	"fmt"
 	"os"
+	"strings"
 	"testing"
+
+	"bou.ke/monkey"
 )
 
-func TestRunMain(t *testing.T) {
-	main()
-	discardStdOut()
+var exitCode int
+
+func TestMain(m *testing.M) {
+	m.Run()
+	os.Exit(exitCode)
 }
 
-// ignore test summary
-// PASS
-// coverage: 6.6% of statements in ./...
+func TestRunMain(t *testing.T) {
+	// catch os.Exit
+	fakeOsExit := func(code int) {
+		exitCode = code
+		panic(fmt.Sprintf("exit code %d", code))
+	}
+	patch := monkey.Patch(os.Exit, fakeOsExit)
+	defer patch.Unpatch()
+
+	// catch and ignore fakeOsExit panic
+	defer func() {
+		if r := recover(); r != nil {
+			if strings.HasPrefix(fmt.Sprint(r), "exit code") {
+				return
+			}
+
+			panic(r)
+		}
+	}()
+
+	// ignore test options
+	oldArgs := os.Args
+	var newArgs []string
+	for _, arg := range os.Args {
+		if strings.HasPrefix(arg, "-test.") {
+			continue
+		}
+		newArgs = append(newArgs, arg)
+	}
+	os.Args = newArgs
+	defer func() {
+		os.Args = oldArgs
+	}()
+
+	// ignore test summary
+	// PASS
+	// coverage: 6.6% of statements in ./...
+	defer discardStdOut()
+
+	main()
+}
+
 func discardStdOut() {
 	w, err := os.Open(os.DevNull)
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -61,7 +61,7 @@ require (
 	github.com/mjibson/esc v0.2.0 // indirect
 	github.com/moby/buildkit v0.3.3
 	github.com/moby/moby v0.7.3-0.20190411110308-fc52433fa677
-	github.com/onsi/ginkgo v1.8.0
+	github.com/onsi/ginkgo v1.11.0
 	github.com/onsi/gomega v1.5.0
 	github.com/opentracing-contrib/go-stdlib v0.0.0-20171029140428-b1a47cfbdd75 // indirect
 	github.com/opentracing/opentracing-go v0.0.0-20171003133519-1361b9cd60be // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,5 @@
 bitbucket.org/bertimus9/systemstat v0.0.0-20180207000608-0eeff89b0690/go.mod h1:Ulb78X89vxKYgdL24HMTiXYHlyHEvruOj1ZPlqeNEZM=
+bou.ke/monkey v1.0.1 h1:zEMLInw9xvNakzUUPjfS4Ds6jYPqCFx3m7bRmG5NH2U=
 bou.ke/monkey v1.0.1/go.mod h1:FgHuK96Rv2Nlf+0u1OOVDpCMdsWyOFmeeketDHE7LIg=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
@@ -200,6 +201,7 @@ github.com/flant/logboek v0.2.5/go.mod h1:eEQXX0UOWpyC8iaA9QOvzx8drZ64u0SRESiwQK
 github.com/flant/logboek v0.2.6-0.20190726104558-c32b60bb4a37/go.mod h1:eEQXX0UOWpyC8iaA9QOvzx8drZ64u0SRESiwQKnxF+I=
 github.com/flant/logboek v0.2.6-0.20190918091020-d00ba619a349 h1:ANKnp53Kl4sspROTuIai9aAVRed4ZEX/dZI9Tj0gEPE=
 github.com/flant/logboek v0.2.6-0.20190918091020-d00ba619a349/go.mod h1:eEQXX0UOWpyC8iaA9QOvzx8drZ64u0SRESiwQKnxF+I=
+github.com/flant/multiwerf v1.2.3 h1:zfaO/b5OKg4z2uo4fEgpS8uqcdt2FoXAYlA+K01RTn0=
 github.com/flant/shluz v0.0.0-20191217184635-c09679d23ed2 h1:Ub9bCx27gm93uWs4DaSnasX2hC7gvWTQ6KDwl4oKBe8=
 github.com/flant/shluz v0.0.0-20191217184635-c09679d23ed2/go.mod h1:A8tow8a6JcCXi29Qio1sFpnoCL1r3WZLdPbLHbZnkmg=
 github.com/flynn-archive/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:rZfgFAXFS/z/lEd6LJmf9HVZ1LkgYiHx5pHhV5DR16M=
@@ -450,6 +452,8 @@ github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+W
 github.com/onsi/ginkgo v1.7.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.8.0 h1:VkHVNpR4iVnU8XQR6DBm8BqYjN7CRzw+xKUbVVbbW9w=
 github.com/onsi/ginkgo v1.8.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
+github.com/onsi/ginkgo v1.11.0 h1:JAKSXpt1YjtLA7YpPiqO9ss6sNXEsPfSGdwN0UHqzrw=
+github.com/onsi/ginkgo v1.11.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/gomega v0.0.0-20170829124025-dcabb60a477c/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v1.4.3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/onsi/gomega v1.5.0 h1:izbySO9zDPmjJ8rDjLvkA2zJHIo+HkYXHnf7eN7SSyo=
@@ -482,6 +486,7 @@ github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/profile v1.2.1/go.mod h1:hJw3o1OdXxsrSjjVksARp5W95eeEaEfptyVZyv6JUPA=
 github.com/pmezard/go-difflib v0.0.0-20151028094244-d8ed2627bdf0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pquerna/cachecontrol v0.0.0-20171018203845-0dec1b30a021/go.mod h1:prYjPmNq4d1NPVmpShWobRqXY3q7Vp+80DqgxxUrUIA=
 github.com/pquerna/ffjson v0.0.0-20180717144149-af8b230fcd20/go.mod h1:YARuvh7BUWHNhzDq2OM5tzR2RiCcN2D7sapiKyCel/M=
@@ -539,6 +544,7 @@ github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
 github.com/stretchr/testify v0.0.0-20151208002404-e3a8ff8ce365/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/syndtr/gocapability v0.0.0-20160928074757-e7cb7fa329f4/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/syndtr/gocapability v0.0.0-20170704070218-db04d3cc01c8 h1:zLV6q4e8Jv9EHjNg/iHfzwDkCve6Ua5jCygptrtXHvI=

--- a/integration/ansible/common_test.go
+++ b/integration/ansible/common_test.go
@@ -5,15 +5,16 @@ package ansible_test
 import (
 	"fmt"
 
+	"github.com/flant/werf/pkg/testing/utils"
 	"github.com/flant/werf/pkg/testing/utils/liveexec"
 )
 
 func werfBuild(dir string, opts liveexec.ExecCommandOptions, extraArgs ...string) error {
-	return liveexec.ExecCommand(dir, werfBinPath, opts, append([]string{"build", "--stages-storage", ":local"}, extraArgs...)...)
+	return liveexec.ExecCommand(dir, werfBinPath, opts, utils.WerfBinArgs(append([]string{"build", "--stages-storage", ":local"}, extraArgs...)...)...)
 }
 
 func werfPurge(dir string, opts liveexec.ExecCommandOptions, extraArgs ...string) error {
-	return liveexec.ExecCommand(dir, werfBinPath, opts, append([]string{"stages", "purge", "--stages-storage", ":local"}, extraArgs...)...)
+	return liveexec.ExecCommand(dir, werfBinPath, opts, utils.WerfBinArgs(append([]string{"stages", "purge", "--stages-storage", ":local"}, extraArgs...)...)...)
 }
 
 func setGitRepoState(workTreeDir, repoDir string, commitMessage string) error {

--- a/integration/ansible/setup_test.go
+++ b/integration/ansible/setup_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestSuite(t *testing.T) {
 	gomega.RegisterFailHandler(ginkgo.Fail)
-	ginkgo.RunSpecs(t, "Release server suite")
+	ginkgo.RunSpecs(t, "Ansible suite")
 }
 
 var werfBinPath string

--- a/integration/releaseserver/common_test.go
+++ b/integration/releaseserver/common_test.go
@@ -2,12 +2,15 @@
 
 package releaseserver_test
 
-import "github.com/flant/werf/pkg/testing/utils/liveexec"
+import (
+	"github.com/flant/werf/pkg/testing/utils"
+	"github.com/flant/werf/pkg/testing/utils/liveexec"
+)
 
 func werfDeploy(dir string, opts liveexec.ExecCommandOptions, extraArgs ...string) error {
-	return liveexec.ExecCommand(dir, werfBinPath, opts, append([]string{"deploy", "--env", "dev"}, extraArgs...)...)
+	return liveexec.ExecCommand(dir, werfBinPath, opts, utils.WerfBinArgs(append([]string{"deploy", "--env", "dev"}, extraArgs...)...)...)
 }
 
 func werfDismiss(dir string, opts liveexec.ExecCommandOptions) error {
-	return liveexec.ExecCommand(dir, werfBinPath, opts, "dismiss", "--env", "dev", "--with-namespace")
+	return liveexec.ExecCommand(dir, werfBinPath, opts, utils.WerfBinArgs("dismiss", "--env", "dev", "--with-namespace")...)
 }

--- a/pkg/testing/utils/command.go
+++ b/pkg/testing/utils/command.go
@@ -30,6 +30,10 @@ type RunCommandOptions struct {
 }
 
 func RunCommandWithOptions(dir, command string, args []string, options RunCommandOptions) ([]byte, error) {
+	if command == werfBinPath {
+		args = WerfBinArgs(args...)
+	}
+
 	cmd := exec.Command(command, args...)
 
 	if dir != "" {

--- a/pkg/testing/utils/suite.go
+++ b/pkg/testing/utils/suite.go
@@ -9,6 +9,7 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"time"
 
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gexec"
@@ -30,15 +31,32 @@ func GetTempDir() (string, error) {
 	return dir, nil
 }
 
+var werfBinPath string
+
 func ProcessWerfBinPath() string {
-	path := os.Getenv("WERF_TEST_WERF_BINARY_PATH")
-	if path == "" {
+	werfBinPath = os.Getenv("WERF_TEST_BINARY_PATH")
+	if werfBinPath == "" {
 		var err error
-		path, err = gexec.Build("github.com/flant/werf/cmd/werf")
+		werfBinPath, err = gexec.Build("github.com/flant/werf/cmd/werf")
 		Ω(err).ShouldNot(HaveOccurred())
 	}
 
-	return path
+	return werfBinPath
+}
+
+func WerfBinArgs(userArgs ...string) []string {
+	var args []string
+	if os.Getenv("WERF_TEST_BINARY_PATH") != "" && os.Getenv("WERF_TEST_COVERAGE_DIR") != "" {
+		coverageFilePath := filepath.Join(
+			os.Getenv("WERF_TEST_COVERAGE_DIR"),
+			fmt.Sprintf("%s-%s.out", strconv.FormatInt(time.Now().UTC().UnixNano(), 10), GetRandomString(10)),
+		)
+		args = append(args, fmt.Sprintf("-test.coverprofile=%s", coverageFilePath))
+	}
+
+	args = append(args, userArgs...)
+
+	return args
 }
 
 func BeforeEachOverrideWerfProjectName() {

--- a/scripts/ci/codeclimate.sh
+++ b/scripts/ci/codeclimate.sh
@@ -15,7 +15,7 @@ do
 done
 
 ./cc-test-reporter sum-coverage \
-  -p=$(ls -1q coverage/*.codeclimate.json | wc -l) \
+  -p="$(ls -1q coverage/*.codeclimate.json | wc -l)" \
   coverage/*.codeclimate.json
 
 ./cc-test-reporter upload-coverage

--- a/scripts/ci/parallel.sh
+++ b/scripts/ci/parallel.sh
@@ -1,5 +1,0 @@
-#!/bin/bash -e
-
-sudo apt-get install parallel -y
-mkdir -p ~/.parallel
-true>~/.parallel/will-cite

--- a/scripts/ci/unit_tests_runner.sh
+++ b/scripts/ci/unit_tests_runner.sh
@@ -1,0 +1,7 @@
+#!/bin/bash -e
+
+test_binaries=$(find . -type f -name '*.test')
+for test_binary in $test_binaries; do
+  coverage_file_name="$(openssl rand -hex 6)-$(date +"%H_%M_%S")_coverage.out"
+  $test_binary -test.v -test.coverprofile="$WERF_TEST_COVERAGE_DIR"/"$coverage_file_name"
+done

--- a/scripts/tests/precompiled_tests_binaries.sh
+++ b/scripts/tests/precompiled_tests_binaries.sh
@@ -1,0 +1,32 @@
+#!/bin/bash -e
+
+script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+project_dir=$script_dir/../..
+
+find_dir=${1:-.}
+tests_binaries_output_dirname=${2:-$project_dir/precompiled_test_binaries}
+go_test_extra_tags="${*:3}"
+
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  if ! [[ -x "$(command -v gfind)" ]]; then
+    brew install findutils
+  fi
+
+  package_paths=$(gfind "$find_dir" -type f -name '*_test.go' -printf '%h\n' | sort -u)
+else
+  package_paths=$(find "$find_dir" -type f -name '*_test.go' -printf '%h\n' | sort -u)
+fi
+
+for package_path in $package_paths; do
+  test_binary_filename=$(basename -- "$package_path").test
+	test_binary_path="$tests_binaries_output_dirname"/"$package_path"/"$test_binary_filename"
+	go test -ldflags="-s -w" --tags "dfrunmount dfssh $go_test_extra_tags" "$package_path" -coverpkg=./... -c -o "$test_binary_path"
+
+  if [[ ! -f $test_binary_path ]]; then # cmd/werf/main_test.go
+     continue
+  fi
+
+	if [[ -x "$(command -v upx)" ]]; then
+	  upx "$test_binary_path"
+  fi
+done


### PR DESCRIPTION
* Precompiled test binaries
* Simplified use of werf binary with coverage
  * binary improvements: handle os.Exit (coverage++) and small refactoring
  * adding extra option with coverage path in tests (with WerfBinArgs function) instead of in bash script wrapping