### PR TITLE
Signatures and stages storage rework: implement optimistic locking

### DIFF
--- a/pkg/build/conveyor.go
+++ b/pkg/build/conveyor.go
@@ -259,7 +259,7 @@ func (c *Conveyor) GetStageImage(name string) *image.StageImage {
 	return c.stageImages[name]
 }
 
-func (c *Conveyor) GetOrCreateImage(fromImage *image.StageImage, name string) *image.StageImage {
+func (c *Conveyor) GetOrCreateStageImage(fromImage *image.StageImage, name string) *image.StageImage {
 	if img, ok := c.stageImages[name]; ok {
 		return img
 	}

--- a/pkg/build/image.go
+++ b/pkg/build/image.go
@@ -92,7 +92,7 @@ func (i *Image) SetupBaseImage(c *Conveyor) {
 		baseImageName = c.GetImage(i.baseImageImageName).LatestStage().GetImage().Name()
 	}
 
-	i.baseImage = c.GetOrCreateImage(nil, baseImageName)
+	i.baseImage = c.GetOrCreateStageImage(nil, baseImageName)
 }
 
 func (i *Image) GetBaseImage() *image.StageImage {

--- a/pkg/build/signatures_phase.go
+++ b/pkg/build/signatures_phase.go
@@ -105,7 +105,7 @@ func (p *SignaturesPhase) calculateImageSignatures(c *Conveyor, image *Image) er
 				fmt.Printf("-- SelectCacheImage => %v\n", imgInfo)
 				imageExists = true
 
-				i = c.GetOrCreateImage(prevImage, imgInfo.ImageName)
+				i = c.GetOrCreateStageImage(prevImage, imgInfo.ImageName)
 				s.SetImage(i)
 
 				if err := c.StagesStorage.SyncStageImage(i); err != nil {
@@ -117,7 +117,7 @@ func (p *SignaturesPhase) calculateImageSignatures(c *Conveyor, image *Image) er
 		if !imageExists {
 			imageName := fmt.Sprintf(imagePkg.LocalImageStageImageFormat, c.projectName(), stageSig, util.UUIDToShortString(uuid.New()))
 
-			i = c.GetOrCreateImage(prevImage, imageName)
+			i = c.GetOrCreateStageImage(prevImage, imageName)
 			s.SetImage(i)
 		}
 

--- a/pkg/image/base.go
+++ b/pkg/image/base.go
@@ -24,6 +24,10 @@ func (i *base) Name() string {
 	return i.name
 }
 
+func (i *base) SetName(name string) {
+	i.name = name
+}
+
 func (i *base) MustGetId() (string, error) {
 	if inspect, err := i.MustGetInspect(); err == nil {
 		return inspect.ID, nil

--- a/pkg/image/interface.go
+++ b/pkg/image/interface.go
@@ -9,6 +9,7 @@ type BuildOptions struct {
 
 type ImageInterface interface {
 	Name() string
+	SetName(name string)
 	Inspect() *types.ImageInspect
 	Labels() map[string]string
 	ID() string

--- a/pkg/util/hashsum.go
+++ b/pkg/util/hashsum.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"strings"
 
+	"golang.org/x/crypto/sha3"
+
 	"github.com/google/uuid"
 
 	"github.com/spaolacci/murmur3"
@@ -16,6 +18,11 @@ func MurmurHash(args ...string) string {
 	h32 := murmur3.New32()
 	h32.Write([]byte(prepareHashArgs(args...)))
 	sum := h32.Sum32()
+	return fmt.Sprintf("%x", sum)
+}
+
+func Sha3_224Hash(args ...string) string {
+	sum := sha3.Sum224([]byte(prepareHashArgs(args...)))
 	return fmt.Sprintf("%x", sum)
 }
 


### PR DESCRIPTION
 - Discard already built temporary image when saving into stages storage if there is existing suitable image for this signature.
 - Generate image id as: <sha-3-224>-<time-up-to-millisecs>