### PR TITLE
Temporarily disable stages cleanup by default due to the bug

### DIFF
--- a/cmd/werf/cleanup/cleanup.go
+++ b/cmd/werf/cleanup/cleanup.go
@@ -2,6 +2,7 @@ package cleanup
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 
 	"github.com/flant/shluz"
@@ -184,12 +185,18 @@ func runCleanup() error {
 		Policies:                  policies,
 	}
 
+	stagesCleanupDryRun := *CommonCmdData.DryRun
+	if os.Getenv("WERF_STAGES_CLEANUP_ENABLED") != "1" {
+		// FIXME: dry-run=true is forced by default because of the broken cleanup for v1.1
+		stagesCleanupDryRun = true
+	}
+
 	stagesCleanupOptions := cleaning.StagesCleanupOptions{
 		ProjectName:       projectName,
 		ImagesRepoManager: imagesRepoManager,
 		StagesStorage:     stagesStorage,
 		ImagesNames:       imagesNames,
-		DryRun:            *CommonCmdData.DryRun,
+		DryRun:            stagesCleanupDryRun,
 	}
 
 	cleanupOptions := cleaning.CleanupOptions{

--- a/cmd/werf/stages/cleanup/cleanup.go
+++ b/cmd/werf/stages/cleanup/cleanup.go
@@ -2,6 +2,7 @@ package cleanup
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 
 	"github.com/flant/shluz"
@@ -128,12 +129,18 @@ func runSync() error {
 		imagesNames = append(imagesNames, image.Name)
 	}
 
+	stagesCleanupDryRun := *CommonCmdData.DryRun
+	if os.Getenv("WERF_STAGES_CLEANUP_ENABLED") != "1" {
+		// FIXME: dry-run=true is forced by default because of the broken cleanup for v1.1
+		stagesCleanupDryRun = true
+	}
+
 	stagesCleanupOptions := cleaning.StagesCleanupOptions{
 		ProjectName:       projectName,
 		ImagesRepoManager: imagesRepoManager,
 		StagesStorage:     stagesStorage,
 		ImagesNames:       imagesNames,
-		DryRun:            *CommonCmdData.DryRun,
+		DryRun:            stagesCleanupDryRun,
 	}
 
 	logboek.LogOptionalLn()


### PR DESCRIPTION
Dry-run mode is forced by default for stages-cleanup procedure in commands: `werf stages cleanup`, `werf cleanup`.

Images cleanup is not affected and enabled as always in `werf cleanup`.

To enable stages-cleanup forcefully set: `WERF_STAGES_CLEANUP_ENABLED=1`.

Dry-run by default will be disabled when stages-cleanup procedure bug is fixed.