### PR TITLE
Store managed images list in stages storage

### DIFF
--- a/cmd/werf/build_and_publish/main.go
+++ b/cmd/werf/build_and_publish/main.go
@@ -127,9 +127,9 @@ func runBuildAndPublish(imagesToProcess []string) error {
 
 	common.ProcessLogProjectDir(&commonCmdData, projectDir)
 
-	werfConfig, err := common.GetWerfConfig(projectDir, true)
+	werfConfig, err := common.GetRequiredWerfConfig(projectDir, true)
 	if err != nil {
-		return fmt.Errorf("bad config: %s", err)
+		return fmt.Errorf("unable to load werf config: %s", err)
 	}
 
 	logboek.LogOptionalLn()

--- a/cmd/werf/common/managed_images.go
+++ b/cmd/werf/common/managed_images.go
@@ -1,0 +1,30 @@
+package common
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/flant/werf/pkg/config"
+	"github.com/flant/werf/pkg/storage"
+
+	"github.com/flant/werf/pkg/util"
+)
+
+func GetManagedImagesNames(projectName string, stagesStorage storage.StagesStorage, werfConfig *config.WerfConfig) ([]string, error) {
+	var imagesNames []string
+	if managedImages, err := stagesStorage.GetManagedImages(projectName); err != nil {
+		return nil, fmt.Errorf("unable to get managed images for project %q: %s", projectName, err)
+	} else {
+		imagesNames = append(imagesNames, managedImages...)
+	}
+	for _, image := range werfConfig.StapelImages {
+		imagesNames = append(imagesNames, image.Name)
+	}
+	for _, image := range werfConfig.ImagesFromDockerfile {
+		imagesNames = append(imagesNames, image.Name)
+	}
+	uniqImagesNames := util.UniqStrings(imagesNames)
+	sort.Strings(uniqImagesNames)
+
+	return uniqImagesNames, nil
+}

--- a/cmd/werf/config/list/list.go
+++ b/cmd/werf/config/list/list.go
@@ -54,7 +54,7 @@ func run() error {
 		return fmt.Errorf("getting project dir failed: %s", err)
 	}
 
-	werfConfigPath, err := common.GetWerfConfigPath(projectDir)
+	werfConfigPath, err := common.GetWerfConfigPath(projectDir, true)
 	if err != nil {
 		return err
 	}

--- a/cmd/werf/config/render/render.go
+++ b/cmd/werf/config/render/render.go
@@ -35,7 +35,7 @@ func NewCmd() *cobra.Command {
 				return fmt.Errorf("getting project dir failed: %s", err)
 			}
 
-			werfConfigPath, err := common.GetWerfConfigPath(projectDir)
+			werfConfigPath, err := common.GetWerfConfigPath(projectDir, true)
 			if err != nil {
 				return err
 			}

--- a/cmd/werf/deploy/main.go
+++ b/cmd/werf/deploy/main.go
@@ -181,9 +181,9 @@ func runDeploy() error {
 	}
 	defer tmp_manager.ReleaseProjectDir(projectTmpDir)
 
-	werfConfig, err := common.GetWerfConfig(projectDir, true)
+	werfConfig, err := common.GetRequiredWerfConfig(projectDir, true)
 	if err != nil {
-		return fmt.Errorf("bad config: %s", err)
+		return fmt.Errorf("unable to load werf config: %s", err)
 	}
 
 	logboek.LogOptionalLn()

