### PR TITLE
Use yaml strict unmarshal everywhere

### DIFF
--- a/cmd/werf/ci_env/ci_env.go
+++ b/cmd/werf/ci_env/ci_env.go
@@ -307,7 +307,7 @@ func getCleanupConfig() (CleanupConfig, error) {
 	}
 
 	config := CleanupConfig{}
-	if err := yaml.Unmarshal(data, &config); err != nil {
+	if err := yaml.UnmarshalStrict(data, &config); err != nil {
 		return CleanupConfig{}, fmt.Errorf("bad config yaml %s: %s", configPath, err)
 	}
 

--- a/cmd/werf/helm/secret/common/edit.go
+++ b/cmd/werf/helm/secret/common/edit.go
@@ -240,7 +240,7 @@ func prepareResultValuesData(data, encodedData, newData, newEncodedData []byte) 
 
 func unmarshalYaml(data []byte) (yaml.MapSlice, error) {
 	config := make(yaml.MapSlice, 0)
-	err := yaml.Unmarshal(data, &config)
+	err := yaml.UnmarshalStrict(data, &config)
 	if err != nil {
 		return nil, err
 	}

--- a/go.mod
+++ b/go.mod
@@ -39,7 +39,7 @@ require (
 	github.com/flant/logboek v0.2.6-0.20200204184239-37f691eb9129
 	github.com/flant/shluz v0.0.0-20191223174507-c6152b298d53
 	github.com/flynn-archive/go-shlex v0.0.0-20150515145356-3f9db97f8568
-	github.com/ghodss/yaml v0.0.0-20180820084758-c7ce16629ff4
+	github.com/ghodss/yaml v1.0.1-0.20190212211648-25d852aebe32
 	github.com/gofrs/flock v0.7.1
 	github.com/google/btree v1.0.0
 	github.com/google/go-cmp v0.3.0
@@ -168,4 +168,4 @@ replace k8s.io/sample-controller => k8s.io/sample-controller v0.16.7
 
 go 1.13
 
-replace k8s.io/helm => github.com/flant/helm v0.0.0-20200212200317-4fdb38920375
+replace k8s.io/helm => github.com/flant/helm v0.0.0-20200217100637-b18c566416d9

--- a/go.sum
+++ b/go.sum
@@ -183,6 +183,8 @@ github.com/flant/go-containerregistry v0.0.0-20190712094650-0cfc503dc51a h1:fatg
 github.com/flant/go-containerregistry v0.0.0-20190712094650-0cfc503dc51a/go.mod h1:MgVxbTqOBzPfJUyizvHRrXq2MmYT6MobMn/1N9+QTFA=
 github.com/flant/helm v0.0.0-20200212200317-4fdb38920375 h1:SIB+/4/JaWceehHw+pPtSA8RtjE5gI4WxrhqdoFi6K4=
 github.com/flant/helm v0.0.0-20200212200317-4fdb38920375/go.mod h1:FHKowHypya/eJOow7G2J/e8KCAXhhhZ/kVfzzNyAOB8=
+github.com/flant/helm v0.0.0-20200217100637-b18c566416d9 h1:GeY1frTHUMr3Zi3wYP+Y9Q6k7D0HadULpCQzELw/FN4=
+github.com/flant/helm v0.0.0-20200217100637-b18c566416d9/go.mod h1:kVR/UJ6TuuVNuyUbJ2WDnIiP6Is/ikNMwM+2jq2+jSc=
 github.com/flant/kubedog v0.3.5-0.20200213111410-09bddc160684 h1:qlP25ub/MTaZufGerOv01ruZJZTDj0K6YZFlpr5sd0E=
 github.com/flant/kubedog v0.3.5-0.20200213111410-09bddc160684/go.mod h1:cyOV/syD4pkYuqdFuUs/GMkUMGOoNa0MA51eP84nvg4=
 github.com/flant/logboek v0.2.5/go.mod h1:eEQXX0UOWpyC8iaA9QOvzx8drZ64u0SRESiwQKnxF+I=
@@ -197,6 +199,8 @@ github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMo
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/ghodss/yaml v0.0.0-20180820084758-c7ce16629ff4 h1:bRzFpEzvausOAt4va+I/22BZ1vXDtERngp0BNYDKej0=
 github.com/ghodss/yaml v0.0.0-20180820084758-c7ce16629ff4/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
+github.com/ghodss/yaml v1.0.1-0.20190212211648-25d852aebe32 h1:Mn26/9ZMNWSw9C9ERFA1PUxfmGpolnw2v0bKOREu5ew=
+github.com/ghodss/yaml v1.0.1-0.20190212211648-25d852aebe32/go.mod h1:GIjDIg/heH5DOkXY3YJ/wNhfHsQHoXGjl8G8amsYQ1I=
 github.com/gliderlabs/ssh v0.1.1/go.mod h1:U7qILu1NlMHj9FlMhZLlkCdDnU1DBEAqr0aevW3Awn0=
 github.com/gliderlabs/ssh v0.2.2/go.mod h1:U7qILu1NlMHj9FlMhZLlkCdDnU1DBEAqr0aevW3Awn0=
 github.com/globalsign/mgo v0.0.0-20180905125535-1ca0a4f7cbcb/go.mod h1:xkRDCp4j0OGD1HRkm4kmhM+pmpv3AKq5SU7GMg4oO/Q=
@@ -835,6 +839,8 @@ gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v3 v3.0.0-20200121175148-a6ecf24a6d71 h1:Xe2gvTZUJpsvOWUnvmL/tmhVBZUmHSvLbMjRj6NUUKo=
+gopkg.in/yaml.v3 v3.0.0-20200121175148-a6ecf24a6d71/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gotest.tools v2.1.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
 gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
 gotest.tools/gotestsum v0.3.5/go.mod h1:Mnf3e5FUzXbkCfynWBGOwLssY7gTQgCHObK9tMpAriY=

--- a/pkg/config/parser.go
+++ b/pkg/config/parser.go
@@ -501,7 +501,7 @@ func splitByMetaAndRawImages(docs []*doc) (*Meta, []*rawStapelImage, []*rawImage
 	parentStack = util.NewStack()
 	for _, doc := range docs {
 		var raw map[string]interface{}
-		err := yaml.Unmarshal(doc.Content, &raw)
+		err := yaml.UnmarshalStrict(doc.Content, &raw)
 		if err != nil {
 			return nil, nil, nil, newYamlUnmarshalError(err, doc)
 		}
@@ -512,7 +512,7 @@ func splitByMetaAndRawImages(docs []*doc) (*Meta, []*rawStapelImage, []*rawImage
 			}
 
 			rawMeta := &rawMeta{doc: doc}
-			err := yaml.Unmarshal(doc.Content, &rawMeta)
+			err := yaml.UnmarshalStrict(doc.Content, &rawMeta)
 			if err != nil {
 				return nil, nil, nil, newYamlUnmarshalError(err, doc)
 			}
@@ -520,7 +520,7 @@ func splitByMetaAndRawImages(docs []*doc) (*Meta, []*rawStapelImage, []*rawImage
 			resultMeta = rawMeta.toMeta()
 		} else if isImageFromDockerfileDoc(raw) {
 			imageFromDockerfile := &rawImageFromDockerfile{doc: doc}
-			err := yaml.Unmarshal(doc.Content, &imageFromDockerfile)
+			err := yaml.UnmarshalStrict(doc.Content, &imageFromDockerfile)
 			if err != nil {
 				return nil, nil, nil, newYamlUnmarshalError(err, doc)
 			}
@@ -528,7 +528,7 @@ func splitByMetaAndRawImages(docs []*doc) (*Meta, []*rawStapelImage, []*rawImage
 			rawImagesFromDockerfile = append(rawImagesFromDockerfile, imageFromDockerfile)
 		} else if isImageDoc(raw) {
 			image := &rawStapelImage{doc: doc}
-			err := yaml.Unmarshal(doc.Content, &image)
+			err := yaml.UnmarshalStrict(doc.Content, &image)
 			if err != nil {
 				return nil, nil, nil, newYamlUnmarshalError(err, doc)
 			}

--- a/pkg/config/raw_ansible_task.go
+++ b/pkg/config/raw_ansible_task.go
@@ -160,7 +160,7 @@ func (c *rawAnsibleTask) toDirective() (*AnsibleTask, error) {
 	}
 
 	var unmarshal map[string]interface{}
-	err = yaml.Unmarshal(marshal, &unmarshal)
+	err = yaml.UnmarshalStrict(marshal, &unmarshal)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/deploy/helm/render.go
+++ b/pkg/deploy/helm/render.go
@@ -121,7 +121,7 @@ func vals(values valueFiles, secretValues []map[string]interface{}, set []string
 			return []byte{}, err
 		}
 
-		if err := yaml.Unmarshal(bytes, &currentMap); err != nil {
+		if err := yaml.UnmarshalStrict(bytes, &currentMap); err != nil {
 			return []byte{}, fmt.Errorf("failed to parse %s: %s", filePath, err)
 		}
 		// Merge with the previous map

--- a/pkg/deploy/helm/templates.go
+++ b/pkg/deploy/helm/templates.go
@@ -162,7 +162,7 @@ func parseTemplates(rawTemplates string) (ChartTemplates, error) {
 
 func parseTemplate(rawTemplate string) (Template, error) {
 	var t Template
-	err := yaml.Unmarshal([]byte(rawTemplate), &t)
+	err := yaml.UnmarshalStrict([]byte(rawTemplate), &t)
 	if err != nil {
 		return Template{}, fmt.Errorf("%s\n\n%s\n", err, util.NumerateLines(rawTemplate, 1))
 	}
@@ -195,13 +195,13 @@ func (e *WerfEngine) Render(chrt *chart.Chart, values chartutil.Values) (map[str
 		var resultManifests []string
 		for _, manifestContent := range releaseutil.SplitManifests(fileContent) {
 			var t Template
-			err := yaml.Unmarshal([]byte(manifestContent), &t)
+			err := yaml.UnmarshalStrict([]byte(manifestContent), &t)
 			if err != nil {
 				return nil, fmt.Errorf("parsing file %s failed: %s\n\n%s\n", fileName, err, util.NumerateLines(manifestContent, 1))
 			}
 
 			var h map[string]interface{}
-			_ = yaml.Unmarshal([]byte(manifestContent), &h)
+			_ = yaml.UnmarshalStrict([]byte(manifestContent), &h)
 
 			manifestContentIsEmpty := len(h) == 0
 			if manifestContentIsEmpty {

--- a/pkg/deploy/secret/base_manager.go
+++ b/pkg/deploy/secret/base_manager.go
@@ -75,7 +75,7 @@ func (s *BaseManager) DecryptYamlData(data []byte) ([]byte, error) {
 
 func doYamlData(doFunc func([]byte) ([]byte, error), data []byte) ([]byte, error) {
 	config := make(yaml.MapSlice, 0)
-	err := yaml.Unmarshal(data, &config)
+	err := yaml.UnmarshalStrict(data, &config)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/deploy/werf_chart/werf_chart.go
+++ b/pkg/deploy/werf_chart/werf_chart.go
@@ -61,7 +61,7 @@ func (chart *WerfChart) SetSecretValuesFile(path string, m secret.Manager) error
 	}
 
 	var values map[string]interface{}
-	if err := yaml.Unmarshal(decodedData, &values); err != nil {
+	if err := yaml.UnmarshalStrict(decodedData, &values); err != nil {
 		return fmt.Errorf("cannot unmarshal secret values file %s: %s", path, err)
 	}
 	chart.SecretValues = append(chart.SecretValues, values)


### PR DESCRIPTION
 - Update flant/helm to the version with strict unmarshal.
 - Update gopkg/yaml to v3.
 - Update github.com/ghodss/yaml to v1.0.
 - Use yaml.UnmarshalStrict everywhere in the werf codebase.