### PR TITLE
Signatures and stages storage rework: fix dockerInstructions signature does not depend on prev stage signature

### DIFF
--- a/pkg/build/stage/docker_instructions.go
+++ b/pkg/build/stage/docker_instructions.go
@@ -40,7 +40,6 @@ func (s *DockerInstructionsStage) GetDependencies(_ Conveyor, _, _ image.ImageIn
 	args = append(args, s.instructions.Entrypoint)
 	args = append(args, s.instructions.Workdir)
 	args = append(args, s.instructions.User)
-	args = append(args, "") // legacy StopSignal
 	args = append(args, s.instructions.HealthCheck)
 
 	return util.Sha256Hash(args...), nil


### PR DESCRIPTION
Also remove dockerInstructions legacy signature dependency.