### PR TITLE
[dockerfile] Fix dockerfile stage name from "COPY --from" is not detected

### DIFF
--- a/pkg/build/conveyor.go
+++ b/pkg/build/conveyor.go
@@ -1171,15 +1171,18 @@ func prepareImageBasedOnImageFromDockerfile(imageFromDockerfileConfig *config.Im
 func resolveDockerStagesFromValue(stages []instructions.Stage) {
 	nameToIndex := make(map[string]string)
 	for i, s := range stages {
+		name := strings.ToLower(s.Name)
 		index := strconv.Itoa(i)
-		if s.Name != index {
-			nameToIndex[s.Name] = index
+		if name != index {
+			nameToIndex[name] = index
 		}
+
 		for _, cmd := range s.Commands {
 			switch c := cmd.(type) {
 			case *instructions.CopyCommand:
 				if c.From != "" {
-					if val, ok := nameToIndex[c.From]; ok {
+					from := strings.ToLower(c.From)
+					if val, ok := nameToIndex[from]; ok {
 						c.From = val
 					}
 				}

--- a/pkg/build/stage/dockerfile.go
+++ b/pkg/build/stage/dockerfile.go
@@ -168,10 +168,11 @@ func (s *DockerfileStage) GetDependencies(_ Conveyor, _, _ image.ImageInterface)
 			case *instructions.CopyCommand:
 				if c.From != "" {
 					relatedStageIndex, err := strconv.Atoi(c.From)
-					if err == nil && relatedStageIndex < len(stagesDependencies) {
-						stagesDependencies[ind] = append(stagesDependencies[ind], stagesDependencies[relatedStageIndex]...)
+					if err != nil || relatedStageIndex >= len(stagesDependencies) {
+						logboek.LogWarnF("WARNING: COPY --from with nonexistent dockerfile stage %s detected\n", c.From)
+						continue
 					} else {
-						logboek.LogWarnF("WARNING: COPY --from with unexistent stage %s detected\n", c.From)
+						stagesDependencies[ind] = append(stagesDependencies[ind], stagesDependencies[relatedStageIndex]...)
 					}
 				}
 			}


### PR DESCRIPTION
Docker parser coverts dockerfile stage name (AS) to lowercase but in places of the name usage (COPY --from) does not.
This affected dockerfile stage signature calculation and occurred false warning messages.