### PR TITLE
Signatures and stages storage rework: commit affects next stages signatures

### DIFF
--- a/pkg/build/signatures_phase.go
+++ b/pkg/build/signatures_phase.go
@@ -76,13 +76,15 @@ func (p *SignaturesPhase) calculateImageSignatures(c *Conveyor, image *Image) er
 		}
 
 		checksumArgs := []string{stageDependencies, imagePkg.BuildCacheVersion}
-
 		if prevStage != nil {
-			checksumArgs = append(checksumArgs, prevStage.GetSignature())
+			prevStageDependencies, err := prevStage.GetNextStageDependencies(c)
+			if err != nil {
+				return fmt.Errorf("unable to get prev stage %s dependencies for the stage %s: %s", prevStage.Name(), s.Name(), err)
+			}
+
+			checksumArgs = append(checksumArgs, prevStage.GetSignature(), prevStageDependencies)
 		}
-
-		stageSig := util.MD5Hash(checksumArgs...)
-
+		stageSig := util.Sha256Hash(checksumArgs...)
 		s.SetSignature(stageSig)
 
 		logboek.LogInfoF("%s:%s %s\n", s.Name(), strings.Repeat(" ", maxStageNameLength-len(s.Name())), stageSig)

--- a/pkg/build/stage/git_archive.go
+++ b/pkg/build/stage/git_archive.go
@@ -77,24 +77,16 @@ ScanImages:
 func (s *GitArchiveStage) GetDependencies(_ Conveyor, prevImage, prevBuiltImage image.ImageInterface) (string, error) {
 	var args []string
 	for _, gitMapping := range s.gitMappings {
-		commit := gitMapping.GetGitCommitFromImageLabels(prevImage.Labels())
-		fmt.Printf("gitMapping.GetGitCommitFromImageLabels %v -> %s\n", prevImage.Name(), commit)
-		if commit == "" {
-			latestCommit, err := gitMapping.LatestCommit()
-			if err != nil {
-				return "", err
-			}
-			commit = latestCommit
-			fmt.Printf("gitMapping.GetGitCommitFromImageLabels take latest commit -> %s\n", commit)
-		}
-
-		// FIXME
 		args = append(args, gitMapping.GetParamshash())
 	}
 
 	sort.Strings(args)
 
 	return util.Sha256Hash(args...), nil
+}
+
+func (s *GitArchiveStage) GetNextStageDependencies(c Conveyor) (string, error) {
+	return s.BaseStage.getNextStageGitDependencies(c)
 }
 
 func (s *GitArchiveStage) PrepareImage(c Conveyor, prevBuiltImage, image image.ImageInterface) error {

--- a/pkg/build/stage/interface.go
+++ b/pkg/build/stage/interface.go
@@ -13,6 +13,7 @@ type Interface interface {
 	ShouldBeReset(builtImage image.ImageInterface) (bool, error)
 
 	GetDependencies(c Conveyor, prevImage image.ImageInterface, prevBuiltImage image.ImageInterface) (string, error)
+	GetNextStageDependencies(c Conveyor) (string, error)
 
 	PrepareImage(c Conveyor, prevBuiltImage, image image.ImageInterface) error
 

--- a/pkg/build/stage/user_with_git_patch.go
+++ b/pkg/build/stage/user_with_git_patch.go
@@ -19,6 +19,10 @@ type UserWithGitPatchStage struct {
 	GitPatchStage *GitPatchStage
 }
 
+func (s *UserWithGitPatchStage) GetNextStageDependencies(c Conveyor) (string, error) {
+	return s.BaseStage.getNextStageGitDependencies(c)
+}
+
 func (s *UserWithGitPatchStage) PrepareImage(c Conveyor, prevBuiltImage, image image.ImageInterface) error {
 	if err := s.BaseStage.PrepareImage(c, prevBuiltImage, image); err != nil {
 		return err


### PR DESCRIPTION
Introduce new hook Stage.GetNextStageDependencies to get from stage dependencies for the next stage signature.

GetNextStageDependencies returns commit from stage-image labels or latest commit (which will be used during stage build).

Use sha256 for signature part of stage-image name.