### PR TITLE
Remote storages support: optimize distributed builds

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -103,6 +103,7 @@ require (
 	gopkg.in/src-d/go-billy.v4 v4.3.2
 	gopkg.in/src-d/go-git.v4 v4.13.1
 	gopkg.in/yaml.v2 v2.2.8
+	gopkg.in/yaml.v3 v3.0.0-20200121175148-a6ecf24a6d71
 	honnef.co/go/tools v0.0.1-2019.2.3 // indirect
 	k8s.io/api v0.17.4
 	k8s.io/apiextensions-apiserver v0.0.0

--- a/pkg/build/conveyor.go
+++ b/pkg/build/conveyor.go
@@ -204,7 +204,7 @@ func (c *Conveyor) ShouldBeBuilt() error {
 	}
 
 	phases := []Phase{
-		NewBuildPhase(c, BuildPhaseOptions{SignaturesOnly: true}),
+		NewBuildPhase(c, BuildPhaseOptions{CalculateStagesOnly: true}),
 		NewShouldBeBuiltPhase(c),
 	}
 
@@ -265,10 +265,12 @@ func (c *Conveyor) BuildStages(opts BuildStagesOptions) error {
 		return err
 	}
 
-	phases := []Phase{NewBuildPhase(c, BuildPhaseOptions{
-		IntrospectOptions: opts.IntrospectOptions,
-		ImageBuildOptions: opts.ImageBuildOptions,
-	})}
+	phases := []Phase{
+		NewBuildPhase(c, BuildPhaseOptions{
+			IntrospectOptions: opts.IntrospectOptions,
+			ImageBuildOptions: opts.ImageBuildOptions,
+		}),
+	}
 
 	return c.runPhases(phases, true)
 }
@@ -284,7 +286,7 @@ func (c *Conveyor) PublishImages(opts PublishImagesOptions) error {
 	}
 
 	phases := []Phase{
-		NewBuildPhase(c, BuildPhaseOptions{SignaturesOnly: true}),
+		NewBuildPhase(c, BuildPhaseOptions{CalculateStagesOnly: true}),
 		NewShouldBeBuiltPhase(c),
 		NewPublishImagesPhase(c, c.ImagesRepo, opts),
 	}
