### PR TITLE
[deploy] Hotfix werf helm render: fix problem with '|' rendered as '|-'

### DIFF
--- a/pkg/deploy/helm/templates.go
+++ b/pkg/deploy/helm/templates.go
@@ -7,9 +7,8 @@ import (
 	"strings"
 	"text/template"
 
-	"gopkg.in/yaml.v2"
-
 	"github.com/Masterminds/sprig"
+	"github.com/ghodss/yaml"
 
 	"k8s.io/helm/pkg/chartutil"
 	"k8s.io/helm/pkg/engine"


### PR DESCRIPTION
Change `gopkg.in/yaml.v2` to `github.com/ghodss/yaml` in custom werf templates engine,
as `github.com/ghodss/yaml` is used everywhere in the helm 2.

In the helm 3 `sigs.k8s.io/yaml` is used, but it is not possible for now to switch to `sigs.k8s.io/yaml` before switching to helm 3 codebase.
https://github.com/helm/helm/blob/master/pkg/engine/funcs.go#L27