### PR TITLE
Cache local git repo object between images and artifacts

### DIFF
--- a/pkg/build/conveyor.go
+++ b/pkg/build/conveyor.go
@@ -5,11 +5,12 @@ import (
 	"path/filepath"
 
 	"github.com/flant/logboek"
+	"github.com/flant/shluz"
+
 	"github.com/flant/werf/pkg/build/stage"
 	"github.com/flant/werf/pkg/config"
 	"github.com/flant/werf/pkg/git_repo"
 	"github.com/flant/werf/pkg/image"
-	"github.com/flant/shluz"
 	"github.com/flant/werf/pkg/util"
 )
 
@@ -20,6 +21,7 @@ type Conveyor struct {
 
 	stageImages                     map[string]*image.StageImage
 	buildingGitStageNameByImageName map[string]stage.StageName
+	localGitRepo                    *git_repo.Local
 	remoteGitRepos                  map[string]*git_repo.Remote
 	imagesBySignature               map[string]image.ImageInterface
 	globalLocks                     []string
@@ -96,6 +98,7 @@ func (c *Conveyor) ReInitRuntimeFields() {
 
 	c.buildingGitStageNameByImageName = make(map[string]stage.StageName)
 
+	c.localGitRepo = nil
 	c.remoteGitRepos = make(map[string]*git_repo.Remote)
 
 	c.tmpDir = filepath.Join(c.baseTmpDir, string(util.GenerateConsistentRandomString(10)))

--- a/pkg/build/initialization_phase.go
+++ b/pkg/build/initialization_phase.go
@@ -268,11 +268,15 @@ func generateGitMappings(imageBaseConfig *config.StapelImageBase, c *Conveyor) (
 
 	var localGitRepo *git_repo.Local
 	if len(imageBaseConfig.Git.Local) != 0 {
-		localGitRepo = &git_repo.Local{
-			Base:   git_repo.Base{Name: "own"},
-			Path:   c.projectDir,
-			GitDir: filepath.Join(c.projectDir, ".git"),
+		if c.localGitRepo == nil {
+			c.localGitRepo = &git_repo.Local{
+				Base:   git_repo.Base{Name: "own"},
+				Path:   c.projectDir,
+				GitDir: filepath.Join(c.projectDir, ".git"),
+			}
 		}
+
+		localGitRepo = c.localGitRepo
 	}
 
 	for _, localGitMappingConfig := range imageBaseConfig.Git.Local {


### PR DESCRIPTION
Optimize usage of `git fsck` command for the local repository: run only once for all images and artifacts instead of for each as before