@@ -452,17 +454,13 @@ func (c *Conveyor) runPhases(phases []Phase, logImages bool) error {
 
 				logProcessMsg = fmt.Sprintf("Phase %s -- OnImageStage()", phase.Name())
 				logboek.Debug.LogProcessStart(logProcessMsg, logboek.LevelLogProcessStartOptions{})
-				var newStages []stage.Interface
 				for _, stg := range img.GetStages() {
 					logboek.Debug.LogF("Phase %s -- OnImageStage() %s %s\n", phase.Name(), img.GetLogName(), stg.LogDetailedName())
-					if keepStage, err := phase.OnImageStage(img, stg); err != nil {
+					if err := phase.OnImageStage(img, stg); err != nil {
 						logboek.Debug.LogProcessFail(logboek.LevelLogProcessFailOptions{})
 						return fmt.Errorf("phase %s on image %s stage %s handler failed: %s", phase.Name(), img.GetLogName(), stg.Name(), err)
-					} else if keepStage {
-						newStages = append(newStages, stg)
 					}
 				}
-				img.SetStages(newStages)
 				logboek.Debug.LogProcessEnd(logboek.LevelLogProcessEndOptions{})
 
 				logProcessMsg = fmt.Sprintf("Phase %s -- AfterImageStages()", phase.Name())

--- a/pkg/build/phase.go
+++ b/pkg/build/phase.go
@@ -7,7 +7,7 @@ type Phase interface {
 	BeforeImages() error
 	AfterImages() error
 	BeforeImageStages(img *Image) error
-	OnImageStage(img *Image, stg stage.Interface) (bool, error)
+	OnImageStage(img *Image, stg stage.Interface) error
 	AfterImageStages(img *Image) error
 	ImageProcessingShouldBeStopped(img *Image) bool
 }

--- a/pkg/build/should_be_built_phase.go
+++ b/pkg/build/should_be_built_phase.go
@@ -43,11 +43,18 @@ func (phase *ShouldBeBuiltPhase) ImageProcessingShouldBeStopped(img *Image) bool
 	return len(phase.BadStagesByImage[img.GetName()]) > 0
 }
 
-func (phase *ShouldBeBuiltPhase) OnImageStage(img *Image, stg stage.Interface) (bool, error) {
+func (phase *ShouldBeBuiltPhase) OnImageStage(img *Image, stg stage.Interface) error {
+	// stage is empty
+	if stg.GetImage() == nil {
+		return nil
+	}
+
+	// stage is not empty and stages-storage does not contain suitable cached image
 	if stg.GetImage().GetStagesStorageImageInfo() == nil {
 		phase.BadStagesByImage[img.GetName()] = append(phase.BadStagesByImage[img.GetName()], stg)
 	}
-	return true, nil
+
+	return nil
 }
 
 func (phase *ShouldBeBuiltPhase) BeforeImages() error {

--- a/pkg/build/stages_iterator.go
+++ b/pkg/build/stages_iterator.go
@@ -1,0 +1,77 @@
+package build
+
+import (
+	"fmt"
+
+	"github.com/flant/logboek"
+	"github.com/flant/werf/pkg/build/stage"
+	"github.com/flant/werf/pkg/container_runtime"
+)
+
+type StagesIterator struct {
+	Conveyor *Conveyor
+
+	PrevStage                  stage.Interface
+	PrevNonEmptyStage          stage.Interface
+	PrevBuiltStage             stage.Interface
+	PrevNonEmptyStageImageSize int64
+}
+
+func NewStagesIterator(conveyor *Conveyor) *StagesIterator {
+	return &StagesIterator{Conveyor: conveyor}
+}
+
+func (iterator *StagesIterator) GetPrevImage(img *Image, stg stage.Interface) container_runtime.ImageInterface {
+	if stg.Name() == "from" {
+		return img.GetBaseImage()
+	} else if iterator.PrevNonEmptyStage != nil {
+		return iterator.PrevNonEmptyStage.GetImage()
+	}
+	return nil
+}
+
+func (iterator *StagesIterator) GetPrevBuiltImage(img *Image, stg stage.Interface) container_runtime.ImageInterface {
+	if stg.Name() == "from" {
+		return img.GetBaseImage()
+	} else if iterator.PrevBuiltStage != nil {
+		return iterator.PrevBuiltStage.GetImage()
+	}
+	return nil
+}
+
+func (iterator *StagesIterator) OnImageStage(img *Image, stg stage.Interface, onImageStageFunc func(img *Image, stg stage.Interface, isEmpty bool) error) error {
+	isEmpty, err := stg.IsEmpty(iterator.Conveyor, iterator.GetPrevBuiltImage(img, stg))
+	if err != nil {
+		return fmt.Errorf("error checking stage %s is empty: %s", stg.Name(), err)
+	}
+
+	if stg.Name() != "from" {
+		if iterator.PrevStage == nil {
+			panic(fmt.Sprintf("expected PrevStage to be set for image %q stage %s!", img.GetName(), stg.Name()))
+		}
+	}
+
+	if err := onImageStageFunc(img, stg, isEmpty); err != nil {
+		return err
+	}
+
+	iterator.PrevStage = stg
+	logboek.Debug.LogF("Set prev stage = %q %s\n", iterator.PrevStage.Name(), iterator.PrevStage.GetSignature())
+
+	if !isEmpty {
+		iterator.PrevNonEmptyStage = stg
+		logboek.Debug.LogF("Set prev non empty stage = %q %s\n", iterator.PrevNonEmptyStage.Name(), iterator.PrevNonEmptyStage.GetSignature())
+
+		if iterator.PrevNonEmptyStage.GetImage().GetStagesStorageImageInfo() != nil {
+			iterator.PrevNonEmptyStageImageSize = iterator.PrevNonEmptyStage.GetImage().GetStagesStorageImageInfo().Size
+			logboek.Debug.LogF("Set prev non empty stage image size = %d %q %s\n", iterator.PrevNonEmptyStageImageSize, iterator.PrevNonEmptyStage.Name(), iterator.PrevNonEmptyStage.GetSignature())
+		}
+
+		if stg.GetImage().GetStagesStorageImageInfo() != nil {
+			iterator.PrevBuiltStage = stg
+			logboek.Debug.LogF("Set prev built stage = %q (image %s)\n", iterator.PrevBuiltStage.Name(), iterator.PrevBuiltStage.GetImage().Name())
+		}
+	}
+
+	return nil
+}

--- a/pkg/build/stages_storage.go
+++ b/pkg/build/stages_storage.go
@@ -1,0 +1,148 @@
+package build
+
+import (
+	"fmt"
+
+	"github.com/flant/logboek"
+	"github.com/flant/werf/pkg/build/stage"
+	"github.com/flant/werf/pkg/container_runtime"
+	"github.com/flant/werf/pkg/image"
+	"github.com/flant/werf/pkg/storage"
+	"gopkg.in/yaml.v3"
+)
+
+func fetchStage(stagesStorage storage.StagesStorage, stg stage.Interface) error {
+	if shouldFetch, err := stagesStorage.ShouldFetchImage(&container_runtime.DockerImage{Image: stg.GetImage()}); err == nil && shouldFetch {
+		if err := logboek.Default.LogProcess(
+			fmt.Sprintf("Fetching stage %s from stages storage", stg.LogDetailedName()),
+			logboek.LevelLogProcessOptions{Style: logboek.HighlightStyle()},
+			func() error {
+				logboek.Info.LogF("Image name: %s\n", stg.GetImage().Name())
+				if err := stagesStorage.FetchImage(&container_runtime.DockerImage{Image: stg.GetImage()}); err != nil {
+					return fmt.Errorf("unable to fetch stage %s image %s from stages storage %s: %s", stg.LogDetailedName(), stg.GetImage().Name(), stagesStorage.String(), err)
+				}
+				return nil
+			},
+		); err != nil {
+			return err
+		}
+	} else if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func selectSuitableStagesStorageImage(stg stage.Interface, imagesDescs []*image.Info) (*image.Info, error) {
+	if len(imagesDescs) == 0 {
+		return nil, nil
+	}
+
+	var imgInfo *image.Info
+	if err := logboek.Info.LogProcess(
+		fmt.Sprintf("Selecting suitable image for stage %s by signature %s", stg.Name(), stg.GetSignature()),
+		logboek.LevelLogProcessOptions{},
+		func() error {
+			var err error
+			imgInfo, err = stg.SelectCacheImage(imagesDescs)
+			return err
+		},
+	); err != nil {
+		return nil, err
+	}
+	if imgInfo == nil {
+		return nil, nil
+	}
+
+	imgInfoData, err := yaml.Marshal(imgInfo)
+	if err != nil {
+		panic(err)
+	}
+
+	_ = logboek.Debug.LogBlock("Selected cache image", logboek.LevelLogBlockOptions{Style: logboek.HighlightStyle()}, func() error {
+		logboek.Debug.LogF(string(imgInfoData))
+		return nil
+	})
+
+	return imgInfo, nil
+}
+
+func atomicGetImagesBySignatureFromStagesStorageWithCacheReset(conveyor *Conveyor, stageName, stageSig string) ([]*image.Info, error) {
+	if err := conveyor.StorageLockManager.LockStageCache(conveyor.projectName(), stageSig); err != nil {
+		return nil, fmt.Errorf("error locking project %s stage %s cache: %s", conveyor.projectName(), stageSig, err)
+	}
+	defer conveyor.StorageLockManager.UnlockStageCache(conveyor.projectName(), stageSig)
+
+	var originImagesDescs []*image.Info
+	var err error
+	if err := logboek.Default.LogProcess(
+		fmt.Sprintf("Get stage %s images by signature %s from stages storage", stageName, stageSig),
+		logboek.LevelLogProcessOptions{},
+		func() error {
+			originImagesDescs, err = conveyor.StagesStorage.GetRepoImagesBySignature(conveyor.projectName(), stageSig)
+			if err != nil {
+				return fmt.Errorf("error getting project %s stage %s images from stages storage: %s", conveyor.StagesStorage.String(), stageSig, err)
+			}
+
+			logboek.Debug.LogF("Images: %#v\n", originImagesDescs)
+
+			return nil
+		},
+	); err != nil {
+		return nil, err
+	}
+
+	if err := logboek.Info.LogProcess(
+		fmt.Sprintf("Storing stage %s images by signature %s into stages storage cache", stageName, stageSig),
+		logboek.LevelLogProcessOptions{},
+		func() error {
+			if err := conveyor.StagesStorageCache.StoreImagesBySignature(conveyor.projectName(), stageSig, originImagesDescs); err != nil {
+				return fmt.Errorf("error storing stage %s images by signature %s into stages storage cache: %s", stageName, stageSig, err)
+			}
+			return nil
+		},
+	); err != nil {
+		return nil, err
+	}
+
+	return originImagesDescs, nil
+}
+
+func atomicStoreStageCache(conveyor *Conveyor, stageName, stageSig string, imagesDescs []*image.Info) error {
+	if err := conveyor.StorageLockManager.LockStageCache(conveyor.projectName(), stageSig); err != nil {
+		return fmt.Errorf("error locking stage %s cache by signature %s: %s", stageName, stageSig, err)
+	}
+	defer conveyor.StorageLockManager.UnlockStageCache(conveyor.projectName(), stageSig)
+
+	return logboek.Info.LogProcess(
+		fmt.Sprintf("Storing stage %s images by signature %s into stages storage cache", stageName, stageSig),
+		logboek.LevelLogProcessOptions{},
+		func() error {
+			if err := conveyor.StagesStorageCache.StoreImagesBySignature(conveyor.projectName(), stageSig, imagesDescs); err != nil {
+				return fmt.Errorf("error storing stage %s images by signature %s into stages storage cache: %s", stageName, stageSig, err)
+			}
+			return nil
+		},
+	)
+}
+
+func getImagesBySignatureFromCache(conveyor *Conveyor, stageName, stageSig string) (bool, []*image.Info, error) {
+	var cacheExists bool
+	var cacheImagesDescs []*image.Info
+
+	err := logboek.Info.LogProcess(
+		fmt.Sprintf("Getting stage %s images by signature %s from stages storage cache", stageName, stageSig),
+		logboek.LevelLogProcessOptions{},
+		func() error {
+			var err error
+			cacheExists, cacheImagesDescs, err = conveyor.StagesStorageCache.GetImagesBySignature(conveyor.projectName(), stageSig)
+			if err != nil {
+				return fmt.Errorf("error getting project %s stage %s images from stages storage cache: %s", conveyor.projectName(), stageSig, err)
+			}
+
+			return nil
+		},
+	)
+
+	return cacheExists, cacheImagesDescs, err
+}

--- a/pkg/container_runtime/container_runtime.go
+++ b/pkg/container_runtime/container_runtime.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/flant/logboek"
-	"github.com/flant/werf/pkg/image"
 
 	"github.com/docker/docker/api/types"
 	"github.com/flant/werf/pkg/docker"
@@ -34,14 +33,9 @@ func (runtime *LocalDockerServerRuntime) RefreshImageObject(img Image) error {
 
 	if inspect, err := runtime.GetImageInspect(dockerImage.Image.Name()); err != nil {
 		return err
-	} else if inspect == nil {
-		dockerImage.Image.SetInspect(nil)
-		dockerImage.Image.SetStagesStorageImageInfo(nil)
 	} else {
 		dockerImage.Image.SetInspect(inspect)
-		dockerImage.Image.SetStagesStorageImageInfo(image.NewInfoFromInspect(dockerImage.Image.Name(), inspect))
 	}
-
 	return nil
 }
 

--- a/pkg/storage/local_docker_server_stages_storage.go
+++ b/pkg/storage/local_docker_server_stages_storage.go
@@ -42,14 +42,6 @@ func (storage *LocalDockerServerStagesStorage) Validate() error {
 	return nil
 }
 
-func (storage *LocalDockerServerStagesStorage) ShouldFetchImage(img container_runtime.Image) (bool, error) {
-	return false, nil
-}
-
-func (storage *LocalDockerServerStagesStorage) ShouldCleanupLocalImage(img container_runtime.Image) (bool, error) {
-	return false, nil
-}
-
 func (storage *LocalDockerServerStagesStorage) ConstructStageImageName(projectName, signature, uniqueID string) string {
 	return fmt.Sprintf(LocalStage_ImageFormat, projectName, signature, uniqueID)
 }
@@ -190,16 +182,16 @@ func (storage *LocalDockerServerStagesStorage) GetRepoImagesBySignature(projectN
 	return repoImages, nil
 }
 
+func (storage *LocalDockerServerStagesStorage) ShouldFetchImage(img container_runtime.Image) (bool, error) {
+	return false, nil
+}
+
 func (storage *LocalDockerServerStagesStorage) FetchImage(img container_runtime.Image) error {
 	return nil
 }
 
 func (storage *LocalDockerServerStagesStorage) StoreImage(img container_runtime.Image) error {
 	return storage.LocalDockerServerRuntime.TagBuiltImageByName(img)
-}
-
-func (storage *LocalDockerServerStagesStorage) CleanupLocalImage(img container_runtime.Image) error {
-	return nil
 }
 
 func (storage *LocalDockerServerStagesStorage) String() string {

--- a/pkg/storage/repo_stages_storage.go
+++ b/pkg/storage/repo_stages_storage.go
@@ -240,19 +240,8 @@ func (storage *RepoStagesStorage) FetchImage(img container_runtime.Image) error 
 func (storage *RepoStagesStorage) StoreImage(img container_runtime.Image) error {
 	switch containerRuntime := storage.ContainerRuntime.(type) {
 	case *container_runtime.LocalDockerServerRuntime:
-		// FIXME: construct image name
 		return containerRuntime.PushBuiltImage(img)
 		// TODO: case *container_runtime.LocalHostRuntime:
-	default:
-		panic("not implemented")
-	}
-}
-
-func (storage *RepoStagesStorage) CleanupLocalImage(img container_runtime.Image) error {
-	switch storage.ContainerRuntime.(type) {
-	case *container_runtime.LocalDockerServerRuntime:
-		dockerImage := img.(*container_runtime.DockerImage)
-		return dockerImage.Image.Untag()
 	default:
 		panic("not implemented")
 	}
@@ -263,16 +252,6 @@ func (storage *RepoStagesStorage) ShouldFetchImage(img container_runtime.Image) 
 	case *container_runtime.LocalDockerServerRuntime:
 		dockerImage := img.(*container_runtime.DockerImage)
 		return !dockerImage.Image.IsExistsLocally(), nil
-	default:
-		panic("not implemented")
-	}
-}
-
-func (storage *RepoStagesStorage) ShouldCleanupLocalImage(img container_runtime.Image) (bool, error) {
-	switch storage.ContainerRuntime.(type) {
-	case *container_runtime.LocalDockerServerRuntime:
-		dockerImage := img.(*container_runtime.DockerImage)
-		return dockerImage.Image.IsExistsLocally(), nil
 	default:
 		panic("not implemented")
 	}

--- a/pkg/storage/stages_storage.go
+++ b/pkg/storage/stages_storage.go
@@ -26,10 +26,7 @@ type StagesStorage interface {
 	FetchImage(img container_runtime.Image) error
 	// StoreImage will store a local image into the container-runtime, local built image should exist prior running store
 	StoreImage(img container_runtime.Image) error
-	// CleanupLocalImage will remove a local image from container-runtime
-	CleanupLocalImage(img container_runtime.Image) error
 	ShouldFetchImage(img container_runtime.Image) (bool, error)
-	ShouldCleanupLocalImage(img container_runtime.Image) (bool, error)
 
 	AddManagedImage(projectName, imageName string) error
 	RmManagedImage(projectName, imageName string) error


### PR DESCRIPTION
  - do not cleanup built and fetched stages from localhost — these will be reused as a cache on retries;
  - refactor build-phase: use separate StagesIterator when iterating stages;
  - move stages-storage common functions into separate stages_storage.go file.
