### PR TITLE
Fix import stage logic and stages cleanup

### DIFF
--- a/cmd/werf/cleanup/cleanup.go
+++ b/cmd/werf/cleanup/cleanup.go
@@ -2,7 +2,6 @@ package cleanup
 
 import (
 	"fmt"
-	"os"
 	"path/filepath"
 
 	"github.com/flant/shluz"
@@ -185,18 +184,12 @@ func runCleanup() error {
 		Policies:                  policies,
 	}
 
-	stagesCleanupDryRun := *CommonCmdData.DryRun
-	if os.Getenv("WERF_STAGES_CLEANUP_ENABLED") != "1" {
-		// FIXME: dry-run=true is forced by default because of the broken cleanup for v1.1
-		stagesCleanupDryRun = true
-	}
-
 	stagesCleanupOptions := cleaning.StagesCleanupOptions{
 		ProjectName:       projectName,
 		ImagesRepoManager: imagesRepoManager,
 		StagesStorage:     stagesStorage,
 		ImagesNames:       imagesNames,
-		DryRun:            stagesCleanupDryRun,
+		DryRun:            *CommonCmdData.DryRun,
 	}
 
 	cleanupOptions := cleaning.CleanupOptions{

--- a/cmd/werf/stages/cleanup/cleanup.go
+++ b/cmd/werf/stages/cleanup/cleanup.go
@@ -2,7 +2,6 @@ package cleanup
 
 import (
 	"fmt"
-	"os"
 	"path/filepath"
 
 	"github.com/flant/shluz"
@@ -129,18 +128,12 @@ func runSync() error {
 		imagesNames = append(imagesNames, image.Name)
 	}
 
-	stagesCleanupDryRun := *CommonCmdData.DryRun
-	if os.Getenv("WERF_STAGES_CLEANUP_ENABLED") != "1" {
-		// FIXME: dry-run=true is forced by default because of the broken cleanup for v1.1
-		stagesCleanupDryRun = true
-	}
-
 	stagesCleanupOptions := cleaning.StagesCleanupOptions{
 		ProjectName:       projectName,
 		ImagesRepoManager: imagesRepoManager,
 		StagesStorage:     stagesStorage,
 		ImagesNames:       imagesNames,
-		DryRun:            stagesCleanupDryRun,
+		DryRun:            *CommonCmdData.DryRun,
 	}
 
 	logboek.LogOptionalLn()

--- a/integration/cleanup/_fixtures/default/werf.yaml
+++ b/integration/cleanup/_fixtures/default/werf.yaml
@@ -5,3 +5,13 @@ image: ~
 from: alpine
 shell:
   setup: date
+import:
+- artifact: test
+  add: /test
+  to: /test
+  before: setup
+---
+artifact: test
+from: alpine
+shell:
+  install: echo "123" > /test

--- a/integration/cleanup/_fixtures/stages_cleanup/werf.yaml
+++ b/integration/cleanup/_fixtures/stages_cleanup/werf.yaml
@@ -6,3 +6,14 @@ from: alpine
 fromCacheVersion: {{ env "FROM_CACHE_VERSION" }}
 shell:
   setup: date
+import:
+- artifact: test
+  add: /test
+  to: /test
+  before: setup
+---
+artifact: test
+from: alpine
+fromCacheVersion: {{ env "FROM_CACHE_VERSION" }}
+shell:
+  install: echo "123" > /test

--- a/integration/cleanup/images_cleanup_test.go
+++ b/integration/cleanup/images_cleanup_test.go
@@ -64,7 +64,7 @@ var _ = Describe("cleaning images", func() {
 		basicWerfArgs := basicWerfArgs
 
 		Describe(commandToCheck, func() {
-			Context("when deployed images in kubernetes are not taken in account", func() {
+			Context("when deployed images in kubernetes are not taken into account", func() {
 				BeforeEach(func() {
 					stubs.SetEnv("WERF_WITHOUT_KUBE", "1")
 				})

--- a/pkg/build/conveyor.go
+++ b/pkg/build/conveyor.go
@@ -460,6 +460,10 @@ func (c *Conveyor) GetImageLastStageImageName(imageName string) string {
 	return c.GetImage(imageName).GetLastNonEmptyStage().GetImage().Name()
 }
 
+func (c *Conveyor) GetImageLastStageImageID(imageName string) string {
+	return c.GetImage(imageName).GetLastNonEmptyStage().GetImage().ID()
+}
+
 func (c *Conveyor) SetBuildingGitStage(imageName string, stageName stage.StageName) {
 	c.buildingGitStageNameByImageName[imageName] = stageName
 }

--- a/pkg/build/stage/conveyor.go
+++ b/pkg/build/stage/conveyor.go
@@ -3,6 +3,7 @@ package stage
 type Conveyor interface {
 	GetImageStagesSignature(imageName string) string
 	GetImageLastStageImageName(imageName string) string
+	GetImageLastStageImageID(imageName string) string
 	SetBuildingGitStage(imageName string, stageName StageName)
 	GetBuildingGitStage(imageName string) StageName
 }

--- a/pkg/build/stage/imports.go
+++ b/pkg/build/stage/imports.go
@@ -86,10 +86,10 @@ func (s *ImportsStage) PrepareImage(c Conveyor, _, image imagePkg.ImageInterface
 		var labelKey, labelValue string
 		if elm.ImageName != "" {
 			labelKey = imagePkg.WerfImportLabelPrefix + slug.Slug(elm.ImageName)
-			labelValue = c.GetImageStagesSignature(elm.ImageName)
+			labelValue = c.GetImageLastStageImageID(elm.ImageName)
 		} else {
 			labelKey = imagePkg.WerfImportLabelPrefix + slug.Slug(elm.ArtifactName)
-			labelValue = c.GetImageStagesSignature(elm.ArtifactName)
+			labelValue = c.GetImageLastStageImageID(elm.ArtifactName)
 		}
 
 		imageServiceCommitChangeOptions.AddLabel(map[string]string{labelKey: labelValue})


### PR DESCRIPTION
The import stage image has a specific label that is used during stages cleanup procedure. In this commit, related image/artifact signature which stored in the label is replaced on image ID.

The signature does not identify the stage since we started to use not only signature in an image tag. From v1.1, werf is building stages consistently so related image/artifact image ID is available when werf is preparing import stage.