### PR TITLE
[logs] werf build and publish default logs output revised

### DIFF
--- a/cmd/werf/build_and_publish/main.go
+++ b/cmd/werf/build_and_publish/main.go
@@ -116,7 +116,7 @@ func runBuildAndPublish(imagesToProcess []string) error {
 		return err
 	}
 
-	if err := docker.Init(*CommonCmdData.DockerConfig); err != nil {
+	if err := docker.Init(*CommonCmdData.DockerConfig, *CommonCmdData.LogVerbose, *CommonCmdData.LogDebug); err != nil {
 		return err
 	}
 

--- a/cmd/werf/ci_env/ci_env.go
+++ b/cmd/werf/ci_env/ci_env.go
@@ -106,7 +106,7 @@ func generateGitlabEnvs(taggingStrategy string) error {
 	}
 
 	// Init with new docker config dir
-	if err := docker.Init(dockerConfig); err != nil {
+	if err := docker.Init(dockerConfig, *CommonCmdData.LogVerbose, *CommonCmdData.LogDebug); err != nil {
 		return err
 	}
 

--- a/cmd/werf/cleanup/cleanup.go
+++ b/cmd/werf/cleanup/cleanup.go
@@ -85,7 +85,7 @@ func runCleanup() error {
 		return err
 	}
 
-	if err := docker.Init(*CommonCmdData.DockerConfig); err != nil {
+	if err := docker.Init(*CommonCmdData.DockerConfig, *CommonCmdData.LogVerbose, *CommonCmdData.LogDebug); err != nil {
 		return err
 	}
 

--- a/cmd/werf/common/common.go
+++ b/cmd/werf/common/common.go
@@ -756,7 +756,9 @@ func GetWerfConfig(projectDir string) (*config.WerfConfig, error) {
 		return nil, err
 	}
 
-	return config.GetWerfConfig(werfConfigPath, true)
+	res, err := config.GetWerfConfig(werfConfigPath, true)
+	logboek.LogLn()
+	return res, err
 }
 
 func GetWerfConfigPath(projectDir string) (string, error) {

--- a/cmd/werf/deploy/main.go
+++ b/cmd/werf/deploy/main.go
@@ -156,7 +156,7 @@ func runDeploy() error {
 		return err
 	}
 
-	if err := docker.Init(*CommonCmdData.DockerConfig); err != nil {
+	if err := docker.Init(*CommonCmdData.DockerConfig, *CommonCmdData.LogVerbose, *CommonCmdData.LogDebug); err != nil {
 		return err
 	}
 

--- a/cmd/werf/dismiss/dismiss.go
+++ b/cmd/werf/dismiss/dismiss.go
@@ -111,7 +111,7 @@ func runDismiss() error {
 
 	common.LogKubeContext(kube.Context)
 
-	if err := docker.Init(*CommonCmdData.DockerConfig); err != nil {
+	if err := docker.Init(*CommonCmdData.DockerConfig, *CommonCmdData.LogVerbose, *CommonCmdData.LogDebug); err != nil {
 		return err
 	}
 

--- a/cmd/werf/helm/get_autogenerated_values/main.go
+++ b/cmd/werf/helm/get_autogenerated_values/main.go
@@ -85,7 +85,7 @@ func runGetServiceValues() error {
 		return err
 	}
 
-	if err := docker.Init(*CommonCmdData.DockerConfig); err != nil {
+	if err := docker.Init(*CommonCmdData.DockerConfig, *CommonCmdData.LogVerbose, *CommonCmdData.LogDebug); err != nil {
 		return err
 	}
 

--- a/cmd/werf/helm/get_namespace/main.go
+++ b/cmd/werf/helm/get_namespace/main.go
@@ -42,7 +42,7 @@ func runGetNamespace() error {
 		return err
 	}
 
-	if err := docker.Init(*CommonCmdData.DockerConfig); err != nil {
+	if err := docker.Init(*CommonCmdData.DockerConfig, *CommonCmdData.LogVerbose, *CommonCmdData.LogDebug); err != nil {
 		return err
 	}
 

--- a/cmd/werf/helm/get_release/main.go
+++ b/cmd/werf/helm/get_release/main.go
@@ -42,7 +42,7 @@ func runGetRelease() error {
 		return err
 	}
 
-	if err := docker.Init(*CommonCmdData.DockerConfig); err != nil {
+	if err := docker.Init(*CommonCmdData.DockerConfig, *CommonCmdData.LogVerbose, *CommonCmdData.LogDebug); err != nil {
 		return err
 	}
 

--- a/cmd/werf/helm/lint/lint.go
+++ b/cmd/werf/helm/lint/lint.go
@@ -70,7 +70,7 @@ func runLint() error {
 		return err
 	}
 
-	if err := docker.Init(*CommonCmdData.DockerConfig); err != nil {
+	if err := docker.Init(*CommonCmdData.DockerConfig, *CommonCmdData.LogVerbose, *CommonCmdData.LogDebug); err != nil {
 		return err
 	}
 

--- a/cmd/werf/helm/render/render.go
+++ b/cmd/werf/helm/render/render.go
@@ -87,7 +87,7 @@ func runRender(outputFilePath string) error {
 		return err
 	}
 
-	if err := docker.Init(*commonCmdData.DockerConfig); err != nil {
+	if err := docker.Init(*commonCmdData.DockerConfig, *commonCmdData.LogVerbose, *commonCmdData.LogDebug); err != nil {
 		return err
 	}
 

--- a/cmd/werf/host/cleanup/cleanup.go
+++ b/cmd/werf/host/cleanup/cleanup.go
@@ -79,7 +79,7 @@ func runGC() error {
 		return err
 	}
 
-	if err := docker.Init(*CommonCmdData.DockerConfig); err != nil {
+	if err := docker.Init(*CommonCmdData.DockerConfig, *CommonCmdData.LogVerbose, *CommonCmdData.LogDebug); err != nil {
 		return err
 	}
 

--- a/cmd/werf/host/project/list/list.go
+++ b/cmd/werf/host/project/list/list.go
@@ -56,7 +56,7 @@ func run() error {
 		return fmt.Errorf("initialization error: %s", err)
 	}
 
-	if err := docker.Init(*CommonCmdData.DockerConfig); err != nil {
+	if err := docker.Init(*CommonCmdData.DockerConfig, *CommonCmdData.LogVerbose, *CommonCmdData.LogDebug); err != nil {
 		return err
 	}
 

--- a/cmd/werf/host/project/purge/purge.go
+++ b/cmd/werf/host/project/purge/purge.go
@@ -74,7 +74,7 @@ func run(projectNames ...string) error {
 		return err
 	}
 
-	if err := docker.Init(*CommonCmdData.DockerConfig); err != nil {
+	if err := docker.Init(*CommonCmdData.DockerConfig, *CommonCmdData.LogVerbose, *CommonCmdData.LogDebug); err != nil {
 		return err
 	}
 

--- a/cmd/werf/host/purge/purge.go
+++ b/cmd/werf/host/purge/purge.go
@@ -78,7 +78,7 @@ func runReset() error {
 		return err
 	}
 
-	if err := docker.Init(*CommonCmdData.DockerConfig); err != nil {
+	if err := docker.Init(*CommonCmdData.DockerConfig, *CommonCmdData.LogVerbose, *CommonCmdData.LogDebug); err != nil {
 		return err
 	}
 

--- a/cmd/werf/images/cleanup/cleanup.go
+++ b/cmd/werf/images/cleanup/cleanup.go
@@ -77,7 +77,7 @@ func runCleanup() error {
 		return err
 	}
 
-	if err := docker.Init(*CommonCmdData.DockerConfig); err != nil {
+	if err := docker.Init(*CommonCmdData.DockerConfig, *CommonCmdData.LogVerbose, *CommonCmdData.LogDebug); err != nil {
 		return err
 	}
 

--- a/cmd/werf/images/publish/cmd_factory/main.go
+++ b/cmd/werf/images/publish/cmd_factory/main.go
@@ -84,7 +84,7 @@ func runImagesPublish(commonCmdData *common.CmdData, imagesToProcess []string) e
 		return err
 	}
 
-	if err := docker.Init(*commonCmdData.DockerConfig); err != nil {
+	if err := docker.Init(*commonCmdData.DockerConfig, *commonCmdData.LogVerbose, *commonCmdData.LogDebug); err != nil {
 		return err
 	}
 

--- a/cmd/werf/images/purge/purge.go
+++ b/cmd/werf/images/purge/purge.go
@@ -69,7 +69,7 @@ func runPurge() error {
 		return err
 	}
 
-	if err := docker.Init(*CommonCmdData.DockerConfig); err != nil {
+	if err := docker.Init(*CommonCmdData.DockerConfig, *CommonCmdData.LogVerbose, *CommonCmdData.LogDebug); err != nil {
 		return err
 	}
 

--- a/cmd/werf/purge/purge.go
+++ b/cmd/werf/purge/purge.go
@@ -96,7 +96,7 @@ func runPurge() error {
 		return err
 	}
 
-	if err := docker.Init(*CommonCmdData.DockerConfig); err != nil {
+	if err := docker.Init(*CommonCmdData.DockerConfig, *CommonCmdData.LogVerbose, *CommonCmdData.LogDebug); err != nil {
 		return err
 	}
 

--- a/cmd/werf/run/run.go
+++ b/cmd/werf/run/run.go
@@ -164,7 +164,7 @@ func runRun() error {
 		return err
 	}
 
-	if err := docker.Init(*CommonCmdData.DockerConfig); err != nil {
+	if err := docker.Init(*CommonCmdData.DockerConfig, *CommonCmdData.LogVerbose, *CommonCmdData.LogDebug); err != nil {
 		return err
 	}
 

--- a/cmd/werf/stage/image/main.go
+++ b/cmd/werf/stage/image/main.go
@@ -83,7 +83,7 @@ func run(imageName string) error {
 		return err
 	}
 
-	if err := docker.Init(*CommonCmdData.DockerConfig); err != nil {
+	if err := docker.Init(*CommonCmdData.DockerConfig, *CommonCmdData.LogVerbose, *CommonCmdData.LogDebug); err != nil {
 		return err
 	}
 

--- a/cmd/werf/stages/build/cmd_factory/main.go
+++ b/cmd/werf/stages/build/cmd_factory/main.go
@@ -107,7 +107,7 @@ func runStagesBuild(cmdData *CmdData, commonCmdData *common.CmdData, imagesToPro
 		return err
 	}
 
-	if err := docker.Init(*commonCmdData.DockerConfig); err != nil {
+	if err := docker.Init(*commonCmdData.DockerConfig, *commonCmdData.LogVerbose, *commonCmdData.LogDebug); err != nil {
 		return err
 	}
 

--- a/cmd/werf/stages/cleanup/cleanup.go
+++ b/cmd/werf/stages/cleanup/cleanup.go
@@ -74,7 +74,7 @@ func runSync() error {
 		return err
 	}
 
-	if err := docker.Init(*CommonCmdData.DockerConfig); err != nil {
+	if err := docker.Init(*CommonCmdData.DockerConfig, *CommonCmdData.LogVerbose, *CommonCmdData.LogDebug); err != nil {
 		return err
 	}
 

--- a/cmd/werf/stages/purge/purge.go
+++ b/cmd/werf/stages/purge/purge.go
@@ -74,7 +74,7 @@ func runPurge() error {
 		return err
 	}
 
-	if err := docker.Init(*CommonCmdData.DockerConfig); err != nil {
+	if err := docker.Init(*CommonCmdData.DockerConfig, *CommonCmdData.LogVerbose, *CommonCmdData.LogDebug); err != nil {
 		return err
 	}
 

--- a/pkg/build/build_phase.go
+++ b/pkg/build/build_phase.go
@@ -268,7 +268,6 @@ func (phase *BuildPhase) calculateStageSignature(img *Image, stg stage.Interface
 				"Stage %q image %s by signature %s from stages storage cache is not exists: resetting stages storage cache\n",
 				stg.Name(), stageSig, i.Name(),
 			)
-			logboek.LogOptionalLn()
 			shouldResetCache = true
 		}
 	} else {
@@ -276,7 +275,6 @@ func (phase *BuildPhase) calculateStageSignature(img *Image, stg stage.Interface
 			"Stage %q cache by signature %s is not exists in stages storage cache: resetting stages storage cache\n",
 			stg.Name(), stageSig,
 		)
-		logboek.LogOptionalLn()
 		shouldResetCache = true
 	}
 
@@ -320,7 +318,7 @@ func (phase *BuildPhase) selectSuitableStagesStorageImage(stg stage.Interface, i
 	}
 
 	var imgInfo *storage.ImageInfo
-	if err := logboek.Debug.LogProcess(
+	if err := logboek.Info.LogProcess(
 		fmt.Sprintf("Selecting suitable image for stage %s by signature %s", stg.Name(), stg.GetSignature()),
 		logboek.LevelLogProcessOptions{},
 		func() error {
@@ -348,7 +346,7 @@ func (phase *BuildPhase) selectSuitableStagesStorageImage(stg stage.Interface, i
 	i := phase.Conveyor.GetOrCreateStageImage(phase.PrevImage, imgInfo.ImageName)
 	stg.SetImage(i)
 
-	if err := logboek.Debug.LogProcess(
+	if err := logboek.Info.LogProcess(
 		fmt.Sprintf("Sync stage %s signature %s image %s from stages storage", stg.Name(), stg.GetSignature(), i.Name()),
 		logboek.LevelLogProcessOptions{},
 		func() error {
@@ -368,7 +366,7 @@ func (phase *BuildPhase) getImagesBySignatureFromCache(stageName, stageSig strin
 	var cacheExists bool
 	var cacheImagesDescs []*storage.ImageInfo
 
-	err := logboek.Debug.LogProcess(
+	err := logboek.Info.LogProcess(
 		fmt.Sprintf("Getting stage %s images by signature %s from stages storage cache", stageName, stageSig),
 		logboek.LevelLogProcessOptions{},
 		func() error {
@@ -392,7 +390,7 @@ func (phase *BuildPhase) atomicGetImagesBySignatureFromStagesStorageWithCacheRes
 
 	var originImagesDescs []*storage.ImageInfo
 	var err error
-	if err := logboek.Debug.LogProcess(
+	if err := logboek.Info.LogProcess(
 		fmt.Sprintf("Getting stage %s images by signature %s from stages storage", stageName, stageSig),
 		logboek.LevelLogProcessOptions{},
 		func() error {
@@ -407,7 +405,7 @@ func (phase *BuildPhase) atomicGetImagesBySignatureFromStagesStorageWithCacheRes
 		return nil, err
 	}
 
-	if err := logboek.Debug.LogProcess(
+	if err := logboek.Info.LogProcess(
 		fmt.Sprintf("Storing stage %s images by signature %s into stages storage cache", stageName, stageSig),
 		logboek.LevelLogProcessOptions{},
 		func() error {
@@ -429,7 +427,7 @@ func (phase *BuildPhase) atomicStoreStageCache(stageName, stageSig string, image
 	}
 	defer phase.Conveyor.StorageLockManager.UnlockStageCache(phase.Conveyor.projectName(), stageSig)
 
-	return logboek.Debug.LogProcess(
+	return logboek.Info.LogProcess(
 		fmt.Sprintf("Storing stage %q images by signature %s into stages storage cache", stageName, stageSig),
 		logboek.LevelLogProcessOptions{},
 		func() error {
@@ -570,7 +568,6 @@ func (phase *BuildPhase) atomicBuildStageImage(img *Image, stg stage.Interface) 
 	}); err != nil {
 		return fmt.Errorf("failed to build image for stage %q with signature %s: %s", stg.Name(), stg.GetSignature(), err)
 	}
-	logboek.LogOptionalLn()
 
 	if err := phase.Conveyor.StorageLockManager.LockStage(phase.Conveyor.projectName(), stg.GetSignature()); err != nil {
 		return fmt.Errorf("unable to lock project %s signature %s: %s", phase.Conveyor.projectName(), stg.GetSignature(), err)
@@ -584,7 +581,7 @@ func (phase *BuildPhase) atomicBuildStageImage(img *Image, stg stage.Interface) 
 
 	if len(imagesDescs) > 0 {
 		var imgInfo *storage.ImageInfo
-		if err := logboek.Debug.LogProcess(
+		if err := logboek.Info.LogProcess(
 			fmt.Sprintf("Selecting suitable image for stage %q by signature %s", stg.Name(), stg.GetSignature()),
 			logboek.LevelLogProcessOptions{},
 			func() error {
@@ -596,14 +593,14 @@ func (phase *BuildPhase) atomicBuildStageImage(img *Image, stg stage.Interface) 
 		}
 
 		if imgInfo != nil {
-			logboek.Debug.LogF(
-				"DISCARDING own built image: detected already existing image %s after build for stage %q signature %s\n",
-				imgInfo.ImageName, stg.Name(), stg.GetSignature(),
+			logboek.Default.LogF(
+				"Discarding newly built image for stage %q by signature %s: detected already existing image %s in the stages storage\n",
+				stg.Name(), stg.GetSignature(), imgInfo.ImageName,
 			)
 			i := phase.Conveyor.GetOrCreateStageImage(phase.PrevImage, imgInfo.ImageName)
 			stg.SetImage(i)
 
-			if err := logboek.Debug.LogProcess(
+			if err := logboek.Info.LogProcess(
 				fmt.Sprintf("Sync stage %q signature %s image %s from stages storage", stg.Name(), stg.GetSignature(), i.Name()),
 				logboek.LevelLogProcessOptions{},
 				func() error {
@@ -628,7 +625,7 @@ func (phase *BuildPhase) atomicBuildStageImage(img *Image, stg stage.Interface) 
 	stageImageObj.SetName(newStageImageName)
 	phase.Conveyor.SetStageImage(stageImageObj)
 
-	if err := logboek.Debug.LogProcess(
+	if err := logboek.Info.LogProcess(
 		fmt.Sprintf("Store stage %q signature %s image %s into stages storage", stageImage.Name(), stg.GetSignature(), stageImage.Name()),
 		logboek.LevelLogProcessOptions{},
 		func() error {
@@ -669,7 +666,7 @@ func (phase *BuildPhase) generateUniqStageImageName(signature string, imagesDesc
 }
 
 func introspectStage(s stage.Interface) error {
-	return logboek.Default.LogProcess(
+	return logboek.Info.LogProcess(
 		fmt.Sprintf("Introspecting stage %q", s.Name()),
 		logboek.LevelLogProcessOptions{Style: logboek.HighlightStyle()},
 		func() error {

--- a/pkg/build/conveyor.go
+++ b/pkg/build/conveyor.go
@@ -351,8 +351,7 @@ func (c *Conveyor) BuildAndPublish(stagesRepo string, imagesRepoManager ImagesRe
 }
 
 func (c *Conveyor) determineStages() error {
-	logboek.LogOptionalLn()
-	return logboek.Default.LogProcess(
+	return logboek.Info.LogProcess(
 		"Determining of stages",
 		logboek.LevelLogProcessOptions{Style: logboek.HighlightStyle()},
 		func() error {
@@ -377,7 +376,7 @@ func (c *Conveyor) doDetermineStages() error {
 			style = ImageLogProcessStyle(false)
 		}
 
-		err := logboek.Default.LogProcess(imageLogName, logboek.LevelLogProcessOptions{Style: style}, func() error {
+		err := logboek.Info.LogProcess(imageLogName, logboek.LevelLogProcessOptions{Style: style}, func() error {
 			var err error
 
 			switch imageConfig := imageInterfaceConfig.(type) {
@@ -765,7 +764,7 @@ func initStages(image *Image, imageInterfaceConfig config.StapelImageInterface, 
 	}
 
 	if len(gitMappings) != 0 {
-		logboek.Default.LogLnDetails("Using git stages")
+		logboek.Info.LogLnDetails("Using git stages")
 
 		for _, s := range stages {
 			s.SetGitMappings(gitMappings)
@@ -797,7 +796,7 @@ func generateGitMappings(imageBaseConfig *config.StapelImageBase, c *Conveyor) (
 				Url:  remoteGitMappingConfig.Url,
 			}
 
-			if err := logboek.LogProcess(fmt.Sprintf("Refreshing %s repository", remoteGitMappingConfig.Name), logboek.LogProcessOptions{}, func() error {
+			if err := logboek.Info.LogProcess(fmt.Sprintf("Refreshing %s repository", remoteGitMappingConfig.Name), logboek.LevelLogProcessOptions{}, func() error {
 				return remoteGitRepo.CloneAndFetch()
 			}); err != nil {
 				return nil, err
@@ -812,7 +811,7 @@ func generateGitMappings(imageBaseConfig *config.StapelImageBase, c *Conveyor) (
 	var res []*stage.GitMapping
 
 	if len(gitMappings) != 0 {
-		err := logboek.LogProcess(fmt.Sprintf("Initializing git mappings"), logboek.LogProcessOptions{}, func() error {
+		err := logboek.Info.LogProcess(fmt.Sprintf("Initializing git mappings"), logboek.LevelLogProcessOptions{}, func() error {
 			resGitMappings, err := filterAndLogGitMappings(gitMappings)
 			if err != nil {
 				return err
@@ -835,7 +834,7 @@ func filterAndLogGitMappings(gitMappings []*stage.GitMapping) ([]*stage.GitMappi
 	var res []*stage.GitMapping
 
 	for ind, gitMapping := range gitMappings {
-		if err := logboek.LogProcess(fmt.Sprintf("[%d] git mapping from %s repository", ind, gitMapping.Name), logboek.LogProcessOptions{}, func() error {
+		if err := logboek.Info.LogProcess(fmt.Sprintf("[%d] git mapping from %s repository", ind, gitMapping.Name), logboek.LevelLogProcessOptions{}, func() error {
 			withTripleIndent := func(f func()) {
 				logboek.IndentUp()
 				logboek.IndentUp()
@@ -847,53 +846,53 @@ func filterAndLogGitMappings(gitMappings []*stage.GitMapping) ([]*stage.GitMappi
 			}
 
 			withTripleIndent(func() {
-				logboek.Default.LogFDetails("add: %s\n", gitMapping.Add)
-				logboek.Default.LogFDetails("to: %s\n", gitMapping.To)
+				logboek.Info.LogFDetails("add: %s\n", gitMapping.Add)
+				logboek.Info.LogFDetails("to: %s\n", gitMapping.To)
 
 				if len(gitMapping.IncludePaths) != 0 {
-					logboek.Default.LogFDetails("includePaths: %+v\n", gitMapping.IncludePaths)
+					logboek.Info.LogFDetails("includePaths: %+v\n", gitMapping.IncludePaths)
 				}
 
 				if len(gitMapping.ExcludePaths) != 0 {
-					logboek.Default.LogFDetails("excludePaths: %+v\n", gitMapping.ExcludePaths)
+					logboek.Info.LogFDetails("excludePaths: %+v\n", gitMapping.ExcludePaths)
 				}
 
 				if gitMapping.Commit != "" {
-					logboek.Default.LogFDetails("commit: %s\n", gitMapping.Commit)
+					logboek.Info.LogFDetails("commit: %s\n", gitMapping.Commit)
 				}
 
 				if gitMapping.Branch != "" {
-					logboek.Default.LogFDetails("branch: %s\n", gitMapping.Branch)
+					logboek.Info.LogFDetails("branch: %s\n", gitMapping.Branch)
 				}
 
 				if gitMapping.Owner != "" {
-					logboek.Default.LogFDetails("owner: %s\n", gitMapping.Owner)
+					logboek.Info.LogFDetails("owner: %s\n", gitMapping.Owner)
 				}
 
 				if gitMapping.Group != "" {
-					logboek.Default.LogFDetails("group: %s\n", gitMapping.Group)
+					logboek.Info.LogFDetails("group: %s\n", gitMapping.Group)
 				}
 
 				if len(gitMapping.StagesDependencies) != 0 {
-					logboek.Default.LogLnDetails("stageDependencies:")
+					logboek.Info.LogLnDetails("stageDependencies:")
 
 					for s, values := range gitMapping.StagesDependencies {
 						if len(values) != 0 {
-							logboek.Default.LogFDetails("  %s: %v\n", s, values)
+							logboek.Info.LogFDetails("  %s: %v\n", s, values)
 						}
 					}
 
 				}
 			})
 
-			logboek.LogLn()
+			logboek.Info.LogLn()
 
 			commit, err := gitMapping.LatestCommit()
 			if err != nil {
 				return fmt.Errorf("unable to get commit of repo '%s': %s", gitMapping.GitRepo().GetName(), err)
 			}
 
-			logboek.Default.LogFDetails("Commit %s will be used\n", commit)
+			logboek.Info.LogFDetails("Commit %s will be used\n", commit)
 
 			res = append(res, gitMapping)
 
@@ -996,7 +995,7 @@ func stageDependenciesToMap(sd *config.StageDependencies) map[stage.StageName][]
 
 func appendIfExist(stages []stage.Interface, stage stage.Interface) []stage.Interface {
 	if !reflect.ValueOf(stage).IsNil() {
-		logboek.Default.LogFDetails("Using stage %s\n", stage.Name())
+		logboek.Info.LogFDetails("Using stage %s\n", stage.Name())
 		return append(stages, stage)
 	}
 
@@ -1139,7 +1138,7 @@ func prepareImageBasedOnImageFromDockerfile(imageFromDockerfileConfig *config.Im
 
 	img.stages = append(img.stages, dockerfileStage)
 
-	logboek.Default.LogFDetails("Using stage %s\n", dockerfileStage.Name())
+	logboek.Info.LogFDetails("Using stage %s\n", dockerfileStage.Name())
 
 	return img, nil
 }

--- a/pkg/build/debug.go
+++ b/pkg/build/debug.go
@@ -1,7 +1,0 @@
-package build
-
-import "os"
-
-func debug() bool {
-	return os.Getenv("WERF_CONVEYOR_DEBUG") == "1"
-}

--- a/pkg/build/image.go
+++ b/pkg/build/image.go
@@ -139,8 +139,6 @@ func (i *Image) PrepareBaseImage(c *Conveyor) error {
 
 			return nil
 		}
-
-		logboek.LogOptionalLn()
 	}
 
 	logProcessOptions := logboek.LevelLogProcessOptions{Style: logboek.HighlightStyle()}
@@ -169,7 +167,7 @@ func (i *Image) getFromBaseImageIdFromRegistry(c *Conveyor, baseImageName string
 
 	var fetchedBaseImageRepoId string
 	processMsg := fmt.Sprintf("Trying to get from base image id from registry (%s)", baseImageName)
-	if err := logboek.LogProcessInline(processMsg, logboek.LogProcessInlineOptions{}, func() error {
+	if err := logboek.Info.LogProcessInline(processMsg, logboek.LevelLogProcessInlineOptions{}, func() error {
 		var fetchImageIdErr error
 		fetchedBaseImageRepoId, fetchImageIdErr = docker_registry.ImageId(baseImageName)
 		if fetchImageIdErr != nil {

--- a/pkg/build/import_server/rsync_server.go
+++ b/pkg/build/import_server/rsync_server.go
@@ -84,7 +84,8 @@ strict modes = false
 		"--config=/.werf/rsyncd.conf",
 	}
 	logboek.Debug.LogF("Run rsync server command: %q\n", fmt.Sprintf("docker run %s", strings.Join(runArgs, " ")))
-	if err := docker.CliRun(runArgs...); err != nil {
+	if output, err := docker.CliRun_RecordedOutput(runArgs...); err != nil {
+		logboek.LogErrorF("%s", output)
 		return nil, err
 	}
 
@@ -103,7 +104,8 @@ strict modes = false
 }
 
 func (srv *RsyncServer) Shutdown() error {
-	if err := docker.CliRm("--force", srv.DockerContainerName); err != nil {
+	if output, err := docker.CliRm_RecordedOutput("--force", srv.DockerContainerName); err != nil {
+		logboek.LogErrorF("%s", output)
 		return fmt.Errorf("unable to remove container %s: %s", srv.DockerContainerName, err)
 	}
 	return nil

--- a/pkg/build/stage/base.go
+++ b/pkg/build/stage/base.go
@@ -90,7 +90,7 @@ type BaseStage struct {
 }
 
 func (s *BaseStage) LogDetailedName() string {
-	return fmt.Sprintf("stage %s", s.Name())
+	return fmt.Sprintf("stage %s/%s", s.imageName, s.Name())
 }
 
 func (s *BaseStage) Name() StageName {

--- a/pkg/build/stage/git_mapping.go
+++ b/pkg/build/stage/git_mapping.go
@@ -127,7 +127,7 @@ func (gm *GitMapping) getOrCreateArchive(opts git_repo.ArchiveOptions) (git_repo
 func (gm *GitMapping) createArchive(opts git_repo.ArchiveOptions) (git_repo.Archive, error) {
 	var res git_repo.Archive
 
-	err := logboek.LogProcess(fmt.Sprintf("Creating archive for commit %s of %s git mapping %s", opts.Commit, gm.GitRepo().GetName(), gm.Add), logboek.LogProcessOptions{}, func() error {
+	err := logboek.Info.LogProcess(fmt.Sprintf("Creating archive for commit %s of %s git mapping %s", opts.Commit, gm.GitRepo().GetName(), gm.Add), logboek.LevelLogProcessOptions{}, func() error {
 		archive, err := gm.GitRepo().CreateArchive(opts)
 		if err != nil {
 			return err
@@ -160,7 +160,7 @@ func (gm *GitMapping) createPatch(opts git_repo.PatchOptions) (git_repo.Patch, e
 	var res git_repo.Patch
 
 	logProcessMsg := fmt.Sprintf("Creating patch %s..%s for %s git mapping %s", opts.FromCommit, opts.ToCommit, gm.GitRepo().GetName(), gm.Add)
-	err := logboek.LogProcess(logProcessMsg, logboek.LogProcessOptions{}, func() error {
+	err := logboek.Info.LogProcess(logProcessMsg, logboek.LevelLogProcessOptions{}, func() error {
 		patch, err := gm.GitRepo().CreatePatch(opts)
 		if err != nil {
 			return err

--- a/pkg/cleaning/common.go
+++ b/pkg/cleaning/common.go
@@ -179,7 +179,7 @@ func imageReferencesRemove(references []string, options CommonOptions) error {
 			}
 			args = append(args, references...)
 
-			if err := docker.CliRmi(args...); err != nil {
+			if err := docker.CliRmi_LiveOutput(args...); err != nil {
 				return err
 			}
 		}

--- a/pkg/deploy/dismiss.go
+++ b/pkg/deploy/dismiss.go
@@ -11,12 +11,8 @@ type DismissOptions struct {
 }
 
 func RunDismiss(releaseName, namespace, _ string, opts DismissOptions) error {
-	if debug() {
-		logboek.LogF("Dismiss options: %#v\n", opts)
-		logboek.LogF("Namespace: %s\n", namespace)
-	}
-
-	logboek.LogLn()
+	logboek.Debug.LogF("Dismiss options: %#v\n", opts)
+	logboek.Debug.LogF("Namespace: %s\n", namespace)
 	logProcessOptions := logboek.LevelLogProcessOptions{Style: logboek.HighlightStyle()}
 	return logboek.Default.LogProcess("Running dismiss", logProcessOptions, func() error {
 		return helm.PurgeHelmRelease(releaseName, namespace, opts.WithNamespace, opts.WithHooks)

--- a/pkg/deploy/lint.go
+++ b/pkg/deploy/lint.go
@@ -25,9 +25,7 @@ type LintOptions struct {
 }
 
 func RunLint(projectDir string, werfConfig *config.WerfConfig, imagesRepoManager images_manager.ImagesRepoManager, images []images_manager.ImageInfoGetter, commonTag string, tagStrategy tag_strategy.TagStrategy, opts LintOptions) error {
-	if debug() {
-		fmt.Fprintf(logboek.GetOutStream(), "Lint options: %#v\n", opts)
-	}
+	logboek.Debug.LogF("Lint options: %#v\n", opts)
 
 	m, err := GetSafeSecretManager(projectDir, opts.SecretValues, opts.IgnoreSecretKey)
 	if err != nil {

--- a/pkg/deploy/render.go
+++ b/pkg/deploy/render.go
@@ -1,7 +1,6 @@
 package deploy
 
 import (
-	"fmt"
 	"io"
 	"path/filepath"
 
@@ -29,9 +28,7 @@ type RenderOptions struct {
 }
 
 func RunRender(out io.Writer, projectDir string, werfConfig *config.WerfConfig, imagesRepoManager images_manager.ImagesRepoManager, images []images_manager.ImageInfoGetter, commonTag string, tagStrategy tag_strategy.TagStrategy, opts RenderOptions) error {
-	if debug() {
-		fmt.Fprintf(logboek.GetOutStream(), "Render options: %#v\n", opts)
-	}
+	logboek.Debug.LogF("Render options: %#v\n", opts)
 
 	m, err := GetSafeSecretManager(projectDir, opts.SecretValues, opts.IgnoreSecretKey)
 	if err != nil {

--- a/pkg/deploy/service_values.go
+++ b/pkg/deploy/service_values.go
@@ -1,10 +1,7 @@
 package deploy
 
 import (
-	"fmt"
-
 	"github.com/flant/werf/pkg/images_manager"
-
 	"github.com/ghodss/yaml"
 
 	"github.com/flant/logboek"
@@ -90,10 +87,7 @@ func GetServiceValues(projectName string, imagesRepoManager images_manager.Image
 				} else {
 					imageData[key] = value
 				}
-
-				if debug() {
-					_, _ = fmt.Fprintf(logboek.GetOutStream(), "ServiceValues: %s.%s=%s", image.GetImageName(), key, value)
-				}
+				logboek.Debug.LogF("ServiceValues: %s.%s=%s", image.GetImageName(), key, value)
 			}
 
 			imageID, err := image.GetImageId()
@@ -112,10 +106,8 @@ func GetServiceValues(projectName string, imagesRepoManager images_manager.Image
 		}
 	}
 
-	if debug() {
-		data, err := yaml.Marshal(res)
-		fmt.Fprintf(logboek.GetOutStream(), "GetServiceValues result (err=%s):\n%s\n", err, data)
-	}
+	data, err := yaml.Marshal(res)
+	logboek.Debug.LogF("GetServiceValues result (err=%s):\n%s\n", err, data)
 
 	return res, nil
 }

--- a/pkg/deploy/werf_chart.go
+++ b/pkg/deploy/werf_chart.go
@@ -1,9 +1,6 @@
 package deploy
 
 import (
-	"fmt"
-	"os"
-
 	"github.com/flant/logboek"
 
 	"github.com/flant/werf/pkg/deploy/secret"
@@ -28,13 +25,7 @@ func PrepareWerfChart(projectName, chartDir, env string, m secret.Manager, secre
 		}
 	}
 
-	if debug() {
-		fmt.Fprintf(logboek.GetOutStream(), "werf chart: %#v\n", werfChart)
-	}
+	logboek.Debug.LogF("werf chart: %#v\n", werfChart)
 
 	return werfChart, nil
-}
-
-func debug() bool {
-	return os.Getenv("WERF_DEPLOY_DEBUG") == "1"
 }

--- a/pkg/docker/container.go
+++ b/pkg/docker/container.go
@@ -1,6 +1,7 @@
 package docker
 
 import (
+	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/command/container"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/client"
@@ -47,44 +48,62 @@ func ContainerRemove(ref string, options types.ContainerRemoveOptions) error {
 	return nil
 }
 
+func doCliCreate(c *command.DockerCli, args ...string) error {
+	return prepareCliCmd(container.NewCreateCommand(c), args...).Execute()
+}
+
 func CliCreate(args ...string) error {
-	cmd := container.NewCreateCommand(cli)
-	cmd.SilenceErrors = true
-	cmd.SilenceUsage = true
-	cmd.SetArgs(args)
+	return callCliWithAutoOutput(func(c *command.DockerCli) error {
+		return doCliCreate(c, args...)
+	})
+}
 
-	err := cmd.Execute()
-	if err != nil {
-		return err
-	}
+func CliCreate_LiveOutput(args ...string) error {
+	return doCliCreate(liveOutputCli, args...)
+}
 
-	return nil
+func CliCreate_RecordedOutput(args ...string) (string, error) {
+	return callCliWithRecordedOutput(func(c *command.DockerCli) error {
+		return doCliCreate(c, args...)
+	})
+}
+
+func doCliRun(c *command.DockerCli, args ...string) error {
+	return prepareCliCmd(container.NewRunCommand(c), args...).Execute()
 }
 
 func CliRun(args ...string) error {
-	cmd := container.NewRunCommand(cli)
-	cmd.SilenceErrors = true
-	cmd.SilenceUsage = true
-	cmd.SetArgs(args)
+	return callCliWithAutoOutput(func(c *command.DockerCli) error {
+		return doCliRun(c, args...)
+	})
+}
 
-	err := cmd.Execute()
-	if err != nil {
-		return err
-	}
+func CliRun_LiveOutput(args ...string) error {
+	return doCliRun(liveOutputCli, args...)
+}
 
-	return nil
+func CliRun_RecordedOutput(args ...string) (string, error) {
+	return callCliWithRecordedOutput(func(c *command.DockerCli) error {
+		return doCliRun(c, args...)
+	})
+}
+
+func doCliRm(c *command.DockerCli, args ...string) error {
+	return prepareCliCmd(container.NewRmCommand(c), args...).Execute()
 }
 
 func CliRm(args ...string) error {
-	cmd := container.NewRmCommand(cli)
-	cmd.SilenceErrors = true
-	cmd.SilenceUsage = true
-	cmd.SetArgs(args)
+	return callCliWithAutoOutput(func(c *command.DockerCli) error {
+		return doCliRm(c, args...)
+	})
+}
 
-	err := cmd.Execute()
-	if err != nil {
-		return err
-	}
+func CliRm_LiveOutput(args ...string) error {
+	return doCliRm(liveOutputCli, args...)
+}
 
-	return nil
+func CliRm_RecordedOutput(args ...string) (string, error) {
+	return callCliWithRecordedOutput(func(c *command.DockerCli) error {
+		return doCliRm(c, args...)
+	})
 }

--- a/pkg/docker/image.go
+++ b/pkg/docker/image.go
@@ -4,6 +4,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/docker/cli/cli/command"
+
 	"github.com/docker/cli/cli/command/image"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/client"
@@ -41,13 +43,33 @@ func ImageInspect(ref string) (*types.ImageInspect, error) {
 	return &inspect, nil
 }
 
+func doCliPull(c *command.DockerCli, args ...string) error {
+	return prepareCliCmd(image.NewPullCommand(c), args...).Execute()
+}
+
+func CliPull(args ...string) error {
+	return callCliWithAutoOutput(func(c *command.DockerCli) error {
+		return doCliPull(c, args...)
+	})
+}
+
+func CliPull_LiveOutput(args ...string) error {
+	return doCliPull(liveOutputCli, args...)
+}
+
+func CliPull_RecordedOutput(args ...string) (string, error) {
+	return callCliWithRecordedOutput(func(c *command.DockerCli) error {
+		return doCliPull(c, args...)
+	})
+}
+
 const cliPullMaxAttempts = 5
 
-func CliPullWithRetries(args ...string) error {
+func doCliPullWithRetries(c *command.DockerCli, args ...string) error {
 	var attempt int
 
 tryPull:
-	if err := CliPull(args...); err != nil {
+	if err := doCliPull(c, args...); err != nil {
 		if attempt < cliPullMaxAttempts {
 			specificErrors := []string{
 				"Client.Timeout exceeded while awaiting headers",
@@ -59,7 +81,7 @@ tryPull:
 				if strings.Index(err.Error(), specificError) != -1 {
 					attempt += 1
 
-					logboek.LogWarnF("Retrying in 5 seconds (%d/%d) ...\n", attempt, cliPullMaxAttempts)
+					logboek.LogWarnF("Retrying docker pull in 5 seconds (%d/%d) ...\n", attempt, cliPullMaxAttempts)
 					time.Sleep(5 * time.Second)
 					goto tryPull
 				}
@@ -72,41 +94,49 @@ tryPull:
 	return nil
 }
 
-func CliPull(args ...string) error {
-	cmd := image.NewPullCommand(cli)
-	cmd.SilenceErrors = true
-	cmd.SilenceUsage = true
-	cmd.SetArgs(args)
+func CliPullWithRetries(args ...string) error {
+	return callCliWithAutoOutput(func(c *command.DockerCli) error {
+		return doCliPullWithRetries(c, args...)
+	})
+}
 
-	err := cmd.Execute()
-	if err != nil {
-		return err
-	}
+func CliPullWithRetries_LiveOutput(args ...string) error {
+	return doCliPullWithRetries(liveOutputCli, args...)
+}
 
-	return nil
+func CliPullWithRetries_RecordedOutput(args ...string) (string, error) {
+	return callCliWithRecordedOutput(func(c *command.DockerCli) error {
+		return doCliPullWithRetries(c, args...)
+	})
+}
+
+func doCliPush(c *command.DockerCli, args ...string) error {
+	return prepareCliCmd(image.NewPushCommand(c), args...).Execute()
 }
 
 func CliPush(args ...string) error {
-	cmd := image.NewPushCommand(cli)
-	cmd.SilenceErrors = true
-	cmd.SilenceUsage = true
-	cmd.SetArgs(args)
+	return callCliWithAutoOutput(func(c *command.DockerCli) error {
+		return doCliPush(c, args...)
+	})
+}
 
-	err := cmd.Execute()
-	if err != nil {
-		return err
-	}
+func CliPush_LiveOutput(args ...string) error {
+	return doCliPush(liveOutputCli, args...)
+}
 
-	return nil
+func CliPush_RecordedOutput(args ...string) (string, error) {
+	return callCliWithRecordedOutput(func(c *command.DockerCli) error {
+		return doCliPush(c, args...)
+	})
 }
 
 const cliPushMaxAttempts = 5
 
-func CliPushWithRetries(args ...string) error {
+func doCliPushWithRetries(c *command.DockerCli, args ...string) error {
 	var attempt int
 
 tryPush:
-	if err := CliPush(args...); err != nil {
+	if err := doCliPush(c, args...); err != nil {
 		if attempt < cliPushMaxAttempts {
 			specificErrors := []string{
 				"Client.Timeout exceeded while awaiting headers",
@@ -118,7 +148,7 @@ tryPush:
 				if strings.Index(err.Error(), specificError) != -1 {
 					attempt += 1
 
-					logboek.Default.LogFDetails("Retrying in 5 seconds (%d/%d) ...\n", attempt, cliPushMaxAttempts)
+					logboek.Warn.LogFDetails("Retrying docker push in 5 seconds (%d/%d) ...\n", attempt, cliPushMaxAttempts)
 
 					time.Sleep(5 * time.Second)
 					goto tryPush
@@ -132,44 +162,78 @@ tryPush:
 	return nil
 }
 
+func CliPushWithRetries(args ...string) error {
+	return callCliWithAutoOutput(func(c *command.DockerCli) error {
+		return doCliPushWithRetries(c, args...)
+	})
+}
+
+func CliPushWithRetries_LiveOutput(args ...string) error {
+	return doCliPushWithRetries(liveOutputCli, args...)
+}
+
+func CliPushWithRetries_RecordedOutput(args ...string) (string, error) {
+	return callCliWithRecordedOutput(func(c *command.DockerCli) error {
+		return doCliPushWithRetries(c, args...)
+	})
+}
+
+func doCliTag(c *command.DockerCli, args ...string) error {
+	return prepareCliCmd(image.NewTagCommand(c), args...).Execute()
+}
+
 func CliTag(args ...string) error {
-	cmd := image.NewTagCommand(cli)
-	cmd.SilenceErrors = true
-	cmd.SilenceUsage = true
-	cmd.SetArgs(args)
+	return callCliWithAutoOutput(func(c *command.DockerCli) error {
+		return doCliTag(c, args...)
+	})
+}
 
-	err := cmd.Execute()
-	if err != nil {
-		return err
-	}
+func CliTag_LiveOutput(args ...string) error {
+	return doCliTag(liveOutputCli, args...)
+}
 
-	return nil
+func CliTag_RecordedOutput(args ...string) (string, error) {
+	return callCliWithRecordedOutput(func(c *command.DockerCli) error {
+		return doCliTag(c, args...)
+	})
+}
+
+func doCliRmi(c *command.DockerCli, args ...string) error {
+	return prepareCliCmd(image.NewRemoveCommand(c), args...).Execute()
 }
 
 func CliRmi(args ...string) error {
-	cmd := image.NewRemoveCommand(cli)
-	cmd.SilenceErrors = true
-	cmd.SilenceUsage = true
-	cmd.SetArgs(args)
+	return callCliWithAutoOutput(func(c *command.DockerCli) error {
+		return doCliRmi(c, args...)
+	})
+}
 
-	err := cmd.Execute()
-	if err != nil {
-		return err
-	}
+func CliRmi_LiveOutput(args ...string) error {
+	return doCliRmi(liveOutputCli, args...)
+}
 
-	return nil
+func CliRmiOutput_RecordedOutput(args ...string) (string, error) {
+	return callCliWithRecordedOutput(func(c *command.DockerCli) error {
+		return doCliRmi(c, args...)
+	})
+}
+
+func doCliBuild(c *command.DockerCli, args ...string) error {
+	return prepareCliCmd(image.NewBuildCommand(c), args...).Execute()
 }
 
 func CliBuild(args ...string) error {
-	cmd := image.NewBuildCommand(cli)
-	cmd.SilenceErrors = true
-	cmd.SilenceUsage = true
-	cmd.SetArgs(args)
+	return callCliWithAutoOutput(func(c *command.DockerCli) error {
+		return doCliBuild(c, args...)
+	})
+}
 
-	err := cmd.Execute()
-	if err != nil {
-		return err
-	}
+func CliBuild_LiveOutput(args ...string) error {
+	return doCliBuild(liveOutputCli, args...)
+}
 
-	return nil
+func CliBuild_RecordedOutput(args ...string) (string, error) {
+	return callCliWithRecordedOutput(func(c *command.DockerCli) error {
+		return doCliBuild(c, args...)
+	})
 }

--- a/pkg/docker/main.go
+++ b/pkg/docker/main.go
@@ -1,13 +1,18 @@
 package docker
 
 import (
+	"bytes"
 	"fmt"
+	"io"
 	"os"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/spf13/cobra"
 
 	"golang.org/x/net/context"
 
 	"github.com/flant/logboek"
-	"github.com/sirupsen/logrus"
 
 	"github.com/docker/cli/cli/command"
 	cliconfig "github.com/docker/cli/cli/config"
@@ -17,11 +22,15 @@ import (
 )
 
 var (
-	cli       *command.DockerCli
-	apiClient *client.Client
+	liveOutputCli *command.DockerCli
+	apiClient     *client.Client
+
+	liveCliOutputEnabled bool
+	isDebug              bool
+	isVerbose            bool
 )
 
-func Init(dockerConfigDir string) error {
+func Init(dockerConfigDir string, verbose, debug bool) error {
 	if dockerConfigDir != "" {
 		cliconfig.SetDir(dockerConfigDir)
 	}
@@ -38,8 +47,11 @@ func Init(dockerConfigDir string) error {
 		return err
 	}
 
-	// TODO: set docker loglevel based on the werf --verbose/--debug flags
-	logrus.StandardLogger().SetLevel(logrus.FatalLevel)
+	logrus.StandardLogger().SetOutput(logboek.GetOutStream())
+
+	isDebug = debug
+	isVerbose = verbose
+	liveCliOutputEnabled = verbose || debug
 
 	return nil
 }
@@ -54,31 +66,42 @@ func ServerVersion() (*types.Version, error) {
 	return &version, nil
 }
 
+func newDockerCli(opts []command.DockerCliOption) (*command.DockerCli, error) {
+	newCli, err := command.NewDockerCli(opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	clientOpts := flags.NewClientOptions()
+	if isDebug {
+		clientOpts.Common.LogLevel = "debug"
+	} else {
+		clientOpts.Common.LogLevel = "fatal"
+	}
+
+	if err := newCli.Initialize(clientOpts); err != nil {
+		return nil, err
+	}
+	return newCli, nil
+}
+
 func setDockerClient() error {
-	cliOpts := []command.DockerCliOption{
+	if c, err := newDockerCli([]command.DockerCliOption{
 		command.WithOutputStream(logboek.GetOutStream()),
 		command.WithErrorStream(logboek.GetErrStream()),
 		command.WithContentTrust(false),
+	}); err != nil {
+		return fmt.Errorf("unable to create live output docker cli: %s", err)
+	} else {
+		liveOutputCli = c
 	}
-
-	newCli, err := command.NewDockerCli(cliOpts...)
-	if err != nil {
-		return err
-	}
-
-	opts := flags.NewClientOptions()
-	if err := newCli.Initialize(opts); err != nil {
-		return err
-	}
-
-	cli = newCli
 
 	return nil
 }
 
 func setDockerApiClient() error {
 	ctx := context.Background()
-	serverVersion, err := cli.Client().ServerVersion(ctx)
+	serverVersion, err := liveOutputCli.Client().ServerVersion(ctx)
 	if err != nil {
 		return err
 	}
@@ -93,4 +116,46 @@ func setDockerApiClient() error {
 
 func Debug() bool {
 	return os.Getenv("WERF_DEBUG_DOCKER") == "1"
+}
+
+func callCliWithRecordedOutput(commandCaller func(c *command.DockerCli) error) (string, error) {
+	var output bytes.Buffer
+
+	if c, err := getRecordingOutputCli(&output, &output); err != nil {
+		return "", fmt.Errorf("unable to create docker cli: %s", err)
+	} else {
+		if err := commandCaller(c); err != nil {
+			return output.String(), err
+		}
+		return output.String(), err
+	}
+}
+
+func getRecordingOutputCli(stdoutWriter, stderrWriter io.Writer) (*command.DockerCli, error) {
+	return newDockerCli([]command.DockerCliOption{
+		command.WithOutputStream(stdoutWriter),
+		command.WithErrorStream(stderrWriter),
+		command.WithContentTrust(false),
+	})
+}
+
+func prepareCliCmd(cmd *cobra.Command, args ...string) *cobra.Command {
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+	cmd.SetArgs(args)
+	return cmd
+}
+
+func callCliWithAutoOutput(commandCaller func(c *command.DockerCli) error) error {
+	if liveCliOutputEnabled {
+		return commandCaller(liveOutputCli)
+	} else {
+		output, err := callCliWithRecordedOutput(func(c *command.DockerCli) error {
+			return commandCaller(c)
+		})
+		if err != nil {
+			logboek.LogErrorF("%s", output)
+		}
+		return err
+	}
 }

--- a/pkg/image/dockerfile_image_builder.go
+++ b/pkg/image/dockerfile_image_builder.go
@@ -32,7 +32,7 @@ func (b *DockerfileImageBuilder) AppendBuildArgs(buildArgs ...string) {
 func (b *DockerfileImageBuilder) Build() error {
 	buildArgs := append(b.BuildArgs, fmt.Sprintf("--tag=%s", b.temporalId))
 
-	if err := docker.CliBuild(buildArgs...); err != nil {
+	if err := docker.CliBuild_LiveOutput(buildArgs...); err != nil {
 		return err
 	}
 

--- a/pkg/image/stage_image.go
+++ b/pkg/image/stage_image.go
@@ -242,19 +242,19 @@ func (i *StageImage) Import(name string) error {
 }
 
 func (i *StageImage) Export(name string) error {
-	if err := logboek.LogProcess(fmt.Sprintf("Tagging %s", name), logboek.LogProcessOptions{}, func() error {
+	if err := logboek.Info.LogProcess(fmt.Sprintf("Tagging %s", name), logboek.LevelLogProcessOptions{}, func() error {
 		return i.Tag(name)
 	}); err != nil {
 		return err
 	}
 
-	if err := logboek.LogProcess(fmt.Sprintf("Pushing %s", name), logboek.LogProcessOptions{}, func() error {
+	if err := logboek.Info.LogProcess(fmt.Sprintf("Pushing %s", name), logboek.LevelLogProcessOptions{}, func() error {
 		return docker.CliPushWithRetries(name)
 	}); err != nil {
 		return err
 	}
 
-	if err := logboek.LogProcess(fmt.Sprintf("Untagging %s", name), logboek.LogProcessOptions{}, func() error {
+	if err := logboek.Info.LogProcess(fmt.Sprintf("Untagging %s", name), logboek.LevelLogProcessOptions{}, func() error {
 		return docker.CliRmi(name)
 	}); err != nil {
 		return err

--- a/pkg/image/stage_image_container.go
+++ b/pkg/image/stage_image_container.go
@@ -266,7 +266,7 @@ func (c *StageImageContainer) run() error {
 		return err
 	}
 
-	if err := docker.CliRun(runArgs...); err != nil {
+	if err := docker.CliRun_LiveOutput(runArgs...); err != nil {
 		return fmt.Errorf("container run failed: %s", err.Error())
 	}
 
@@ -279,7 +279,7 @@ func (c *StageImageContainer) introspect() error {
 		return err
 	}
 
-	if err := docker.CliRun(runArgs...); err != nil {
+	if err := docker.CliRun_LiveOutput(runArgs...); err != nil {
 		if !strings.Contains(err.Error(), "Code: ") || IsStartContainerErr(err) {
 			return err
 		}
@@ -294,7 +294,7 @@ func (c *StageImageContainer) introspectBefore() error {
 		return err
 	}
 
-	if err := docker.CliRun(runArgs...); err != nil {
+	if err := docker.CliRun_LiveOutput(runArgs...); err != nil {
 		if !strings.Contains(err.Error(), "Code: ") || IsStartContainerErr(err) {
 			return err
 		}

--- a/pkg/ssh_agent/ssh_agent.go
+++ b/pkg/ssh_agent/ssh_agent.go
@@ -45,7 +45,7 @@ func Init(keys []string) error {
 	systemAgentSockExists, _ := util.FileExists(systemAgentSock)
 	if systemAgentSock != "" && systemAgentSockExists {
 		SSHAuthSock = systemAgentSock
-		logboek.LogF("Using system ssh-agent: %s\n", systemAgentSock)
+		logboek.Info.LogF("Using system ssh-agent: %s\n", systemAgentSock)
 		return nil
 	}
 
@@ -129,7 +129,7 @@ func runSSHAgent() (string, error) {
 		return "", fmt.Errorf("error listen unix sock %s: %s", sockPath, err)
 	}
 
-	logboek.LogF("Running ssh agent on unix sock: %s\n", sockPath)
+	logboek.Info.LogF("Running ssh agent on unix sock: %s\n", sockPath)
 
 	go func() {
 		agnt := agent.NewKeyring()
@@ -186,7 +186,7 @@ func addSSHKey(authSock string, key string) error {
 		return err
 	}
 
-	logboek.LogF("Added private key %s to ssh agent %s\n", key, authSock)
+	logboek.Info.LogF("Added private key %s to ssh agent %s\n", key, authSock)
 
 	return nil
 }

--- a/pkg/testing/utils/docker/container_command.go
+++ b/pkg/testing/utils/docker/container_command.go
@@ -15,7 +15,7 @@ import (
 )
 
 func init() {
-	if err := docker.Init(""); err != nil {
+	if err := docker.Init("", true, true); err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "init werf docker failed: %s\n", err)
 		os.Exit(1)
 	}


### PR DESCRIPTION
 - Changed pkg/docker Cli* functions:
   - `Cli<Command>_LiveOutput->error` and `Cli<Command>_RecordedOutput->(string,error)` functions
     to run docker cli commands with live output or with recorded to string output
     (for example CliRun_LiveOutput, CliRun_RecordedOutput, CliRmi_LiveOutput, CliRmi_RecordedOutput, etc.).
   - Default function Cli<Command> (CliRun, CliRm, CliBuild, etc.)
     automatically selects live-output or recorded-output mode based on the `--log-verbose` flag.
 - Logs from pkg/docker logrus are redirected through logboek;
   enabled logrus debug output in --log-verbose mode.
 - Refactored log-verbose mode logs for build and publish, but log-verbose mode is not fully revised yet.
