### PR TITLE
Signatures and stages storage rework: fix panics and errors

### DIFF
--- a/cmd/werf/build_and_publish/main.go
+++ b/cmd/werf/build_and_publish/main.go
@@ -195,7 +195,8 @@ func runBuildAndPublish(imagesToProcess []string) error {
 			IntrospectOptions: introspectOptions,
 		},
 		PublishImagesOptions: build.PublishImagesOptions{
-			TagOptions: tagOpts,
+			ImagesToPublish: imagesToProcess,
+			TagOptions:      tagOpts,
 		},
 	}
 

--- a/cmd/werf/images/publish/cmd_factory/main.go
+++ b/cmd/werf/images/publish/cmd_factory/main.go
@@ -154,7 +154,10 @@ func runImagesPublish(commonCmdData *common.CmdData, imagesToProcess []string) e
 		}
 	}()
 
-	opts := build.PublishImagesOptions{TagOptions: tagOpts}
+	opts := build.PublishImagesOptions{
+		ImagesToPublish: imagesToProcess,
+		TagOptions:      tagOpts,
+	}
 
 	c := build.NewConveyor(werfConfig, imagesToProcess, projectDir, projectTmpDir, ssh_agent.SSHAuthSock)
 	defer c.Terminate()

--- a/pkg/build/build_phase.go
+++ b/pkg/build/build_phase.go
@@ -88,6 +88,12 @@ func (phase *BuildPhase) ImageProcessingShouldBeStopped(img *Image) bool {
 }
 
 func (phase *BuildPhase) BeforeImageStages(img *Image) error {
+	phase.isBaseImagePrepared = false
+	phase.PrevStage = nil
+	phase.PrevImage = nil
+	phase.PrevBuiltImage = nil
+	phase.PrevStageImageSize = 0
+
 	img.SetupBaseImage(phase.Conveyor)
 
 	phase.PrevImage = img.GetBaseImage()

--- a/pkg/build/conveyor.go
+++ b/pkg/build/conveyor.go
@@ -163,6 +163,7 @@ func (c *Conveyor) BuildStages(stageRepo string, opts BuildStagesOptions) error 
 }
 
 type PublishImagesOptions struct {
+	ImagesToPublish []string
 	TagOptions
 }
 
@@ -313,17 +314,8 @@ func (c *Conveyor) runPhases(phases []Phase) error {
 		}
 	}
 
-	var imagesToProcess []*Image
-	if len(c.imageNamesToProcess) == 0 {
-		imagesToProcess = c.imagesInOrder
-	} else {
-		for _, imageName := range c.imageNamesToProcess {
-			imagesToProcess = append(imagesToProcess, c.GetImage(imageName))
-		}
-	}
-
 ImagesProcessing:
-	for _, img := range imagesToProcess {
+	for _, img := range c.imagesInOrder {
 		for _, phase := range phases {
 			if err := phase.BeforeImageStages(img); err != nil {
 				return fmt.Errorf("phase %s before image %s stages handler failed: %s", phase.Name(), img.GetName(), err)

--- a/pkg/build/publish_images_phase.go
+++ b/pkg/build/publish_images_phase.go
@@ -25,7 +25,7 @@ func NewPublishImagesPhase(c *Conveyor, imagesRepoManager ImagesRepoManager, opt
 
 type PublishImagesPhase struct {
 	BasePhase
-	WithStages       bool
+	ImagesToPublish  []string
 	TagsByScheme     map[tag_strategy.TagStrategy][]string
 	ImageRepoManager ImagesRepoManager
 }
@@ -51,7 +51,17 @@ func (phase *PublishImagesPhase) OnImageStage(img *Image, stg stage.Interface) (
 }
 
 func (phase *PublishImagesPhase) AfterImageStages(img *Image) error {
-	return phase.pushImage(img)
+	if len(phase.ImagesToPublish) == 0 {
+		return phase.pushImage(img)
+	}
+
+	for _, name := range phase.ImagesToPublish {
+		if name == img.GetName() {
+			return phase.pushImage(img)
+		}
+	}
+
+	return nil
 }
 
 func (phase *PublishImagesPhase) ImageProcessingShouldBeStopped(img *Image) bool {


### PR DESCRIPTION
 - Reset image context in build-phase when processing next image.
 - Fix panic when images for cmd specified.