### PR TITLE
Fixes related to the "Resource already exists" deploy error, tests included

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,7 @@ module github.com/flant/werf
 
 require (
 	cloud.google.com/go v0.38.0
+	github.com/Masterminds/goutils v1.1.0
 	github.com/Masterminds/semver v1.4.2
 	github.com/Masterminds/sprig v2.20.0+incompatible
 	github.com/agl/ed25519 v0.0.0-20170116200512-5312a6153412 // indirect
@@ -168,4 +169,4 @@ replace k8s.io/sample-controller => k8s.io/sample-controller v0.16.7
 
 go 1.13
 
-replace k8s.io/helm => github.com/flant/helm v0.0.0-20200217100637-b18c566416d9
+replace k8s.io/helm => github.com/flant/helm v0.0.0-20200219121324-93546abae733

--- a/go.sum
+++ b/go.sum
@@ -185,6 +185,8 @@ github.com/flant/helm v0.0.0-20200212200317-4fdb38920375 h1:SIB+/4/JaWceehHw+pPt
 github.com/flant/helm v0.0.0-20200212200317-4fdb38920375/go.mod h1:FHKowHypya/eJOow7G2J/e8KCAXhhhZ/kVfzzNyAOB8=
 github.com/flant/helm v0.0.0-20200217100637-b18c566416d9 h1:GeY1frTHUMr3Zi3wYP+Y9Q6k7D0HadULpCQzELw/FN4=
 github.com/flant/helm v0.0.0-20200217100637-b18c566416d9/go.mod h1:kVR/UJ6TuuVNuyUbJ2WDnIiP6Is/ikNMwM+2jq2+jSc=
+github.com/flant/helm v0.0.0-20200219121324-93546abae733 h1:ZtnR7X18lQ8TiqlchahgBvFZh0jTZzjFnhjet2GonBU=
+github.com/flant/helm v0.0.0-20200219121324-93546abae733/go.mod h1:kVR/UJ6TuuVNuyUbJ2WDnIiP6Is/ikNMwM+2jq2+jSc=
 github.com/flant/kubedog v0.3.5-0.20200213111410-09bddc160684 h1:qlP25ub/MTaZufGerOv01ruZJZTDj0K6YZFlpr5sd0E=
 github.com/flant/kubedog v0.3.5-0.20200213111410-09bddc160684/go.mod h1:cyOV/syD4pkYuqdFuUs/GMkUMGOoNa0MA51eP84nvg4=
 github.com/flant/logboek v0.2.5/go.mod h1:eEQXX0UOWpyC8iaA9QOvzx8drZ64u0SRESiwQKnxF+I=

--- a/integration_k8s/releaseserver/three_way_merge_patches_creator_app3-001/.helm/templates/templates.yaml
+++ b/integration_k8s/releaseserver/three_way_merge_patches_creator_app3-001/.helm/templates/templates.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mycm1
+data:
+  moloko: omlet
+  aloe: aloha

--- a/integration_k8s/releaseserver/three_way_merge_patches_creator_app3-001/werf.yaml
+++ b/integration_k8s/releaseserver/three_way_merge_patches_creator_app3-001/werf.yaml
@@ -1,0 +1,2 @@
+configVersion: 1
+project: release-server-three-way-merge-app1

--- a/integration_k8s/releaseserver/three_way_merge_patches_creator_app3-002/.helm/templates/templates.yaml
+++ b/integration_k8s/releaseserver/three_way_merge_patches_creator_app3-002/.helm/templates/templates.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mycm1
+data:
+  moloko: omlet
+  aloe: aloha
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mydeploy1
+  annotations:
+    "werf.io/failures-allowed-per-replica": 0
+  labels:
+    service: mydeploy1
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      service: mydeploy1
+  template:
+    metadata:
+      labels:
+        service: mydeploy1
+    spec:
+      containers:
+      - name: main
+        command: [ "/bin/bash", "-c", "while true; do date ; sleep 1 ; done" ]
+        image: ubunt:18.04

--- a/integration_k8s/releaseserver/three_way_merge_patches_creator_app3-002/werf.yaml
+++ b/integration_k8s/releaseserver/three_way_merge_patches_creator_app3-002/werf.yaml
@@ -1,0 +1,2 @@
+configVersion: 1
+project: release-server-three-way-merge-app1

--- a/integration_k8s/releaseserver/three_way_merge_patches_creator_app3-003/.helm/templates/templates.yaml
+++ b/integration_k8s/releaseserver/three_way_merge_patches_creator_app3-003/.helm/templates/templates.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mycm1
+data:
+  moloko: omlet
+  aloe: aloha
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mydeploy1
+  annotations:
+    "werf.io/failures-allowed-per-replica": 0
+  labels:
+    service: mydeploy1
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      service: mydeploy1
+  template:
+    metadata:
+      labels:
+        service: mydeploy1
+    spec:
+      containers:
+      - name: main
+        command: [ "/bin/bash", "-c", "while true; do date ; sleep 1 ; done" ]
+        image: ubuntu:18.04

--- a/integration_k8s/releaseserver/three_way_merge_patches_creator_app3-003/werf.yaml
+++ b/integration_k8s/releaseserver/three_way_merge_patches_creator_app3-003/werf.yaml
@@ -1,0 +1,2 @@
+configVersion: 1
+project: release-server-three-way-merge-app1


### PR DESCRIPTION
 - fix "resource already exists" error on redeploy when new resource with an error has been added to the chart,
   refs https://github.com/flant/helm/pull/40
 - fix "resource already exists" error message when creating a helm.sh/hook that already exists,
   refs https://github.com/flant/helm/pull/41
 - do not allow resource adoption during initial release installation, fix error messages,
   refs https://github.com/flant/helm/pull/42
