### PR TITLE
Remote storages support: adopt build conveyor for distributed builds and fixes - part 2

### DIFF
--- a/pkg/build/conveyor.go
+++ b/pkg/build/conveyor.go
@@ -564,7 +564,7 @@ func (c *Conveyor) GetImageLastStageImageName(imageName string) string {
 }
 
 func (c *Conveyor) GetImageLastStageImageID(imageName string) string {
-	return c.GetImage(imageName).GetLastNonEmptyStage().GetImage().GetImageInfo().ID
+	return c.GetImage(imageName).GetLastNonEmptyStage().GetImage().GetStagesStorageImageInfo().ID
 }
 
 func (c *Conveyor) SetBuildingGitStage(imageName string, stageName stage.StageName) {

--- a/pkg/build/publish_images_phase.go
+++ b/pkg/build/publish_images_phase.go
@@ -380,5 +380,5 @@ func (phase *PublishImagesPhase) checkImageAlreadyExists(existingTags []string, 
 		return false, fmt.Errorf("unable to get image %s parent id: %s", werfImageName, err)
 	}
 
-	return lastStageImage.GetImageInfo().ID == parentID, nil
+	return lastStageImage.GetStagesStorageImageInfo().ID == parentID, nil
 }

--- a/pkg/build/should_be_built_phase.go
+++ b/pkg/build/should_be_built_phase.go
@@ -44,7 +44,7 @@ func (phase *ShouldBeBuiltPhase) ImageProcessingShouldBeStopped(img *Image) bool
 }
 
 func (phase *ShouldBeBuiltPhase) OnImageStage(img *Image, stg stage.Interface) (bool, error) {
-	if stg.GetImage().GetImageInfo() == nil {
+	if stg.GetImage().GetStagesStorageImageInfo() == nil {
 		phase.BadStagesByImage[img.GetName()] = append(phase.BadStagesByImage[img.GetName()], stg)
 	}
 	return true, nil

--- a/pkg/build/stage/base.go
+++ b/pkg/build/stage/base.go
@@ -118,8 +118,8 @@ func (s *BaseStage) GetNextStageDependencies(_ Conveyor) (string, error) {
 func (s *BaseStage) getNextStageGitDependencies(_ Conveyor) (string, error) {
 	var args []string
 	for _, gitMapping := range s.gitMappings {
-		if s.image.GetImageInfo() != nil {
-			args = append(args, gitMapping.GetGitCommitFromImageLabels(s.image.GetImageInfo().Labels))
+		if s.image.GetStagesStorageImageInfo() != nil {
+			args = append(args, gitMapping.GetGitCommitFromImageLabels(s.image.GetStagesStorageImageInfo().Labels))
 		} else {
 			latestCommit, err := gitMapping.LatestCommit()
 			if err != nil {
@@ -141,7 +141,7 @@ func (s *BaseStage) IsEmpty(_ Conveyor, _ container_runtime.ImageInterface) (boo
 
 func (s *BaseStage) ShouldBeReset(builtImage container_runtime.ImageInterface) (bool, error) {
 	for _, gitMapping := range s.gitMappings {
-		commit := gitMapping.GetGitCommitFromImageLabels(builtImage.GetImageInfo().Labels)
+		commit := gitMapping.GetGitCommitFromImageLabels(builtImage.GetStagesStorageImageInfo().Labels)
 		if commit == "" {
 			return false, nil
 		} else if exist, err := gitMapping.GitRepo().IsCommitExists(commit); err != nil {
@@ -236,7 +236,7 @@ func (s *BaseStage) PrepareImage(_ Conveyor, prevBuiltImage, image container_run
 	return nil
 }
 
-func (s *BaseStage) AfterImageSyncDockerStateHook(_ Conveyor) error {
+func (s *BaseStage) AfterSignatureCalculated(_ Conveyor) error {
 	return nil
 }
 
@@ -253,7 +253,7 @@ func (s *BaseStage) getServiceMountsFromLabels(prevBuiltImage container_runtime.
 
 	var labels map[string]string
 	if prevBuiltImage != nil {
-		labels = prevBuiltImage.GetImageInfo().Labels
+		labels = prevBuiltImage.GetStagesStorageImageInfo().Labels
 	}
 
 	for _, labelMountType := range []struct{ Label, MountType string }{
@@ -341,7 +341,7 @@ func (s *BaseStage) getCustomMountsFromLabels(prevBuiltImage container_runtime.I
 
 	var labels map[string]string
 	if prevBuiltImage != nil {
-		labels = prevBuiltImage.GetImageInfo().Labels
+		labels = prevBuiltImage.GetStagesStorageImageInfo().Labels
 	}
 	for k, v := range labels {
 		if !strings.HasPrefix(k, imagePkg.WerfMountCustomDirLabelPrefix) {

--- a/pkg/build/stage/git.go
+++ b/pkg/build/stage/git.go
@@ -20,8 +20,8 @@ func (s *GitStage) isEmpty() bool {
 	return len(s.gitMappings) == 0
 }
 
-func (s *GitStage) AfterImageSyncDockerStateHook(c Conveyor) error {
-	if s.image.GetImageInfo() == nil {
+func (s *GitStage) AfterSignatureCalculated(c Conveyor) error {
+	if s.image.GetStagesStorageImageInfo() == nil {
 		stageName := c.GetBuildingGitStage(s.imageName)
 		if stageName == "" {
 			c.SetBuildingGitStage(s.imageName, s.Name())

--- a/pkg/build/stage/git_cache.go
+++ b/pkg/build/stage/git_cache.go
@@ -57,7 +57,7 @@ func (s *GitCacheStage) GetDependencies(_ Conveyor, _, prevBuiltImage container_
 func (s *GitCacheStage) gitMappingsPatchSize(prevBuiltImage container_runtime.ImageInterface) (int64, error) {
 	var size int64
 	for _, gitMapping := range s.gitMappings {
-		commit := gitMapping.GetGitCommitFromImageLabels(prevBuiltImage.GetImageInfo().Labels)
+		commit := gitMapping.GetGitCommitFromImageLabels(prevBuiltImage.GetStagesStorageImageInfo().Labels)
 		if commit == "" {
 			return 0, fmt.Errorf("invalid stage image: can not find git commit in stage image labels: delete stage image %s manually and retry the build", prevBuiltImage.Name())
 		}

--- a/pkg/build/stage/git_latest_patch.go
+++ b/pkg/build/stage/git_latest_patch.go
@@ -26,7 +26,7 @@ func (s *GitLatestPatchStage) IsEmpty(c Conveyor, prevBuiltImage container_runti
 
 	isEmpty := true
 	for _, gitMapping := range s.gitMappings {
-		commit := gitMapping.GetGitCommitFromImageLabels(prevBuiltImage.GetImageInfo().Labels)
+		commit := gitMapping.GetGitCommitFromImageLabels(prevBuiltImage.GetStagesStorageImageInfo().Labels)
 		if exist, err := gitMapping.GitRepo().IsCommitExists(commit); err != nil {
 			return false, err
 		} else if !exist {

--- a/pkg/build/stage/git_mapping.go
+++ b/pkg/build/stage/git_mapping.go
@@ -270,7 +270,7 @@ func (gm *GitMapping) ApplyPatchCommand(prevBuiltImage, image container_runtime.
 }
 
 func (gm *GitMapping) GetCommitsToPatch(prevBuiltImage container_runtime.ImageInterface) (string, string, error) {
-	fromCommit := gm.GetGitCommitFromImageLabels(prevBuiltImage.GetImageInfo().Labels)
+	fromCommit := gm.GetGitCommitFromImageLabels(prevBuiltImage.GetStagesStorageImageInfo().Labels)
 	if fromCommit == "" {
 		panic("Commit should be in prev built image labels!")
 	}
@@ -303,7 +303,7 @@ func (gm *GitMapping) ImageGitCommitLabel() string {
 }
 
 func (gm *GitMapping) baseApplyPatchCommand(fromCommit, toCommit string, prevBuiltImage container_runtime.ImageInterface) ([]string, error) {
-	archiveType := git_repo.ArchiveType(prevBuiltImage.GetImageInfo().Labels[gm.getArchiveTypeLabelName()])
+	archiveType := git_repo.ArchiveType(prevBuiltImage.GetStagesStorageImageInfo().Labels[gm.getArchiveTypeLabelName()])
 
 	patchOpts := git_repo.PatchOptions{
 		FilterOptions: gm.getRepoFilterOptions(),

--- a/pkg/build/stage/git_patch.go
+++ b/pkg/build/stage/git_patch.go
@@ -72,7 +72,7 @@ func (s *GitPatchStage) willGitLatestCommitBeBuiltOnPrevGitStage(c Conveyor) (bo
 
 func (s *GitPatchStage) hasPrevBuiltStageHadActualGitMappings(prevBuiltImage container_runtime.ImageInterface) (bool, error) {
 	for _, gitMapping := range s.gitMappings {
-		commit := gitMapping.GetGitCommitFromImageLabels(prevBuiltImage.GetImageInfo().Labels)
+		commit := gitMapping.GetGitCommitFromImageLabels(prevBuiltImage.GetStagesStorageImageInfo().Labels)
 		latestCommit, err := gitMapping.LatestCommit()
 		if err != nil {
 			return false, err

--- a/pkg/build/stage/interface.go
+++ b/pkg/build/stage/interface.go
@@ -17,7 +17,7 @@ type Interface interface {
 
 	PrepareImage(c Conveyor, prevBuiltImage, image container_runtime.ImageInterface) error
 
-	AfterImageSyncDockerStateHook(Conveyor) error
+	AfterSignatureCalculated(Conveyor) error
 	PreRunHook(Conveyor) error
 
 	SetSignature(signature string)

--- a/pkg/build/stage/user_with_git_patch.go
+++ b/pkg/build/stage/user_with_git_patch.go
@@ -51,9 +51,9 @@ func (s *UserWithGitPatchStage) PrepareImage(c Conveyor, prevBuiltImage, image c
 	return nil
 }
 
-func (s *UserWithGitPatchStage) AfterImageSyncDockerStateHook(c Conveyor) error {
+func (s *UserWithGitPatchStage) AfterSignatureCalculated(c Conveyor) error {
 	if !s.GitPatchStage.isEmpty() {
-		if err := s.GitPatchStage.AfterImageSyncDockerStateHook(c); err != nil {
+		if err := s.GitPatchStage.AfterSignatureCalculated(c); err != nil {
 			return err
 		}
 	}

--- a/pkg/container_runtime/base_image.go
+++ b/pkg/container_runtime/base_image.go
@@ -66,11 +66,11 @@ func (i *baseImage) Untag() error {
 	return nil
 }
 
-func (i *baseImage) SetImageInfo(imgInfo *image.Info) {
+func (i *baseImage) SetStagesStorageImageInfo(imgInfo *image.Info) {
 	i.imgInfo = imgInfo
 }
 
-func (i *baseImage) GetImageInfo() *image.Info {
+func (i *baseImage) GetStagesStorageImageInfo() *image.Info {
 	return i.imgInfo
 }
 

--- a/pkg/container_runtime/container_runtime.go
+++ b/pkg/container_runtime/container_runtime.go
@@ -33,9 +33,12 @@ func (runtime *LocalDockerServerRuntime) RefreshImageObject(img Image) error {
 
 	if inspect, err := runtime.GetImageInspect(dockerImage.Image.Name()); err != nil {
 		return err
+	} else if inspect == nil {
+		dockerImage.Image.SetInspect(nil)
+		dockerImage.Image.SetStagesStorageImageInfo(nil)
 	} else {
 		dockerImage.Image.SetInspect(inspect)
-		dockerImage.Image.SetImageInfo(image.NewInfoFromInspect(dockerImage.Image.Name(), inspect))
+		dockerImage.Image.SetStagesStorageImageInfo(image.NewInfoFromInspect(dockerImage.Image.Name(), inspect))
 	}
 
 	return nil

--- a/pkg/container_runtime/interface.go
+++ b/pkg/container_runtime/interface.go
@@ -32,8 +32,8 @@ type ImageInterface interface {
 
 	SetInspect(inspect *types.ImageInspect)
 	IsExistsLocally() bool
-	SetImageInfo(imgInfo *image.Info)
-	GetImageInfo() *image.Info
+	SetStagesStorageImageInfo(imgInfo *image.Info)
+	GetStagesStorageImageInfo() *image.Info
 }
 
 type Container interface {

--- a/pkg/container_runtime/stage_image.go
+++ b/pkg/container_runtime/stage_image.go
@@ -46,7 +46,7 @@ func (i *StageImage) GetID() string {
 	if i.buildImage != nil {
 		return i.buildImage.Name()
 	} else {
-		return i.baseImage.GetImageInfo().ID
+		return i.baseImage.GetStagesStorageImageInfo().ID
 	}
 }
 
@@ -116,7 +116,7 @@ func (i *StageImage) Build(options BuildOptions) error {
 		return err
 	} else {
 		i.SetInspect(inspect)
-		i.SetImageInfo(image.NewInfoFromInspect(i.Name(), inspect))
+		i.SetStagesStorageImageInfo(image.NewInfoFromInspect(i.Name(), inspect))
 	}
 
 	return nil
@@ -215,7 +215,7 @@ func (i *StageImage) Import(name string) error {
 		return err
 	}
 
-	importedImageId := importedImage.GetImageInfo().ID
+	importedImageId := importedImage.GetStagesStorageImageInfo().ID
 
 	if err := docker.CliTag(importedImageId, i.name); err != nil {
 		return err

--- a/pkg/image/info.go
+++ b/pkg/image/info.go
@@ -35,29 +35,35 @@ func (info *Info) GetCreatedAt() time.Time {
 }
 
 func NewInfoFromInspect(ref string, inspect *types.ImageInspect) *Info {
-	var repository, tag string
-	parts := strings.SplitN(stringutil.Reverse(ref), ":", 2)
-	if len(parts) == 2 {
-		repository = stringutil.Reverse(parts[0])
-		tag = stringutil.Reverse(parts[1])
-	}
+	repository, tag := ParseRepositoryAndTag(ref)
 
 	return &Info{
 		Name:              ref,
 		Repository:        repository,
 		Tag:               tag,
 		Labels:            inspect.Config.Labels,
-		CreatedAtUnixNano: mustParseTimestampString(inspect.Created).UnixNano(),
+		CreatedAtUnixNano: MustParseTimestampString(inspect.Created).UnixNano(),
 		ID:                inspect.ID,
 		ParentID:          inspect.Parent,
 		Size:              inspect.Size,
 	}
 }
 
-func mustParseTimestampString(timestampString string) time.Time {
+func MustParseTimestampString(timestampString string) time.Time {
 	t, err := time.Parse(time.RFC3339, timestampString)
 	if err != nil {
 		panic(fmt.Sprintf("got bad timestamp %q: %s", timestampString, err))
 	}
 	return t
+}
+
+func ParseRepositoryAndTag(ref string) (string, string) {
+	parts := strings.SplitN(stringutil.Reverse(ref), ":", 2)
+	if len(parts) == 2 {
+		tag := stringutil.Reverse(parts[0])
+		repository := stringutil.Reverse(parts[1])
+		return repository, tag
+	} else {
+		return ref, ""
+	}
 }

--- a/pkg/storage/repo_stages_storage.go
+++ b/pkg/storage/repo_stages_storage.go
@@ -182,33 +182,52 @@ func (storage *RepoStagesStorage) GetManagedImages(projectName string) ([]string
 	return res, nil
 }
 
-func (storage *RepoStagesStorage) FetchImage(image container_runtime.Image) error {
+func (storage *RepoStagesStorage) FetchImage(img container_runtime.Image) error {
 	switch containerRuntime := storage.ContainerRuntime.(type) {
 	case *container_runtime.LocalDockerServerRuntime:
 		// FIXME: construct image name
 		// TODO: lock by name to prevent double pull of the same stage
-		return containerRuntime.PullImageFromRegistry(image)
+		return containerRuntime.PullImageFromRegistry(img)
 		// TODO: case *container_runtime.LocalHostRuntime:
 	default:
 		panic("not implemented")
 	}
 }
 
-func (storage *RepoStagesStorage) StoreImage(image container_runtime.Image) error {
+func (storage *RepoStagesStorage) StoreImage(img container_runtime.Image) error {
 	switch containerRuntime := storage.ContainerRuntime.(type) {
 	case *container_runtime.LocalDockerServerRuntime:
 		// FIXME: construct image name
-		return containerRuntime.PushBuiltImage(image)
+		return containerRuntime.PushBuiltImage(img)
 		// TODO: case *container_runtime.LocalHostRuntime:
 	default:
 		panic("not implemented")
 	}
 }
 
-func (storage *RepoStagesStorage) CleanupLocalImage(image container_runtime.Image) error {
-	// FIXME
-	logboek.Default.LogF("Cleaning local image %#v\n", image)
-	return nil
+func (storage *RepoStagesStorage) CleanupLocalImage(img container_runtime.Image) error {
+	logboek.Default.LogF("Cleaning local image %#v\n", img)
+	return fmt.Errorf("not implemented")
+}
+
+func (storage *RepoStagesStorage) ShouldFetchImage(img container_runtime.Image) (bool, error) {
+	switch storage.ContainerRuntime.(type) {
+	case *container_runtime.LocalDockerServerRuntime:
+		dockerImage := img.(*container_runtime.DockerImage)
+		return !dockerImage.Image.IsExistsLocally(), nil
+	default:
+		panic("not implemented")
+	}
+}
+
+func (storage *RepoStagesStorage) ShouldCleanupLocalImage(img container_runtime.Image) (bool, error) {
+	switch storage.ContainerRuntime.(type) {
+	case *container_runtime.LocalDockerServerRuntime:
+		dockerImage := img.(*container_runtime.DockerImage)
+		return dockerImage.Image.IsExistsLocally(), nil
+	default:
+		panic("not implemented")
+	}
 }
 
 func (storage *RepoStagesStorage) String() string {

--- a/pkg/storage/stages_storage.go
+++ b/pkg/storage/stages_storage.go
@@ -21,11 +21,13 @@ type StagesStorage interface {
 	GetImageInfo(stageImageName string) (*image.Info, error)
 
 	// FetchImage will create a local image in the container-runtime
-	FetchImage(image container_runtime.Image) error
+	FetchImage(img container_runtime.Image) error
 	// StoreImage will store a local image into the container-runtime, local built image should exist prior running store
-	StoreImage(image container_runtime.Image) error
+	StoreImage(img container_runtime.Image) error
 	// CleanupLocalImage will remove a local image from container-runtime
-	CleanupLocalImage(image container_runtime.Image) error
+	CleanupLocalImage(img container_runtime.Image) error
+	ShouldFetchImage(img container_runtime.Image) (bool, error)
+	ShouldCleanupLocalImage(img container_runtime.Image) (bool, error)
 
 	AddManagedImage(projectName, imageName string) error
 	RmManagedImage(projectName, imageName string) error
@@ -48,7 +50,7 @@ type StagesStorageOptions struct {
 
 func NewStagesStorage(stagesStorageAddress string, containerRuntime container_runtime.ContainerRuntime, options StagesStorageOptions) (StagesStorage, error) {
 	if stagesStorageAddress == LocalStagesStorageAddress {
-		return NewLocalStagesStorage(containerRuntime.(*container_runtime.LocalDockerServerRuntime)), nil
+		return NewLocalDockerServerStagesStorage(containerRuntime.(*container_runtime.LocalDockerServerRuntime)), nil
 	} else { // Docker registry based stages storage
 		return NewRepoStagesStorage(stagesStorageAddress, containerRuntime, options.RepoStagesStorageOptions)
 	}


### PR DESCRIPTION
 - LocalStagesStorage renamed to LocalDockerServerStagesStorage, because implementation of stages storage for kaniko-like builds will change from LocalStagesStorage implementation;
 - Added new StagesStorage interface methods ShouldFetchImage, ShouldCleanupLocalImage, implemented fetch&cleanup base stage logic when building a new stage;
 - Fixed container_runtime RefreshImageObject bug when inspect is nil;
 - Refactored Conveyor PrevImage, PrevBuiltImage, PrevStage, PrevNonEmptyStage, etc.
   - Removed PrevImage and PrevBuiltImage references, added methods to dynamically fetch image object;
   - Explicit if-s for "from" stage to differentiate a situation when previous image for stage "from" is needed;
   - Added PrevBuiltStage reference;
   - Refactored OnStageImage so that PrevStage references are always valid despite BuildPhase SignaturesOnly mode;
   - This refactor was needed to implement fetch&cleanup base stage logic;
   - Always convert container_runtime.ImageInterface to *container_runtime.StageImage in the conveyor because there are no other cases so far;
 - AfterImageSyncDockerStateHook hook renamed to AfterSignatureCalculated;
 - FIXED an error during cleanup: 'Error: unable to check existence of image "werf-managed-images/alo:werf-managed-images/alo": Error response from daemon: no such image: werf-managed-images/alo:werf-managed-images/alo: invalid reference format';
 - ImageInterface.GetImageInfo renamed to GetStagesStorageImageInfo: if GetStagesStorageImageInfo != nil then image is cached into the stages storage.