### PR TITLE
Signatures and stages storage rework: fix panic 

### DIFF
--- a/pkg/build/build_phase.go
+++ b/pkg/build/build_phase.go
@@ -260,13 +260,12 @@ func (phase *BuildPhase) calculateStageSignature(img *Image, stg stage.Interface
 
 	phase.PrevStage = stg
 	phase.PrevImage = i
-	if phase.PrevImage.IsExists() {
-		phase.PrevBuiltImage = phase.PrevImage
-	}
-
 	logboek.LogDebugF("Set prev stage = %q %s\n", phase.PrevStage.Name(), phase.PrevStage.GetSignature())
 	logboek.LogDebugF("Set prev image = %q\n", phase.PrevImage.Name())
-	logboek.LogDebugF("Set prev built image = %q\n", phase.PrevBuiltImage.Name())
+	if phase.PrevImage.IsExists() {
+		phase.PrevBuiltImage = phase.PrevImage
+		logboek.LogDebugF("Set prev built image = %q\n", phase.PrevBuiltImage.Name())
+	}
 
 	return nil
 }


### PR DESCRIPTION
```

Set prev stage = "from" 2b804703146bc600187dacd735a9cae470a9d2102f6ee3f9b1709784
Set prev image = "3bb0140e-aebb-48f4-8a59-37be9f4c17c3"
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x70 pc=0x18ef83c]

goroutine 1 [running]:
github.com/flant/werf/pkg/build.(*BuildPhase).calculateStageSignature(0xc000a40780, 0xc0008c27e0, 0x26ff8a0, 0xc00086a240, 0x0, 0xc00029fc00)
	/home/ubuntu/actions-runner/_work/werf/werf/pkg/build/build_phase.go:269 +0x74c
github.com/flant/werf/pkg/build.(*BuildPhase).OnImageStage(0xc000a40780, 0xc0008c27e0, 0x26ff8a0, 0xc00086a240, 0x3, 0xc000556bc0, 0x2)
	/home/ubuntu/actions-runner/_work/werf/werf/pkg/build/build_phase.go:178 +0xd3
github.com/flant/werf/pkg/build.(*Conveyor).runPhases(0xc00070ae00, 0xc000abf8e0, 0x1, 0x1, 0xc0006a3f80, 0x42d44a)
	/home/ubuntu/actions-runner/_work/werf/werf/pkg/build/conveyor.go:328 +0x125
github.com/flant/werf/pkg/build.(*Conveyor).BuildStages(0xc00070ae00, 0x7ffd27d324b0, 0x6, 0x0, 0x0, 0x0, 0x0, 0x20, 0x0)
	/home/ubuntu/actions-runner/_work/werf/werf/pkg/build/conveyor.go:164 +0xe5
github.com/flant/werf/cmd/werf/stages/build/cmd_factory.runStagesBuild(0x39df9a0, 0x39e1480, 0xc0003b9d40, 0x1, 0x3, 0x0, 0x0)
	/home/ubuntu/actions-runner/_work/werf/werf/cmd/werf/stages/build/cmd_factory/main.go:174 +0x8f3
github.com/flant/werf/cmd/werf/stages/build/cmd_factory.NewCmdWithData.func1.1(0xbf8784be79b4131a, 0x20c5c06)
	/home/ubuntu/actions-runner/_work/werf/werf/cmd/werf/stages/build/cmd_factory/main.go:66 +0x4e
github.com/flant/werf/cmd/werf/common.LogRunningTime(0xc000aa5c58, 0xc0000dc008, 0x23e42d0)
	/home/ubuntu/actions-runner/_work/werf/werf/cmd/werf/common/common.go:884 +0x61
github.com/flant/werf/cmd/werf/stages/build/cmd_factory.NewCmdWithData.func1(0xc000470280, 0xc0003b9d40, 0x1, 0x3, 0x0, 0x0)
	/home/ubuntu/actions-runner/_work/werf/werf/cmd/werf/stages/build/cmd_factory/main.go:65 +0x1b4
github.com/spf13/cobra.(*Command).execute(0xc000470280, 0xc0003b9d10, 0x3, 0x3, 0xc000470280, 0xc0003b9d10)
	/home/ubuntu/go/pkg/mod/github.com/spf13/cobra@v0.0.5/command.go:826 +0x460
github.com/spf13/cobra.(*Command).ExecuteC(0xc000470000, 0xc000aa5f30, 0x4, 0x4)
	/home/ubuntu/go/pkg/mod/github.com/spf13/cobra@v0.0.5/command.go:914 +0x2fb
github.com/spf13/cobra.(*Command).Execute(...)
	/home/ubuntu/go/pkg/mod/github.com/spf13/cobra@v0.0.5/command.go:864
main.main()
	/home/ubuntu/actions-runner/_work/werf/werf/cmd/werf/main.go:137 +0x608
```