### PR TITLE
[1.0] Fixes related to the "Resource already exists" deploy error

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/flant/werf
 require (
 	cloud.google.com/go v0.38.0
 	github.com/DATA-DOG/go-sqlmock v1.4.0 // indirect
+	github.com/Masterminds/goutils v1.1.0
 	github.com/Masterminds/semver v1.4.2
 	github.com/Masterminds/sprig v2.20.0+incompatible
 	github.com/agl/ed25519 v0.0.0-20170116200512-5312a6153412 // indirect
@@ -119,7 +120,7 @@ require (
 	sigs.k8s.io/yaml v1.1.0
 )
 
-replace k8s.io/helm => github.com/flant/helm v0.0.0-20191216114509-460380ca08d4
+replace k8s.io/helm => github.com/flant/helm v0.0.0-20200219121629-ecc6b3f8cc55
 
 replace k8s.io/api => k8s.io/api v0.0.0-20190918155943-95b840bb6a1f
 

--- a/go.sum
+++ b/go.sum
@@ -158,6 +158,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/daviddengcn/go-colortext v0.0.0-20160507010035-511bcaf42ccd/go.mod h1:dv4zxwHi5C/8AeI+4gX4dCWOIvNi7I6JCSX0HvlKPgE=
+github.com/denisenkom/go-mssqldb v0.0.0-20191124224453-732737034ffd h1:83Wprp6ROGeiHFAP8WJdI2RoxALQYgdllERc3N5N2DM=
+github.com/denisenkom/go-mssqldb v0.0.0-20191124224453-732737034ffd/go.mod h1:xbL0rPBG9cCiLr28tMa8zpbdarY27NDyej4t/EjAShU=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dnaeon/go-vcr v1.0.1/go.mod h1:aBB1+wY4s93YsC3HHjMBMrwTj2R9FHDzUr9KyGc8n1E=
@@ -223,6 +225,8 @@ github.com/flant/helm v0.0.0-20191211084106-f60af6e127ed h1:1KNqSbdml7LhDGIiIsfa
 github.com/flant/helm v0.0.0-20191211084106-f60af6e127ed/go.mod h1:8HfWC34vJLVKWk1DLpU9CS0nKa8k6N6H3coDnrX1Loo=
 github.com/flant/helm v0.0.0-20191216114509-460380ca08d4 h1:7pB14RweMd22FyaEW5Kukut98ahqtnerFVp6X5MioWI=
 github.com/flant/helm v0.0.0-20191216114509-460380ca08d4/go.mod h1:8HfWC34vJLVKWk1DLpU9CS0nKa8k6N6H3coDnrX1Loo=
+github.com/flant/helm v0.0.0-20200219121629-ecc6b3f8cc55 h1:Gm3dk9avBvwdP4GWSAZI0gKLewmYZTYDyDN5Qz1Mkf8=
+github.com/flant/helm v0.0.0-20200219121629-ecc6b3f8cc55/go.mod h1:8HfWC34vJLVKWk1DLpU9CS0nKa8k6N6H3coDnrX1Loo=
 github.com/flant/kubedog v0.3.5-0.20191115094125-b86378ba389b h1:G4d9ZWX43b8x2KKJgzXFWJ3S5LaAp/OW7ImVk5XO6/c=
 github.com/flant/kubedog v0.3.5-0.20191115094125-b86378ba389b/go.mod h1:mQ0PeK5cntODe4lWEhrhIFtNZHAG/AiI7KmRpLSEKDk=
 github.com/flant/kubedog v0.3.5-0.20191128170454-bd02f0299551 h1:X5mZ2zdV3Zv1rywRVkFExE4TBeGXbAxzIaUy9b9zds8=
@@ -323,6 +327,8 @@ github.com/gogo/protobuf v1.2.0/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7a
 github.com/gogo/protobuf v1.2.2-0.20190723190241-65acae22fc9d/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
 github.com/gogo/protobuf v1.3.0 h1:G8O7TerXerS4F6sx9OV7/nRfJdnXgHZu/S/7F2SN+UE=
 github.com/gogo/protobuf v1.3.0/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
+github.com/golang-sql/civil v0.0.0-20190719163853-cb61b32ac6fe h1:lXe2qZdvpiX5WZkZR4hgp4KJVfY3nMkvmwbVkpv1rVY=
+github.com/golang-sql/civil v0.0.0-20190719163853-cb61b32ac6fe/go.mod h1:8vg3r2VgvsThLBIFL93Qb5yWzgyZWhEmBwUJWevAkK0=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20160516000752-02826c3e7903 h1:LbsanbbD6LieFkXbj9YNNBupiGHJgFeLpO0j0Fza1h8=
@@ -938,7 +944,3 @@ sigs.k8s.io/yaml v1.1.0 h1:4A07+ZFc2wgJwo8YNlQpr1rVlgUDlxXHhPJciaPY5gs=
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=
 vbom.ml/util v0.0.0-20160121211510-db5cfe13f5cc h1:MksmcCZQWAQJCTA5T0jgI/0sJ51AVm4Z41MrmfczEoc=
 vbom.ml/util v0.0.0-20160121211510-db5cfe13f5cc/go.mod h1:so/NYdZXCz+E3ZpW0uAoCj6uzU2+8OWDFv/HxUSs7kI=
-github.com/denisenkom/go-mssqldb v0.0.0-20191124224453-732737034ffd h1:83Wprp6ROGeiHFAP8WJdI2RoxALQYgdllERc3N5N2DM=
-github.com/denisenkom/go-mssqldb v0.0.0-20191124224453-732737034ffd/go.mod h1:xbL0rPBG9cCiLr28tMa8zpbdarY27NDyej4t/EjAShU=
-github.com/golang-sql/civil v0.0.0-20190719163853-cb61b32ac6fe h1:lXe2qZdvpiX5WZkZR4hgp4KJVfY3nMkvmwbVkpv1rVY=
-github.com/golang-sql/civil v0.0.0-20190719163853-cb61b32ac6fe/go.mod h1:8vg3r2VgvsThLBIFL93Qb5yWzgyZWhEmBwUJWevAkK0=

--- a/integration_k8s/releaseserver/resources_adopter_app1-001/.helm/templates/templates.yaml
+++ b/integration_k8s/releaseserver/resources_adopter_app1-001/.helm/templates/templates.yaml
@@ -22,30 +22,6 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: mydeploy2
-  labels:
-    service: mydeploy2
-spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      service: mydeploy2
-  template:
-    metadata:
-      labels:
-        service: mydeploy2
-    spec:
-      containers:
-      - name: main
-        command: [ "/bin/bash", "-c", "while true; do date ; sleep 1 ; done" ]
-        image: ubuntu:18.04
-        env:
-          - name: KEY
-            value: VALUE
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
   name: mydeploy3
   labels:
     service: mydeploy3
@@ -63,28 +39,4 @@ spec:
       - name: main
         command: [ "/bin/bash", "-c", "while true; do date ; sleep 1 ; done" ]
         image: ubuntu:18.04
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: mydeploy4
-  labels:
-    service: mydeploy4
-spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      service: mydeploy4
-  template:
-    metadata:
-      labels:
-        service: mydeploy4
-    spec:
-      containers:
-      - name: main
-        command: [ "/bin/bash", "-c", "while true; do date ; sleep 1 ; done" ]
-        image: ubuntu:18.04
-        env:
-        - name: MYVAR
-          value: myvalue
 ---

--- a/integration_k8s/releaseserver/resources_adopter_app1-003/.helm/templates/templates.yaml
+++ b/integration_k8s/releaseserver/resources_adopter_app1-003/.helm/templates/templates.yaml
@@ -39,9 +39,6 @@ spec:
       - name: main
         command: [ "/bin/bash", "-c", "while true; do date ; sleep 1 ; done" ]
         image: ubuntu:18.04
-        env:
-          - name: KEY
-            value: VALUE
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -84,7 +81,25 @@ spec:
       - name: main
         command: [ "/bin/bash", "-c", "while true; do date ; sleep 1 ; done" ]
         image: ubuntu:18.04
-        env:
-        - name: MYVAR
-          value: myvalue
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mydeploy5
+  labels:
+    service: mydeploy5
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      service: mydeploy5
+  template:
+    metadata:
+      labels:
+        service: mydeploy5
+    spec:
+      containers:
+        - name: main
+          command: [ "/bin/bash", "-c", "while true; do date ; sleep 1 ; done" ]
+          image: ubuntu:18.04
 ---

--- a/integration_k8s/releaseserver/resources_adopter_app1-003/werf.yaml
+++ b/integration_k8s/releaseserver/resources_adopter_app1-003/werf.yaml
@@ -1,0 +1,2 @@
+configVersion: 1
+project: release-server-resources-adopter-app1

--- a/integration_k8s/releaseserver/three_way_merge_patches_creator_app3-001/.helm/templates/templates.yaml
+++ b/integration_k8s/releaseserver/three_way_merge_patches_creator_app3-001/.helm/templates/templates.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mycm1
+data:
+  moloko: omlet
+  aloe: aloha

--- a/integration_k8s/releaseserver/three_way_merge_patches_creator_app3-001/werf.yaml
+++ b/integration_k8s/releaseserver/three_way_merge_patches_creator_app3-001/werf.yaml
@@ -1,0 +1,2 @@
+configVersion: 1
+project: release-server-three-way-merge-app1

--- a/integration_k8s/releaseserver/three_way_merge_patches_creator_app3-002/.helm/templates/templates.yaml
+++ b/integration_k8s/releaseserver/three_way_merge_patches_creator_app3-002/.helm/templates/templates.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mycm1
+data:
+  moloko: omlet
+  aloe: aloha
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mydeploy1
+  annotations:
+    "werf.io/failures-allowed-per-replica": 0
+  labels:
+    service: mydeploy1
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      service: mydeploy1
+  template:
+    metadata:
+      labels:
+        service: mydeploy1
+    spec:
+      containers:
+      - name: main
+        command: [ "/bin/bash", "-c", "while true; do date ; sleep 1 ; done" ]
+        image: ubunt:18.04

--- a/integration_k8s/releaseserver/three_way_merge_patches_creator_app3-002/werf.yaml
+++ b/integration_k8s/releaseserver/three_way_merge_patches_creator_app3-002/werf.yaml
@@ -1,0 +1,2 @@
+configVersion: 1
+project: release-server-three-way-merge-app1

--- a/integration_k8s/releaseserver/three_way_merge_patches_creator_app3-003/.helm/templates/templates.yaml
+++ b/integration_k8s/releaseserver/three_way_merge_patches_creator_app3-003/.helm/templates/templates.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mycm1
+data:
+  moloko: omlet
+  aloe: aloha
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mydeploy1
+  annotations:
+    "werf.io/failures-allowed-per-replica": 0
+  labels:
+    service: mydeploy1
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      service: mydeploy1
+  template:
+    metadata:
+      labels:
+        service: mydeploy1
+    spec:
+      containers:
+      - name: main
+        command: [ "/bin/bash", "-c", "while true; do date ; sleep 1 ; done" ]
+        image: ubuntu:18.04

--- a/integration_k8s/releaseserver/three_way_merge_patches_creator_app3-003/werf.yaml
+++ b/integration_k8s/releaseserver/three_way_merge_patches_creator_app3-003/werf.yaml
@@ -1,0 +1,2 @@
+configVersion: 1
+project: release-server-three-way-merge-app1


### PR DESCRIPTION
 - fix "resource already exists" error on redeploy when new resource with an error has been added to the chart,
   refs flant/helm#40
 - fix "resource already exists" error message when creating a helm.sh/hook that already exists,
   refs flant/helm#41
 - do not allow resource adoption during initial release installation, fix error messages,
   refs flant/helm#42