--- a/cmd/werf/dismiss/dismiss.go
+++ b/cmd/werf/dismiss/dismiss.go
@@ -122,9 +122,9 @@ func runDismiss() error {
 
 	common.ProcessLogProjectDir(&commonCmdData, projectDir)
 
-	werfConfig, err := common.GetWerfConfig(projectDir, true)
+	werfConfig, err := common.GetRequiredWerfConfig(projectDir, true)
 	if err != nil {
-		return fmt.Errorf("bad config: %s", err)
+		return fmt.Errorf("unable to load werf config: %s", err)
 	}
 	logboek.LogOptionalLn()
 

--- a/cmd/werf/helm/get_autogenerated_values/main.go
+++ b/cmd/werf/helm/get_autogenerated_values/main.go
@@ -98,9 +98,9 @@ func runGetServiceValues() error {
 		return fmt.Errorf("getting project dir failed: %s", err)
 	}
 
-	werfConfig, err := common.GetWerfConfig(projectDir, false)
+	werfConfig, err := common.GetRequiredWerfConfig(projectDir, false)
 	if err != nil {
-		return fmt.Errorf("bad config: %s", err)
+		return fmt.Errorf("unable to load werf config: %s", err)
 	}
 
 	imagesRepo, err := common.GetOptionalImagesRepo(werfConfig.Meta.Project, &commonCmdData)

--- a/cmd/werf/helm/get_namespace/main.go
+++ b/cmd/werf/helm/get_namespace/main.go
@@ -59,9 +59,9 @@ func runGetNamespace() error {
 		return fmt.Errorf("getting project dir failed: %s", err)
 	}
 
-	werfConfig, err := common.GetWerfConfig(projectDir, false)
+	werfConfig, err := common.GetRequiredWerfConfig(projectDir, false)
 	if err != nil {
-		return fmt.Errorf("bad config: %s", err)
+		return fmt.Errorf("unable to load werf config: %s", err)
 	}
 
 	namespace, err := common.GetKubernetesNamespace("", *commonCmdData.Environment, werfConfig)

--- a/cmd/werf/helm/get_release/main.go
+++ b/cmd/werf/helm/get_release/main.go
@@ -59,9 +59,9 @@ func runGetRelease() error {
 		return fmt.Errorf("getting project dir failed: %s", err)
 	}
 
-	werfConfig, err := common.GetWerfConfig(projectDir, false)
+	werfConfig, err := common.GetRequiredWerfConfig(projectDir, false)
 	if err != nil {
-		return fmt.Errorf("bad config: %s", err)
+		return fmt.Errorf("unable to load werf config: %s", err)
 	}
 
 	release, err := common.GetHelmRelease("", *commonCmdData.Environment, werfConfig)

--- a/cmd/werf/helm/lint/lint.go
+++ b/cmd/werf/helm/lint/lint.go
@@ -83,9 +83,9 @@ func runLint() error {
 		return fmt.Errorf("getting project dir failed: %s", err)
 	}
 
-	werfConfig, err := common.GetWerfConfig(projectDir, true)
+	werfConfig, err := common.GetRequiredWerfConfig(projectDir, true)
 	if err != nil {
-		return fmt.Errorf("bad config: %s", err)
+		return fmt.Errorf("unable to load werf config: %s", err)
 	}
 
 	imagesRepoManager, err := common.GetImagesRepoManager("REPO", common.MultirepoImagesRepoMode)

--- a/cmd/werf/helm/render/render.go
+++ b/cmd/werf/helm/render/render.go
@@ -101,9 +101,9 @@ func runRender(outputFilePath string) error {
 		return fmt.Errorf("getting project dir failed: %s", err)
 	}
 
-	werfConfig, err := common.GetWerfConfig(projectDir, false)
+	werfConfig, err := common.GetRequiredWerfConfig(projectDir, false)
 	if err != nil {
-		return fmt.Errorf("bad config: %s", err)
+		return fmt.Errorf("unable to load werf config: %s", err)
 	}
 
 	optionalImagesRepo, err := common.GetOptionalImagesRepo(werfConfig.Meta.Project, &commonCmdData)

--- a/cmd/werf/images/managed/add/add.go
+++ b/cmd/werf/images/managed/add/add.go
@@ -1,4 +1,4 @@
-package cleanup
+package add
 
 import (
 	"fmt"
@@ -6,62 +6,56 @@ import (
 
 	"github.com/flant/werf/pkg/storage"
 
-	"github.com/spf13/cobra"
-
-	"github.com/flant/logboek"
 	"github.com/flant/shluz"
-
 	"github.com/flant/werf/cmd/werf/common"
-	"github.com/flant/werf/pkg/cleaning"
 	"github.com/flant/werf/pkg/docker"
 	"github.com/flant/werf/pkg/docker_registry"
 	"github.com/flant/werf/pkg/tmp_manager"
 	"github.com/flant/werf/pkg/werf"
+	"github.com/spf13/cobra"
 )
 
 var commonCmdData common.CmdData
 
 func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:                   "cleanup",
+		Use:                   "add",
 		DisableFlagsInUseLine: true,
-		Short:                 "Cleanup project stages from stages storage",
-		Long:                  common.GetLongCommandDescription(`Cleanup project stages from stages storage for the images, that do not exist in the specified images repo`),
+		Short:                 "Add image record to the list of managed images which will be preserved during cleanup procedure",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := common.ProcessLogOptions(&commonCmdData); err != nil {
 				common.PrintHelp(cmd)
 				return err
 			}
 
-			common.LogVersion()
-
-			return common.LogRunningTime(func() error {
-				return runSync()
-			})
+			if err := common.ValidateArgumentCount(1, args, cmd); err != nil {
+				return err
+			}
+			return run(args[0])
 		},
 	}
 
