### PR TITLE
Revise v1.1 default logging output for main commands: build, publish, run, cleanup, deploy, dismiss; disable debug logs by default

### DIFF
--- a/cmd/werf/build_and_publish/main.go
+++ b/cmd/werf/build_and_publish/main.go
@@ -127,10 +127,12 @@ func runBuildAndPublish(imagesToProcess []string) error {
 
 	common.ProcessLogProjectDir(&commonCmdData, projectDir)
 
-	werfConfig, err := common.GetWerfConfig(projectDir)
+	werfConfig, err := common.GetWerfConfig(projectDir, true)
 	if err != nil {
 		return fmt.Errorf("bad config: %s", err)
 	}
+
+	logboek.LogOptionalLn()
 
 	for _, imageToProcess := range imagesToProcess {
 		if !werfConfig.HasImage(imageToProcess) {

--- a/cmd/werf/cleanup/cleanup.go
+++ b/cmd/werf/cleanup/cleanup.go
@@ -110,10 +110,12 @@ func runCleanup() error {
 	}
 	defer tmp_manager.ReleaseProjectDir(projectTmpDir)
 
-	werfConfig, err := common.GetWerfConfig(projectDir)
+	werfConfig, err := common.GetWerfConfig(projectDir, true)
 	if err != nil {
 		return fmt.Errorf("bad config: %s", err)
 	}
+
+	logboek.LogOptionalLn()
 
 	projectName := werfConfig.Meta.Project
 

--- a/cmd/werf/common/common.go
+++ b/cmd/werf/common/common.go
@@ -783,14 +783,13 @@ func GetOptionalImagesRepo(projectName string, cmdData *CmdData) (string, error)
 	return "", nil
 }
 
-func GetWerfConfig(projectDir string) (*config.WerfConfig, error) {
+func GetWerfConfig(projectDir string, logRenderedFilePath bool) (*config.WerfConfig, error) {
 	werfConfigPath, err := GetWerfConfigPath(projectDir)
 	if err != nil {
 		return nil, err
 	}
 
-	res, err := config.GetWerfConfig(werfConfigPath, true)
-	logboek.LogLn()
+	res, err := config.GetWerfConfig(werfConfigPath, logRenderedFilePath)
 	return res, err
 }
 

--- a/cmd/werf/common/common.go
+++ b/cmd/werf/common/common.go
@@ -374,17 +374,17 @@ func SetupLogOptions(cmdData *CmdData, cmd *cobra.Command) {
 func SetupLogDebug(cmdData *CmdData, cmd *cobra.Command) {
 	cmdData.LogDebug = new(bool)
 
-        defaultValue := true
-        for _, envName := range []string{
-          "WERF_LOG_DEBUG", 
-          "WERF_DEBUG", 
-        } {
-          if os.Getenv(envName) != "" {
-            defaultValue = GetBoolEnvironmentDefaultTrue(envName)
-            break
-          } 
-        } 
-	
+	defaultValue := false
+	for _, envName := range []string{
+		"WERF_LOG_DEBUG",
+		"WERF_DEBUG",
+	} {
+		if os.Getenv(envName) != "" {
+			defaultValue = GetBoolEnvironmentDefaultFalse(envName)
+			break
+		}
+	}
+
 	for alias, env := range map[string]string{
 		"log-debug": "WERF_LOG_DEBUG",
 		"debug":     "WERF_DEBUG",
@@ -422,15 +422,15 @@ func SetupLogQuiet(cmdData *CmdData, cmd *cobra.Command) {
 	cmdData.LogQuiet = new(bool)
 
 	var defaultValue bool
-        for _, envName := range []string{
-          "WERF_LOG_QUIET", 
-          "WERF_QUIET", 
-        } {
-          if os.Getenv(envName) != "" {
-            defaultValue = GetBoolEnvironmentDefaultFalse(envName)
-            break
-          } 
-        }
+	for _, envName := range []string{
+		"WERF_LOG_QUIET",
+		"WERF_QUIET",
+	} {
+		if os.Getenv(envName) != "" {
+			defaultValue = GetBoolEnvironmentDefaultFalse(envName)
+			break
+		}
+	}
 
 	for alias, env := range map[string]string{
 		"log-quiet": "WERF_LOG_QUIET",
@@ -454,15 +454,15 @@ func SetupLogVerbose(cmdData *CmdData, cmd *cobra.Command) {
 	cmdData.LogVerbose = new(bool)
 
 	var defaultValue bool
-        for _, envName := range []string{
-          "WERF_LOG_VERBOSE", 
-          "WERF_VERBOSE", 
-        } {
-          if os.Getenv(envName) != "" {
-            defaultValue = GetBoolEnvironmentDefaultFalse(envName)
-            break
-          } 
-        }
+	for _, envName := range []string{
+		"WERF_LOG_VERBOSE",
+		"WERF_VERBOSE",
+	} {
+		if os.Getenv(envName) != "" {
+			defaultValue = GetBoolEnvironmentDefaultFalse(envName)
+			break
+		}
+	}
 
 	for alias, env := range map[string]string{
 		"log-verbose": "WERF_LOG_VERBOSE",

--- a/cmd/werf/deploy/main.go
+++ b/cmd/werf/deploy/main.go
@@ -181,10 +181,12 @@ func runDeploy() error {
 	}
 	defer tmp_manager.ReleaseProjectDir(projectTmpDir)
 
-	werfConfig, err := common.GetWerfConfig(projectDir)
+	werfConfig, err := common.GetWerfConfig(projectDir, true)
 	if err != nil {
 		return fmt.Errorf("bad config: %s", err)
 	}
+
+	logboek.LogOptionalLn()
 
 	var imagesRepoManager *common.ImagesRepoManager
 	var tag string

--- a/cmd/werf/dismiss/dismiss.go
+++ b/cmd/werf/dismiss/dismiss.go
@@ -122,10 +122,11 @@ func runDismiss() error {
 
 	common.ProcessLogProjectDir(&commonCmdData, projectDir)
 
-	werfConfig, err := common.GetWerfConfig(projectDir)
+	werfConfig, err := common.GetWerfConfig(projectDir, true)
 	if err != nil {
 		return fmt.Errorf("bad config: %s", err)
 	}
+	logboek.LogOptionalLn()
 
 	err = kube.Init(kube.InitOptions{KubeContext: *commonCmdData.KubeContext, KubeConfig: *commonCmdData.KubeConfig})
 	if err != nil {
@@ -146,10 +147,16 @@ func runDismiss() error {
 		return err
 	}
 
-	logboek.LogF("Using helm release storage namespace: %s\n", *commonCmdData.HelmReleaseStorageNamespace)
-	logboek.LogF("Using helm release storage type: %s\n", helmReleaseStorageType)
-	logboek.LogF("Using helm release name: %s\n", release)
-	logboek.LogF("Using Kubernetes namespace: %s\n", namespace)
+	if err := logboek.Default.LogBlock("Deploy options", logboek.LevelLogBlockOptions{}, func() error {
+		logboek.LogF("Kubernetes namespace: %s\n", namespace)
+		logboek.LogF("Helm release storage namespace: %s\n", *commonCmdData.HelmReleaseStorageNamespace)
+		logboek.LogF("Helm release storage type: %s\n", helmReleaseStorageType)
+		logboek.LogF("Helm release name: %s\n", release)
+
+		return nil
+	}); err != nil {
+		return err
+	}
 
 	return deploy.RunDismiss(release, namespace, *commonCmdData.KubeContext, deploy.DismissOptions{
 		WithNamespace: cmdData.WithNamespace,

--- a/cmd/werf/helm/get_autogenerated_values/main.go
+++ b/cmd/werf/helm/get_autogenerated_values/main.go
@@ -98,7 +98,7 @@ func runGetServiceValues() error {
 		return fmt.Errorf("getting project dir failed: %s", err)
 	}
 
-	werfConfig, err := common.GetWerfConfig(projectDir)
+	werfConfig, err := common.GetWerfConfig(projectDir, false)
 	if err != nil {
 		return fmt.Errorf("bad config: %s", err)
 	}

--- a/cmd/werf/helm/get_namespace/main.go
+++ b/cmd/werf/helm/get_namespace/main.go
@@ -59,7 +59,7 @@ func runGetNamespace() error {
 		return fmt.Errorf("getting project dir failed: %s", err)
 	}
 
-	werfConfig, err := common.GetWerfConfig(projectDir)
+	werfConfig, err := common.GetWerfConfig(projectDir, false)
 	if err != nil {
 		return fmt.Errorf("bad config: %s", err)
 	}

--- a/cmd/werf/helm/get_release/main.go
+++ b/cmd/werf/helm/get_release/main.go
@@ -59,7 +59,7 @@ func runGetRelease() error {
 		return fmt.Errorf("getting project dir failed: %s", err)
 	}
 
-	werfConfig, err := common.GetWerfConfig(projectDir)
+	werfConfig, err := common.GetWerfConfig(projectDir, false)
 	if err != nil {
 		return fmt.Errorf("bad config: %s", err)
 	}

--- a/cmd/werf/helm/lint/lint.go
+++ b/cmd/werf/helm/lint/lint.go
@@ -83,7 +83,7 @@ func runLint() error {
 		return fmt.Errorf("getting project dir failed: %s", err)
 	}
 
-	werfConfig, err := common.GetWerfConfig(projectDir)
+	werfConfig, err := common.GetWerfConfig(projectDir, true)
 	if err != nil {
 		return fmt.Errorf("bad config: %s", err)
 	}

--- a/cmd/werf/helm/render/render.go
+++ b/cmd/werf/helm/render/render.go
@@ -101,7 +101,7 @@ func runRender(outputFilePath string) error {
 		return fmt.Errorf("getting project dir failed: %s", err)
 	}
 
-	werfConfig, err := common.GetWerfConfig(projectDir)
+	werfConfig, err := common.GetWerfConfig(projectDir, false)
 	if err != nil {
 		return fmt.Errorf("bad config: %s", err)
 	}

--- a/cmd/werf/images/cleanup/cleanup.go
+++ b/cmd/werf/images/cleanup/cleanup.go
@@ -102,10 +102,12 @@ func runCleanup() error {
 	}
 	defer tmp_manager.ReleaseProjectDir(projectTmpDir)
 
-	werfConfig, err := common.GetWerfConfig(projectDir)
+	werfConfig, err := common.GetWerfConfig(projectDir, true)
 	if err != nil {
 		return fmt.Errorf("bad config: %s", err)
 	}
+
+	logboek.LogOptionalLn()
 
 	projectName := werfConfig.Meta.Project
 

--- a/cmd/werf/images/publish/cmd_factory/main.go
+++ b/cmd/werf/images/publish/cmd_factory/main.go
@@ -95,10 +95,12 @@ func runImagesPublish(commonCmdData *common.CmdData, imagesToProcess []string) e
 
 	common.ProcessLogProjectDir(commonCmdData, projectDir)
 
-	werfConfig, err := common.GetWerfConfig(projectDir)
+	werfConfig, err := common.GetWerfConfig(projectDir, true)
 	if err != nil {
 		return fmt.Errorf("bad config: %s", err)
 	}
+
+	logboek.LogOptionalLn()
 
 	for _, imageToProcess := range imagesToProcess {
 		if !werfConfig.HasImage(imageToProcess) {

--- a/cmd/werf/images/purge/purge.go
+++ b/cmd/werf/images/purge/purge.go
@@ -78,10 +78,12 @@ func runPurge() error {
 
 	common.ProcessLogProjectDir(&commonCmdData, projectDir)
 
-	werfConfig, err := common.GetWerfConfig(projectDir)
+	werfConfig, err := common.GetWerfConfig(projectDir, true)
 	if err != nil {
 		return fmt.Errorf("bad config: %s", err)
 	}
+
+	logboek.LogOptionalLn()
 
 	projectName := werfConfig.Meta.Project
 

--- a/cmd/werf/purge/purge.go
+++ b/cmd/werf/purge/purge.go
@@ -100,10 +100,12 @@ func runPurge() error {
 		return err
 	}
 
-	werfConfig, err := common.GetWerfConfig(projectDir)
+	werfConfig, err := common.GetWerfConfig(projectDir, true)
 	if err != nil {
 		return fmt.Errorf("bad config: %s", err)
 	}
+
+	logboek.LogOptionalLn()
 
 	projectName := werfConfig.Meta.Project
 

--- a/cmd/werf/run/run.go
+++ b/cmd/werf/run/run.go
@@ -175,7 +175,7 @@ func runRun() error {
 
 	common.ProcessLogProjectDir(&commonCmdData, projectDir)
 
-	werfConfig, err := common.GetWerfConfig(projectDir)
+	werfConfig, err := common.GetWerfConfig(projectDir, false)
 	if err != nil {
 		return fmt.Errorf("bad config: %s", err)
 	}
@@ -233,7 +233,7 @@ func runRun() error {
 	} else {
 		return logboek.WithRawStreamsOutputModeOn(func() error {
 			return common.WithoutTerminationSignalsTrap(func() error {
-				return docker.CliRun(dockerRunArgs...)
+				return docker.CliRun_LiveOutput(dockerRunArgs...)
 			})
 		})
 	}

--- a/cmd/werf/stage/image/main.go
+++ b/cmd/werf/stage/image/main.go
@@ -99,7 +99,7 @@ func run(imageName string) error {
 
 	common.ProcessLogProjectDir(&commonCmdData, projectDir)
 
-	werfConfig, err := common.GetWerfConfig(projectDir)
+	werfConfig, err := common.GetWerfConfig(projectDir, false)
 	if err != nil {
 		return fmt.Errorf("bad config: %s", err)
 	}

--- a/cmd/werf/stages/build/cmd_factory/main.go
+++ b/cmd/werf/stages/build/cmd_factory/main.go
@@ -118,10 +118,12 @@ func runStagesBuild(cmdData *CmdData, commonCmdData *common.CmdData, imagesToPro
 
 	common.ProcessLogProjectDir(commonCmdData, projectDir)
 
-	werfConfig, err := common.GetWerfConfig(projectDir)
+	werfConfig, err := common.GetWerfConfig(projectDir, true)
 	if err != nil {
 		return fmt.Errorf("bad config: %s", err)
 	}
+
+	logboek.LogOptionalLn()
 
 	for _, imageToProcess := range imagesToProcess {
 		if !werfConfig.HasImage(imageToProcess) {

--- a/cmd/werf/stages/cleanup/cleanup.go
+++ b/cmd/werf/stages/cleanup/cleanup.go
@@ -89,10 +89,12 @@ func runSync() error {
 	}
 	defer tmp_manager.ReleaseProjectDir(projectTmpDir)
 
-	werfConfig, err := common.GetWerfConfig(projectDir)
+	werfConfig, err := common.GetWerfConfig(projectDir, true)
 	if err != nil {
 		return fmt.Errorf("bad config: %s", err)
 	}
+
+	logboek.LogOptionalLn()
 
 	projectName := werfConfig.Meta.Project
 

--- a/cmd/werf/stages/purge/purge.go
+++ b/cmd/werf/stages/purge/purge.go
@@ -85,10 +85,12 @@ func runPurge() error {
 
 	common.ProcessLogProjectDir(&commonCmdData, projectDir)
 
-	werfConfig, err := common.GetWerfConfig(projectDir)
+	werfConfig, err := common.GetWerfConfig(projectDir, true)
 	if err != nil {
 		return fmt.Errorf("bad config: %s", err)
 	}
+
+	logboek.LogOptionalLn()
 
 	projectName := werfConfig.Meta.Project
 

--- a/go.mod
+++ b/go.mod
@@ -165,7 +165,7 @@ replace k8s.io/sample-cli-plugin => k8s.io/sample-cli-plugin v0.16.7
 
 replace k8s.io/sample-controller => k8s.io/sample-controller v0.16.7
 
-replace k8s.io/helm => github.com/flant/helm v0.0.0-20200220095449-c44c7c22d6cc
+replace k8s.io/helm => github.com/flant/helm v0.0.0-20200302114220-d40ba0adc0f1
 
 replace github.com/containerd/containerd => github.com/containerd/containerd v1.2.3
 

--- a/go.sum
+++ b/go.sum
@@ -233,6 +233,10 @@ github.com/flant/helm v0.0.0-20200219121324-93546abae733 h1:ZtnR7X18lQ8Tiqlchahg
 github.com/flant/helm v0.0.0-20200219121324-93546abae733/go.mod h1:kVR/UJ6TuuVNuyUbJ2WDnIiP6Is/ikNMwM+2jq2+jSc=
 github.com/flant/helm v0.0.0-20200220095449-c44c7c22d6cc h1:Ri3LlUmM1kUsxD57WpywdxZ3sdadRyU9Jb0Bk9+qWME=
 github.com/flant/helm v0.0.0-20200220095449-c44c7c22d6cc/go.mod h1:rBQrZQK7AGqzCP1Ve/pE1irL0A9WGQySaDXhpZ6AIJM=
+github.com/flant/helm v0.0.0-20200302104856-93d2a6bb8ec2 h1:806mkyRBJB52chU9f2dAIOVBvgJqt12X0I6Z/f/lDYA=
+github.com/flant/helm v0.0.0-20200302104856-93d2a6bb8ec2/go.mod h1:rBQrZQK7AGqzCP1Ve/pE1irL0A9WGQySaDXhpZ6AIJM=
+github.com/flant/helm v0.0.0-20200302114220-d40ba0adc0f1 h1:KslUJGGR4MPl4fwTineGfcN1JGNUsLt34gb+hGSJ1zU=
+github.com/flant/helm v0.0.0-20200302114220-d40ba0adc0f1/go.mod h1:rBQrZQK7AGqzCP1Ve/pE1irL0A9WGQySaDXhpZ6AIJM=
 github.com/flant/kubedog v0.3.5-0.20200213111410-09bddc160684 h1:qlP25ub/MTaZufGerOv01ruZJZTDj0K6YZFlpr5sd0E=
 github.com/flant/kubedog v0.3.5-0.20200213111410-09bddc160684/go.mod h1:cyOV/syD4pkYuqdFuUs/GMkUMGOoNa0MA51eP84nvg4=
 github.com/flant/kubedog v0.3.5-0.20200220095422-0f37f3ed1897 h1:VIA/WAUnDM88stpnyEj5pXi5VQN4nH7AHDo6GoIodRU=

--- a/pkg/deploy/dismiss.go
+++ b/pkg/deploy/dismiss.go
@@ -13,8 +13,5 @@ type DismissOptions struct {
 func RunDismiss(releaseName, namespace, _ string, opts DismissOptions) error {
 	logboek.Debug.LogF("Dismiss options: %#v\n", opts)
 	logboek.Debug.LogF("Namespace: %s\n", namespace)
-	logProcessOptions := logboek.LevelLogProcessOptions{Style: logboek.HighlightStyle()}
-	return logboek.Default.LogProcess("Running dismiss", logProcessOptions, func() error {
-		return helm.PurgeHelmRelease(releaseName, namespace, opts.WithNamespace, opts.WithHooks)
-	})
+	return helm.PurgeHelmRelease(releaseName, namespace, opts.WithNamespace, opts.WithHooks)
 }

--- a/pkg/deploy/helm/resources_waiter.go
+++ b/pkg/deploy/helm/resources_waiter.go
@@ -163,7 +163,8 @@ func (waiter *ResourcesWaiter) WaitForResources(timeout time.Duration, created h
 func makeMultitrackSpec(objMeta *metav1.ObjectMeta, failuresCountOptions allowedFailuresCountOptions, kind string) (*multitrack.MultitrackSpec, error) {
 	multitrackSpec, err := prepareMultitrackSpec(objMeta.Name, kind, objMeta.Namespace, objMeta.Annotations, failuresCountOptions)
 	if err != nil {
-		logboek.LogWarnF("WARNING: %s\n", err)
+		logboek.LogWarnLn()
+		logboek.LogWarnF("WARNING %s\n", err)
 		return nil, nil
 	}
 
@@ -338,7 +339,7 @@ func (waiter *ResourcesWaiter) WatchUntilReady(namespace string, reader io.Reade
 			})
 
 		default:
-			logboek.LogWarnF("WARNING: Will not track helm hook %s/%s: %s kind not supported for tracking\n", strings.ToLower(kind), name, kind)
+			logboek.Default.LogFDetails("Will not track helm hook %s/%s: %s kind not supported for tracking\n", strings.ToLower(kind), name, kind)
 		}
 	}
 

--- a/pkg/deploy/werf_chart/werf_chart.go
+++ b/pkg/deploy/werf_chart/werf_chart.go
@@ -128,10 +128,10 @@ func (chart *WerfChart) LogExtraAnnotations() {
 	res, _ := yaml.Marshal(chart.ExtraAnnotations)
 
 	annotations := strings.TrimRight(string(res), "\n")
-	logboek.LogLn("Using extra annotations:")
-	logboek.LogF(logboek.FitText(annotations, logboek.FitTextOptions{ExtraIndentWidth: 2}))
-	logboek.LogLn()
-	logboek.LogOptionalLn()
+	logboek.LogBlock(fmt.Sprintf("Extra annotations"), logboek.LogBlockOptions{}, func() error {
+		logboek.LogLn(annotations)
+		return nil
+	})
 }
 
 func (chart *WerfChart) LogExtraLabels() {
@@ -142,10 +142,10 @@ func (chart *WerfChart) LogExtraLabels() {
 	res, _ := yaml.Marshal(chart.ExtraLabels)
 
 	labels := strings.TrimRight(string(res), "\n")
-	logboek.LogLn("Using extra labels:")
-	logboek.LogF(logboek.FitText(labels, logboek.FitTextOptions{ExtraIndentWidth: 2}))
-	logboek.LogLn()
-	logboek.LogOptionalLn()
+	logboek.LogBlock(fmt.Sprintf("Extra labels"), logboek.LogBlockOptions{}, func() error {
+		logboek.LogLn(labels)
+		return nil
+	})
 }
 
 type ChartConfig struct {


### PR DESCRIPTION
 - werf run, werf deploy, werf dismiss commands will not print stages-related info by default (signatures checks, printed only in verbose mode);
 - werf deploy/dismiss output reformed.