### PR TITLE
[logs] Update stapel image to include newer logboek, remove excess git log msg in default log

### DIFF
--- a/pkg/stapel/stapel.go
+++ b/pkg/stapel/stapel.go
@@ -11,7 +11,7 @@ import (
 	"github.com/flant/werf/pkg/docker"
 )
 
-const VERSION = "0.5.0"
+const VERSION = "0.6.1"
 
 func getVersion() string {
 	version := VERSION

--- a/pkg/true_git/work_tree.go
+++ b/pkg/true_git/work_tree.go
@@ -138,7 +138,7 @@ func prepareWorkTree(repoDir, workTreeCacheDir string, commit string, withSubmod
 	// Switch worktree state to the desired commit.
 	// If worktree already exists — it will be used as a cache.
 	logProcessMsg := fmt.Sprintf("Switch work tree %s to commit %s", workTreeDir, commit)
-	if err := logboek.LogProcess(logProcessMsg, logboek.LogProcessOptions{}, func() error {
+	if err := logboek.Info.LogProcess(logProcessMsg, logboek.LevelLogProcessOptions{}, func() error {
 		logboek.Default.LogFDetails("Work tree dir: %s\n", workTreeDir)
 		if currentCommit != "" {
 			logboek.Default.LogFDetails("Current commit: %s\n", currentCommit)


### PR DESCRIPTION
Moved 'Switch work tree to commit' git message from default log to verbose.