+	common.SetupProjectName(&commonCmdData, cmd)
 	common.SetupDir(&commonCmdData, cmd)
 	common.SetupTmpDir(&commonCmdData, cmd)
 	common.SetupHomeDir(&commonCmdData, cmd)
+	common.SetupSSHKey(&commonCmdData, cmd)
 
 	common.SetupStagesStorage(&commonCmdData, cmd)
 	common.SetupStagesStorageLock(&commonCmdData, cmd)
 	common.SetupImagesRepo(&commonCmdData, cmd)
 	common.SetupImagesRepoMode(&commonCmdData, cmd)
-	common.SetupDockerConfig(&commonCmdData, cmd, "Command needs granted permissions to read, pull and delete images from the specified stages storage, read images from the specified images repo")
+	common.SetupDockerConfig(&commonCmdData, cmd, "Command needs granted permissions to read and write images to the specified stages storage")
 	common.SetupInsecureRegistry(&commonCmdData, cmd)
 	common.SetupSkipTlsVerifyRegistry(&commonCmdData, cmd)
 
 	common.SetupLogOptions(&commonCmdData, cmd)
 	common.SetupLogProjectDir(&commonCmdData, cmd)
 
-	common.SetupDryRun(&commonCmdData, cmd)
-
 	return cmd
 }
 
