### PR TITLE
Fix Docker on windows does not support mount with short filename

### DIFF
--- a/pkg/testing/utils/suite.go
+++ b/pkg/testing/utils/suite.go
@@ -20,7 +20,7 @@ func GetTempDir() string {
 	dir, err := ioutil.TempDir("", "werf-integration-tests-")
 	Ω(err).ShouldNot(HaveOccurred())
 
-	if runtime.GOOS == "darwin" {
+	if runtime.GOOS == "darwin" || runtime.GOOS == "windows" {
 		dir, err = filepath.EvalSymlinks(dir)
 		Ω(err).ShouldNot(HaveOccurred(), fmt.Sprintf("eval symlinks of path %s failed: %s", dir, err))
 	}

--- a/pkg/tmp_manager/common.go
+++ b/pkg/tmp_manager/common.go
@@ -5,7 +5,6 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"runtime"
 
 	"github.com/flant/werf/pkg/werf"
 )
@@ -98,14 +97,6 @@ func newTmpFile(prefix string) (string, error) {
 	err = newFile.Close()
 	if err != nil {
 		return "", err
-	}
-
-	if runtime.GOOS == "darwin" {
-		dir, err := filepath.EvalSymlinks(path)
-		if err != nil {
-			return "", fmt.Errorf("eval symlinks of path %s failed: %s", path, err)
-		}
-		path = dir
 	}
 
 	return path, nil

--- a/pkg/werf/main.go
+++ b/pkg/werf/main.go
@@ -67,7 +67,7 @@ func Init(tmpDirOption, homeDirOption string) error {
 		tmpDir = os.TempDir()
 	}
 
-	if runtime.GOOS == "darwin" {
+	if runtime.GOOS == "darwin" || runtime.GOOS == "windows" {
 		dir, err := filepath.EvalSymlinks(tmpDir)
 		if err != nil {
 			return fmt.Errorf("eval symlinks of path %s failed: %s", tmpDir, err)


### PR DESCRIPTION
https://github.com/docker/for-win/issues/1560#issuecomment-577371228