-func runSync() error {
+func run(imageName string) error {
 	if err := werf.Init(*commonCmdData.TmpDir, *commonCmdData.HomeDir); err != nil {
 		return fmt.Errorf("initialization error: %s", err)
 	}
@@ -83,63 +77,36 @@ func runSync() error {
 		return fmt.Errorf("getting project dir failed: %s", err)
 	}
 
-	common.ProcessLogProjectDir(&commonCmdData, projectDir)
-
 	projectTmpDir, err := tmp_manager.CreateProjectDir()
 	if err != nil {
 		return fmt.Errorf("getting project tmp dir failed: %s", err)
 	}
 	defer tmp_manager.ReleaseProjectDir(projectTmpDir)
 
-	werfConfig, err := common.GetRequiredWerfConfig(projectDir, true)
+	werfConfig, err := common.GetOptionalWerfConfig(projectDir, false)
 	if err != nil {
 		return fmt.Errorf("unable to load werf config: %s", err)
 	}
 
-	logboek.LogOptionalLn()
-
-	projectName := werfConfig.Meta.Project
-
-	imagesRepo, err := common.GetImagesRepo(projectName, &commonCmdData)
-	if err != nil {
-		return err
-	}
-
-	imagesRepoMode, err := common.GetImagesRepoMode(&commonCmdData)
-	if err != nil {
-		return err
-	}
-
-	imagesRepoManager, err := common.GetImagesRepoManager(imagesRepo, imagesRepoMode)
-	if err != nil {
-		return err
+	var projectName string
+	if werfConfig != nil {
+		projectName = werfConfig.Meta.Project
+	} else if *commonCmdData.ProjectName != "" {
+		projectName = *commonCmdData.ProjectName
+	} else {
+		return fmt.Errorf("run command in the project directory with werf.yaml or specify --project-name=PROJECT_NAME param")
 	}
 
 	if _, err := common.GetStagesStorage(&commonCmdData); err != nil {
 		return err
 	}
-	if _, err := common.GetStagesStorageLock(&commonCmdData); err != nil {
+	if _, err = common.GetStagesStorageLock(&commonCmdData); err != nil {
 		return err
 	}
+
 	stagesStorage := &storage.LocalStagesStorage{}
-
-	imagesNames, err := common.GetManagedImagesNames(projectName, stagesStorage, werfConfig)
-	if err != nil {
-		return err
-	}
-	logboek.Debug.LogF("Managed images names: %v\n", imagesNames)
-
-	stagesCleanupOptions := cleaning.StagesCleanupOptions{
-		ProjectName:       projectName,
-		ImagesRepoManager: imagesRepoManager,
-		StagesStorage:     stagesStorage,
-		ImagesNames:       imagesNames,
-		DryRun:            *commonCmdData.DryRun,
-	}
-
-	logboek.LogOptionalLn()
-	if err := cleaning.StagesCleanup(stagesCleanupOptions); err != nil {
-		return err
+	if err := stagesStorage.AddManagedImage(projectName, imageName); err != nil {
+		return fmt.Errorf("unable to add managed image %q for project %q: %s", imageName, projectName, err)
 	}
 
 	return nil

--- a/cmd/werf/images/managed/rm/rm.go
+++ b/cmd/werf/images/managed/rm/rm.go
@@ -1,67 +1,62 @@
-package cleanup
+package rm
 
 import (
 	"fmt"
 	"path/filepath"
+	"strings"
 
 	"github.com/flant/werf/pkg/storage"
 
-	"github.com/spf13/cobra"
-
-	"github.com/flant/logboek"
 	"github.com/flant/shluz"
-
 	"github.com/flant/werf/cmd/werf/common"
-	"github.com/flant/werf/pkg/cleaning"
 	"github.com/flant/werf/pkg/docker"
 	"github.com/flant/werf/pkg/docker_registry"
 	"github.com/flant/werf/pkg/tmp_manager"
 	"github.com/flant/werf/pkg/werf"
+	"github.com/spf13/cobra"
 )
 
 var commonCmdData common.CmdData
 
 func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:                   "cleanup",
+		Use:                   "rm",
 		DisableFlagsInUseLine: true,
-		Short:                 "Cleanup project stages from stages storage",
-		Long:                  common.GetLongCommandDescription(`Cleanup project stages from stages storage for the images, that do not exist in the specified images repo`),
+		Short:                 "remove image record from the list of managed images which will be preserved during cleanup procedure",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := common.ProcessLogOptions(&commonCmdData); err != nil {
 				common.PrintHelp(cmd)
 				return err
 			}
 
-			common.LogVersion()
-
-			return common.LogRunningTime(func() error {
-				return runSync()
-			})
+			if err := common.ValidateMinimumNArgs(1, args, cmd); err != nil {
+				return err
+			}
+			return run(args)
 		},
 	}
 
+	common.SetupProjectName(&commonCmdData, cmd)
 	common.SetupDir(&commonCmdData, cmd)
 	common.SetupTmpDir(&commonCmdData, cmd)
 	common.SetupHomeDir(&commonCmdData, cmd)
+	common.SetupSSHKey(&commonCmdData, cmd)
 
 	common.SetupStagesStorage(&commonCmdData, cmd)
 	common.SetupStagesStorageLock(&commonCmdData, cmd)
 	common.SetupImagesRepo(&commonCmdData, cmd)
 	common.SetupImagesRepoMode(&commonCmdData, cmd)
-	common.SetupDockerConfig(&commonCmdData, cmd, "Command needs granted permissions to read, pull and delete images from the specified stages storage, read images from the specified images repo")
+	common.SetupDockerConfig(&commonCmdData, cmd, "Command needs granted permissions to read and write images to the specified stages storage")
 	common.SetupInsecureRegistry(&commonCmdData, cmd)
 	common.SetupSkipTlsVerifyRegistry(&commonCmdData, cmd)
 
 	common.SetupLogOptions(&commonCmdData, cmd)
 	common.SetupLogProjectDir(&commonCmdData, cmd)
 
-	common.SetupDryRun(&commonCmdData, cmd)
-
 	return cmd
 }
 
-func runSync() error {
+func run(imageNames []string) error {
 	if err := werf.Init(*commonCmdData.TmpDir, *commonCmdData.HomeDir); err != nil {
 		return fmt.Errorf("initialization error: %s", err)
 	}
@@ -83,63 +78,47 @@ func runSync() error {
 		return fmt.Errorf("getting project dir failed: %s", err)
 	}
 
-	common.ProcessLogProjectDir(&commonCmdData, projectDir)
-
 	projectTmpDir, err := tmp_manager.CreateProjectDir()
 	if err != nil {
 		return fmt.Errorf("getting project tmp dir failed: %s", err)
 	}
 	defer tmp_manager.ReleaseProjectDir(projectTmpDir)
 
-	werfConfig, err := common.GetRequiredWerfConfig(projectDir, true)
+	werfConfig, err := common.GetOptionalWerfConfig(projectDir, false)
 	if err != nil {
 		return fmt.Errorf("unable to load werf config: %s", err)
 	}
 
-	logboek.LogOptionalLn()
-
-	projectName := werfConfig.Meta.Project
-
-	imagesRepo, err := common.GetImagesRepo(projectName, &commonCmdData)
-	if err != nil {
-		return err
-	}
-
-	imagesRepoMode, err := common.GetImagesRepoMode(&commonCmdData)
-	if err != nil {
-		return err
-	}
-
-	imagesRepoManager, err := common.GetImagesRepoManager(imagesRepo, imagesRepoMode)
-	if err != nil {
-		return err
+	var projectName string
+	if werfConfig != nil {
+		projectName = werfConfig.Meta.Project
+	} else if *commonCmdData.ProjectName != "" {
+		projectName = *commonCmdData.ProjectName
+	} else {
+		return fmt.Errorf("run command in the project directory with werf.yaml or specify --project-name=PROJECT_NAME param")
 	}
 
 	if _, err := common.GetStagesStorage(&commonCmdData); err != nil {
 		return err
 	}
-	if _, err := common.GetStagesStorageLock(&commonCmdData); err != nil {
+	if _, err = common.GetStagesStorageLock(&commonCmdData); err != nil {
 		return err
 	}
 	stagesStorage := &storage.LocalStagesStorage{}
 
-	imagesNames, err := common.GetManagedImagesNames(projectName, stagesStorage, werfConfig)
-	if err != nil {
-		return err
-	}
-	logboek.Debug.LogF("Managed images names: %v\n", imagesNames)
-
-	stagesCleanupOptions := cleaning.StagesCleanupOptions{
-		ProjectName:       projectName,
-		ImagesRepoManager: imagesRepoManager,
-		StagesStorage:     stagesStorage,
-		ImagesNames:       imagesNames,
-		DryRun:            *commonCmdData.DryRun,
+	errs := []error{}
+	for _, imageName := range imageNames {
+		if err := stagesStorage.RmManagedImage(projectName, imageName); err != nil {
+			errs = append(errs, fmt.Errorf("unable to remove known config image name %q of project %q: %s", imageName, projectName, err))
+		}
 	}
 
-	logboek.LogOptionalLn()
-	if err := cleaning.StagesCleanup(stagesCleanupOptions); err != nil {
-		return err
+	if len(errs) > 0 {
+		errMsgs := []string{}
+		for _, err := range errs {
+			errMsgs = append(errMsgs, err.Error())
+		}
+		return fmt.Errorf("%s", strings.Join(errMsgs, "; "))
 	}
 
 	return nil

--- a/cmd/werf/images/publish/cmd_factory/main.go
+++ b/cmd/werf/images/publish/cmd_factory/main.go
@@ -95,9 +95,9 @@ func runImagesPublish(commonCmdData *common.CmdData, imagesToProcess []string) e
 
 	common.ProcessLogProjectDir(commonCmdData, projectDir)
 
-	werfConfig, err := common.GetWerfConfig(projectDir, true)
+	werfConfig, err := common.GetRequiredWerfConfig(projectDir, true)
 	if err != nil {
-		return fmt.Errorf("bad config: %s", err)
+		return fmt.Errorf("unable to load werf config: %s", err)
 	}
 
 	logboek.LogOptionalLn()

--- a/cmd/werf/images/purge/purge.go
+++ b/cmd/werf/images/purge/purge.go
@@ -78,9 +78,9 @@ func runPurge() error {
 
 	common.ProcessLogProjectDir(&commonCmdData, projectDir)
 
-	werfConfig, err := common.GetWerfConfig(projectDir, true)
+	werfConfig, err := common.GetRequiredWerfConfig(projectDir, true)
 	if err != nil {
-		return fmt.Errorf("bad config: %s", err)
+		return fmt.Errorf("unable to load werf config: %s", err)
 	}
 
 	logboek.LogOptionalLn()

--- a/cmd/werf/main.go
+++ b/cmd/werf/main.go
@@ -28,6 +28,10 @@ import (
 	"github.com/flant/werf/cmd/werf/ci_env"
 	"github.com/flant/werf/cmd/werf/slugify"
 
+	images_managed_add "github.com/flant/werf/cmd/werf/images/managed/add"
+	images_managed_ls "github.com/flant/werf/cmd/werf/images/managed/ls"
+	images_managed_rm "github.com/flant/werf/cmd/werf/images/managed/rm"
+
 	images_cleanup "github.com/flant/werf/cmd/werf/images/cleanup"
 	images_publish "github.com/flant/werf/cmd/werf/images/publish"
 	images_purge "github.com/flant/werf/cmd/werf/images/purge"
@@ -152,6 +156,20 @@ func configCmd() *cobra.Command {
 	return cmd
 }
 
+func managedImagesCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "managed",
+		Short: "Work with managed images which will be preserved during cleanup procedure",
+	}
+	cmd.AddCommand(
+		images_managed_add.NewCmd(),
+		images_managed_ls.NewCmd(),
+		images_managed_rm.NewCmd(),
+	)
+
+	return cmd
+}
+
 func imagesCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "images",
@@ -161,6 +179,7 @@ func imagesCmd() *cobra.Command {
 		images_publish.NewCmd(),
 		images_cleanup.NewCmd(),
 		images_purge.NewCmd(),
+		managedImagesCmd(),
 	)
 
 	return cmd

--- a/cmd/werf/purge/purge.go
+++ b/cmd/werf/purge/purge.go
@@ -100,9 +100,9 @@ func runPurge() error {
 		return err
 	}
 
-	werfConfig, err := common.GetWerfConfig(projectDir, true)
+	werfConfig, err := common.GetRequiredWerfConfig(projectDir, true)
 	if err != nil {
-		return fmt.Errorf("bad config: %s", err)
+		return fmt.Errorf("unable to load werf config: %s", err)
 	}
 
 	logboek.LogOptionalLn()

--- a/cmd/werf/run/run.go
+++ b/cmd/werf/run/run.go
@@ -175,9 +175,9 @@ func runRun() error {
 
 	common.ProcessLogProjectDir(&commonCmdData, projectDir)
 
-	werfConfig, err := common.GetWerfConfig(projectDir, false)
+	werfConfig, err := common.GetRequiredWerfConfig(projectDir, false)
 	if err != nil {
-		return fmt.Errorf("bad config: %s", err)
+		return fmt.Errorf("unable to load werf config: %s", err)
 	}
 
 	projectTmpDir, err := tmp_manager.CreateProjectDir()

--- a/cmd/werf/stage/image/main.go
+++ b/cmd/werf/stage/image/main.go
@@ -99,9 +99,9 @@ func run(imageName string) error {
 
 	common.ProcessLogProjectDir(&commonCmdData, projectDir)
 
-	werfConfig, err := common.GetWerfConfig(projectDir, false)
+	werfConfig, err := common.GetRequiredWerfConfig(projectDir, false)
 	if err != nil {
-		return fmt.Errorf("bad config: %s", err)
+		return fmt.Errorf("unable to load werf config: %s", err)
 	}
 
 	projectTmpDir, err := tmp_manager.CreateProjectDir()

--- a/cmd/werf/stages/build/cmd_factory/main.go
+++ b/cmd/werf/stages/build/cmd_factory/main.go
@@ -118,9 +118,9 @@ func runStagesBuild(cmdData *CmdData, commonCmdData *common.CmdData, imagesToPro
 
 	common.ProcessLogProjectDir(commonCmdData, projectDir)
 
-	werfConfig, err := common.GetWerfConfig(projectDir, true)
+	werfConfig, err := common.GetRequiredWerfConfig(projectDir, true)
 	if err != nil {
-		return fmt.Errorf("bad config: %s", err)
+		return fmt.Errorf("unable to load werf config: %s", err)
 	}
 
 	logboek.LogOptionalLn()

--- a/cmd/werf/stages/purge/purge.go
+++ b/cmd/werf/stages/purge/purge.go
@@ -85,9 +85,9 @@ func runPurge() error {
 
 	common.ProcessLogProjectDir(&commonCmdData, projectDir)
 
-	werfConfig, err := common.GetWerfConfig(projectDir, true)
+	werfConfig, err := common.GetRequiredWerfConfig(projectDir, true)
 	if err != nil {
-		return fmt.Errorf("bad config: %s", err)
+		return fmt.Errorf("unable to load werf config: %s", err)
 	}
 
 	logboek.LogOptionalLn()

--- a/pkg/build/build_phase.go
+++ b/pkg/build/build_phase.go
@@ -96,6 +96,10 @@ func (phase *BuildPhase) BeforeImageStages(img *Image) error {
 	phase.PrevBuiltImage = nil
 	phase.PrevNonEmptyStageImageSize = 0
 
+	if err := phase.Conveyor.StagesStorage.AddManagedImage(phase.Conveyor.projectName(), img.GetName()); err != nil {
+		return fmt.Errorf("unable to add image %q to the managed images of project %q: %s", img.GetName(), phase.Conveyor.projectName(), err)
+	}
+
 	img.SetupBaseImage(phase.Conveyor)
 
 	phase.PrevImage = img.GetBaseImage()

--- a/pkg/cleaning/stages_purge.go
+++ b/pkg/cleaning/stages_purge.go
@@ -1,7 +1,14 @@
 package cleaning
 
 import (
+	"fmt"
+
+	"github.com/docker/docker/api/types"
+
+	"github.com/docker/docker/api/types/filters"
 	"github.com/flant/logboek"
+	"github.com/flant/werf/pkg/docker"
+	"github.com/flant/werf/pkg/image"
 )
 
 type StagesPurgeOptions struct {
@@ -39,6 +46,31 @@ func stagesPurge(options StagesPurgeOptions) error {
 
 func projectStagesPurge(options CommonProjectOptions) error {
 	if err := werfImagesFlushByFilterSet(projectImageStageFilterSet(options), options.CommonOptions); err != nil {
+		return err
+	}
+
+	if err := purgeManagedImages(options); err != nil {
+		return fmt.Errorf("unable to purge managed images: %s", err)
+	}
+
+	return nil
+}
+
+func purgeManagedImages(options CommonProjectOptions) error {
+	filterSet := filters.NewArgs()
+	filterSet.Add("reference", fmt.Sprintf(image.ManagedImageRecord_ImageNameFormat, options.ProjectName))
+
+	images, err := docker.Images(types.ImageListOptions{Filters: filterSet})
+	if err != nil {
+		return err
+	}
+
+	images, err = processUsedImages(images, options.CommonOptions)
+	if err != nil {
+		return err
+	}
+
+	if err := imagesRemove(images, options.CommonOptions); err != nil {
 		return err
 	}
 

--- a/pkg/docker/image.go
+++ b/pkg/docker/image.go
@@ -13,6 +13,12 @@ import (
 	"golang.org/x/net/context"
 )
 
+func CreateImage(ref string) error {
+	ctx := context.Background()
+	_, err := apiClient.ImageImport(ctx, types.ImageImportSource{SourceName: "-"}, ref, types.ImageImportOptions{})
+	return err
+}
+
 func Images(options types.ImageListOptions) ([]types.ImageSummary, error) {
 	ctx := context.Background()
 	images, err := apiClient.ImageList(ctx, options)

--- a/pkg/image/const.go
+++ b/pkg/image/const.go
@@ -26,5 +26,9 @@ const (
 	LocalImageStageImageNameFormat = "werf-stages-storage/%s"
 	LocalImageStageImageFormat     = "werf-stages-storage/%s:%s-%s"
 
+	ManagedImageRecord_ImageNamePrefix = "werf-managed-images/"
+	ManagedImageRecord_ImageNameFormat = "werf-managed-images/%s"
+	ManagedImageRecord_ImageFormat     = "werf-managed-images/%s:%s"
+
 	RepoImageStageTagFormat = "image-stage-%s"
 )

--- a/pkg/storage/stages_storage.go
+++ b/pkg/storage/stages_storage.go
@@ -26,5 +26,9 @@ type StagesStorage interface {
 	SyncStageImage(stageImage image.ImageInterface) error
 	StoreStageImage(stageImage image.ImageInterface) error
 
+	AddManagedImage(projectName, imageName string) error
+	RmManagedImage(projectName, imageName string) error
+	GetManagedImages(projectName string) ([]string, error)
+
 	String() string
 }


### PR DESCRIPTION
Store managed images list in stages storage to prevent images defined in different branches from being cleaned up by werf cleanup procedure.

Added commands to manage known images list: `werf images managed add|rm|ls`

`werf stages purge` will delete all managed images records.
