### PR TITLE
Remote storages support: remote stages storage usage in ci-env and 'werf stages mv' command prototype

### DIFF
--- a/cmd/werf/ci_env/ci_env.go
+++ b/cmd/werf/ci_env/ci_env.go
@@ -133,6 +133,9 @@ func generateGitlabEnvs(taggingStrategy string) error {
 	printHeader("DOCKER CONFIG", false)
 	printExportCommand("DOCKER_CONFIG", dockerConfig, true)
 
+	printHeader("STAGES_STORAGE", true)
+	printExportCommand("WERF_STAGES_STORAGE", fmt.Sprintf("%s/stages", ciRegistryImage), false)
+
 	printHeader("IMAGES REPO", true)
 	printExportCommand("WERF_IMAGES_REPO", ciRegistryImage, false)
 	printExportCommand("WERF_IMAGES_REPO_IMPLEMENTATION", imagesRepoImplementation, false)

--- a/cmd/werf/common/common.go
+++ b/cmd/werf/common/common.go
@@ -58,34 +58,16 @@ type CmdData struct {
 	SecretValues    *[]string
 	IgnoreSecretKey *bool
 
-	StagesStorage                      *string
-	StagesStorageRepoImplementation    *string
-	StagesStorageRepoDockerHubToken    *string
-	StagesStorageRepoDockerHubUsername *string
-	StagesStorageRepoDockerHubPassword *string
-	StagesStorageRepoGitHubToken       *string
-	StagesStorageRepoHarborUsername    *string
-	StagesStorageRepoHarborPassword    *string
+	CommonRepoData *RepoData
+
+	StagesStorage         *string
+	StagesStorageRepoData *RepoData
+
+	ImagesRepo     *string
+	ImagesRepoMode *string
+	ImagesRepoData *RepoData
 
 	Synchronization *string
-
-	ImagesRepo                  *string
-	ImagesRepoMode              *string
-	ImagesRepoImplementation    *string
-	ImagesRepoDockerHubToken    *string
-	ImagesRepoDockerHubUsername *string
-	ImagesRepoDockerHubPassword *string
-	ImagesRepoGitHubToken       *string
-	ImagesRepoHarborUsername    *string
-	ImagesRepoHarborPassword    *string
-
-	RepoImplementation    *string
-	RepoDockerHubToken    *string
-	RepoDockerHubUsername *string
-	RepoDockerHubPassword *string
-	RepoGitHubToken       *string
-	RepoHarborUsername    *string
-	RepoHarborPassword    *string
 
 	DockerConfig          *string
 	InsecureRegistry      *bool
@@ -113,9 +95,8 @@ type CmdData struct {
 }
 
 const (
-	CleaningCommandsForceOptionDescription = "Remove containers that are based on deleting werf docker images"
-
-	StubImagesRepoAddress = "stub/repository"
+	CleaningCommandsForceOptionDescription = "First remove containers that use werf docker images which are going to be deleted"
+	StubImagesRepoAddress                  = "stub/repository"
 )
 
 func GetLongCommandDescription(text string) string {
@@ -256,320 +237,38 @@ func SetupHelmReleaseStorageType(cmdData *CmdData, cmd *cobra.Command) {
 	cmd.Flags().StringVarP(cmdData.HelmReleaseStorageType, "helm-release-storage-type", "", defaultValue, fmt.Sprintf("helm storage driver to use. One of '%[1]s' or '%[2]s' (default $WERF_HELM_RELEASE_STORAGE_TYPE or '%[1]s')", helm.ConfigMapStorage, helm.SecretStorage))
 }
 
-func setupRepoImplementation(cmdData *CmdData, cmd *cobra.Command) {
-	if cmdData.RepoImplementation != nil {
-		return
-	}
+func SetupCommonRepoData(cmdData *CmdData, cmd *cobra.Command) {
+	cmdData.CommonRepoData = &RepoData{IsCommon: true}
 
-	usage := fmt.Sprintf(`Choose default repo implementation for images repo and stages storage repo.
-The following docker registry implementations are supported: %s.
-Default %s or auto mode (detect implementation by a registry).`,
-		strings.Join(docker_registry.ImplementationList(), ", "),
-		"$WERF_REPO_IMPLEMENTATION",
-	)
-
-	cmdData.RepoImplementation = new(string)
-	cmd.Flags().StringVarP(
-		cmdData.RepoImplementation,
-		"repo-implementation",
-		"",
-		os.Getenv("WERF_REPO_IMPLEMENTATION"),
-		usage,
-	)
-}
-
-func setupRepoDockerHubToken(cmdData *CmdData, cmd *cobra.Command) {
-	if cmdData.RepoDockerHubToken != nil {
-		return
-	}
-
-	cmdData.RepoDockerHubToken = new(string)
-	cmd.Flags().StringVarP(
-		cmdData.RepoDockerHubToken,
-		"repo-docker-hub-token",
-		"",
-		os.Getenv("WERF_REPO_DOCKER_HUB_TOKEN"),
-		"Default Docker Hub token for stages storage repo and images repo implementations (default $WERF_REPO_DOCKER_HUB_TOKEN).",
-	)
-}
-
-func setupRepoDockerHubUsername(cmdData *CmdData, cmd *cobra.Command) {
-	if cmdData.RepoDockerHubUsername != nil {
-		return
-	}
-
-	cmdData.RepoDockerHubUsername = new(string)
-	cmd.Flags().StringVarP(
-		cmdData.RepoDockerHubUsername,
-		"repo-docker-hub-username",
-		"",
-		os.Getenv("WERF_REPO_DOCKER_HUB_USERNAME"),
-		"Default Docker Hub username for stages storage repo and images repo implementations (default $WERF_REPO_DOCKER_HUB_USERNAME).",
-	)
-}
-
-func setupRepoDockerHubPassword(cmdData *CmdData, cmd *cobra.Command) {
-	if cmdData.RepoDockerHubPassword != nil {
-		return
-	}
-
-	cmdData.RepoDockerHubPassword = new(string)
-	cmd.Flags().StringVarP(
-		cmdData.RepoDockerHubPassword,
-		"repo-docker-hub-password",
-		"",
-		os.Getenv("WERF_REPO_DOCKER_HUB_PASSWORD"),
-		"Default Docker Hub password for stages storage repo and images repo implementations (default $WERF_REPO_DOCKER_HUB_PASSWORD).",
-	)
-}
-
-func setupRepoGitHubToken(cmdData *CmdData, cmd *cobra.Command) {
-	if cmdData.RepoGitHubToken != nil {
-		return
-	}
-
-	cmdData.RepoGitHubToken = new(string)
-	cmd.Flags().StringVarP(
-		cmdData.RepoGitHubToken,
-		"repo-github-token",
-		"",
-		os.Getenv("WERF_REPO_GITHUB_TOKEN"),
-		fmt.Sprintf("Default GitHub token for stages storage repo and images repo implementations (default $WERF_REPO_GITHUB_TOKEN)."),
-	)
-}
-
-func setupRepoHarborUsername(cmdData *CmdData, cmd *cobra.Command) {
-	if cmdData.RepoHarborUsername != nil {
-		return
-	}
-
-	cmdData.RepoHarborUsername = new(string)
-	cmd.Flags().StringVarP(
-		cmdData.RepoHarborUsername,
-		"repo-harbor-username",
-		"",
-		os.Getenv("WERF_REPO_HARBOR_USERNAME"),
-		"Default harbor username for stages storage repo and images repo implementations (default $WERF_REPO_HARBOR_USERNAME).",
-	)
-
-	_ = cmd.Flags().MarkHidden("repo-harbor-username")
-}
-
-func setupRepoHarborPassword(cmdData *CmdData, cmd *cobra.Command) {
-	if cmdData.RepoHarborPassword != nil {
-		return
-	}
-
-	cmdData.RepoHarborPassword = new(string)
-	cmd.Flags().StringVarP(
-		cmdData.RepoHarborPassword,
-		"repo-harbor-password",
-		"",
-		os.Getenv("WERF_REPO_HARBOR_PASSWORD"),
-		"Default harbor password for stages storage repo and images repo implementations (default $WERF_REPO_HARBOR_PASSWORD).",
-	)
-
-	_ = cmd.Flags().MarkHidden("repo-harbor-password")
+	SetupImplementationForRepoData(cmdData.CommonRepoData, cmd, "repo-implementation", []string{"WERF_REPO_IMPLEMENTATION"})
+	SetupDockerHubUsernameForRepoData(cmdData.CommonRepoData, cmd, "repo-docker-hub-username", []string{"WERF_REPO_DOCKER_HUB_USERNAME"})
+	SetupDockerHubPasswordForRepoData(cmdData.CommonRepoData, cmd, "repo-docker-hub-password", []string{"WERF_REPO_DOCKER_HUB_PASSWORD"})
+	SetupDockerHubTokenForRepoData(cmdData.CommonRepoData, cmd, "repo-docker-hub-token", []string{"WERF_REPO_DOCKER_HUB_TOKEN"})
+	SetupGithubTokenForRepoData(cmdData.CommonRepoData, cmd, "repo-github-token", []string{"WERF_REPO_GITHUB_TOKEN"})
+	SetupHarborUsernameForRepoData(cmdData.CommonRepoData, cmd, "repo-harbor-username", []string{"WERF_REPO_HARBOR_USERNAME"})
+	SetupHarborPasswordForRepoData(cmdData.CommonRepoData, cmd, "repo-harbor-password", []string{"WERF_REPO_HARBOR_PASSWORD"})
 }
 
 func SetupStagesStorageOptions(cmdData *CmdData, cmd *cobra.Command) {
-	setupStagesStorage(cmdData, cmd)
-
-	setupRepoImplementation(cmdData, cmd)
-	setupStagesStorageRepoImplementation(cmdData, cmd)
-
-	setupRepoDockerHubToken(cmdData, cmd)
-	setupRepoDockerHubUsername(cmdData, cmd)
-	setupRepoDockerHubPassword(cmdData, cmd)
-	setupRepoGitHubToken(cmdData, cmd)
-	setupRepoHarborUsername(cmdData, cmd)
-	setupRepoHarborPassword(cmdData, cmd)
-	setupStagesStorageRepoDockerHubToken(cmdData, cmd)
-	setupStagesStorageRepoDockerHubUsername(cmdData, cmd)
-	setupStagesStorageRepoDockerHubPassword(cmdData, cmd)
-	setupStagesStorageRepoGitHubToken(cmdData, cmd)
-	setupStagesStorageRepoHarborUsername(cmdData, cmd)
-	setupStagesStorageRepoHarborPassword(cmdData, cmd)
-
-	// TODO: add the following options for stages storage
+	// TODO: add the following options for images repo
 	SetupInsecureRegistry(cmdData, cmd)
 	SetupSkipTlsVerifyRegistry(cmdData, cmd)
-}
 
-func setupStagesStorageRepoImplementation(cmdData *CmdData, cmd *cobra.Command) {
-	var defaultValue string
-	for _, value := range []string{
-		os.Getenv("WERF_STAGES_STORAGE_REPO_IMPLEMENTATION"),
-		os.Getenv("WERF_REPO_IMPLEMENTATION"),
-	} {
-		if value != "" {
-			defaultValue = value
-			break
-		}
+	if cmdData.CommonRepoData == nil {
+		SetupCommonRepoData(cmdData, cmd)
 	}
 
-	usage := fmt.Sprintf(`Choose stages storage repo implementation.
-The following  docker registry implementations are supported: %s.
-Default $WERF_STAGES_STORAGE_REPO_IMPLEMENTATION, $WERF_REPO_IMPLEMENTATION or auto mode (detect implementation by a registry).`,
-		strings.Join(docker_registry.ImplementationList(), ", "),
-	)
+	setupStagesStorage(cmdData, cmd)
 
-	cmdData.StagesStorageRepoImplementation = new(string)
-	cmd.Flags().StringVarP(
-		cmdData.StagesStorageRepoImplementation,
-		"stages-storage-repo-implementation",
-		"",
-		defaultValue,
-		usage,
-	)
-}
+	cmdData.StagesStorageRepoData = &RepoData{DesignationStorageName: "stages storage"}
 
-func setupStagesStorageRepoDockerHubToken(cmdData *CmdData, cmd *cobra.Command) {
-	var defaultValue string
-	for _, value := range []string{
-		os.Getenv("WERF_STAGES_STORAGE_REPO_DOCKER_HUB_TOKEN"),
-		os.Getenv("WERF_REPO_DOCKER_HUB_TOKEN"),
-	} {
-		if value != "" {
-			defaultValue = value
-			break
-		}
-	}
-
-	usage := fmt.Sprintf("Docker Hub token for stages storage repo implementation (default $WERF_STAGES_STORAGE_REPO_DOCKER_HUB_TOKEN or $WERF_REPO_DOCKER_HUB_TOKEN).")
-
-	cmdData.StagesStorageRepoDockerHubUsername = new(string)
-	cmd.Flags().StringVarP(
-		cmdData.StagesStorageRepoDockerHubUsername,
-		"stages-storage-repo-docker-hub-token",
-		"",
-		defaultValue,
-		usage,
-	)
-}
-
-func setupStagesStorageRepoDockerHubUsername(cmdData *CmdData, cmd *cobra.Command) {
-	var defaultValue string
-	for _, value := range []string{
-		os.Getenv("WERF_STAGES_STORAGE_REPO_DOCKER_HUB_USERNAME"),
-		os.Getenv("WERF_REPO_DOCKER_HUB_USERNAME"),
-	} {
-		if value != "" {
-			defaultValue = value
-			break
-		}
-	}
-
-	usage := fmt.Sprintf("Docker Hub username for stages storage repo implementation (default $WERF_STAGES_STORAGE_REPO_DOCKER_HUB_USERNAME or $WERF_REPO_DOCKER_HUB_USERNAME).")
-
-	cmdData.StagesStorageRepoDockerHubUsername = new(string)
-	cmd.Flags().StringVarP(
-		cmdData.StagesStorageRepoDockerHubUsername,
-		"stages-storage-repo-docker-hub-username",
-		"",
-		defaultValue,
-		usage,
-	)
-}
-
-func setupStagesStorageRepoDockerHubPassword(cmdData *CmdData, cmd *cobra.Command) {
-	var defaultValue string
-	for _, value := range []string{
-		os.Getenv("WERF_STAGES_STORAGE_REPO_DOCKER_HUB_PASSWORD"),
-		os.Getenv("WERF_REPO_DOCKER_HUB_PASSWORD"),
-	} {
-		if value != "" {
-			defaultValue = value
-			break
-		}
-	}
-
-	usage := fmt.Sprintf("Docker Hub password for stages storage repo implementation (default $WERF_STAGES_STORAGE_REPO_DOCKER_HUB_PASSWORD or $WERF_REPO_DOCKER_HUB_PASSWORD).")
-
-	cmdData.StagesStorageRepoDockerHubPassword = new(string)
-	cmd.Flags().StringVarP(
-		cmdData.StagesStorageRepoDockerHubPassword,
-		"stages-storage-repo-docker-hub-password",
-		"",
-		defaultValue,
-		usage,
-	)
-}
-
-func setupStagesStorageRepoGitHubToken(cmdData *CmdData, cmd *cobra.Command) {
-	var defaultValue string
-	for _, value := range []string{
-		os.Getenv("WERF_STAGES_STORAGE_REPO_GITHUB_TOKEN"),
-		os.Getenv("WERF_REPO_GITHUB_TOKEN"),
-	} {
-		if value != "" {
-			defaultValue = value
-			break
-		}
-	}
-
-	usage := fmt.Sprintf("GitHub token for stages storage repo implementation (default $WERF_STAGES_STORAGE_REPO_GITHUB_TOKEN or $WERF_REPO_GITHUB_TOKEN).")
-
-	cmdData.StagesStorageRepoGitHubToken = new(string)
-	cmd.Flags().StringVarP(
-		cmdData.StagesStorageRepoGitHubToken,
-		"stages-storage-repo-github-token",
-		"",
-		defaultValue,
-		usage,
-	)
-}
-
-func setupStagesStorageRepoHarborUsername(cmdData *CmdData, cmd *cobra.Command) {
-	var defaultValue string
-	for _, value := range []string{
-		os.Getenv("WERF_STAGES_STORAGE_REPO_HARBOR_USERNAME"),
-		os.Getenv("WERF_REPO_HARBOR_USERNAME"),
-	} {
-		if value != "" {
-			defaultValue = value
-			break
-		}
-	}
-
-	usage := fmt.Sprintf("Harbor username for stages storage repo implementation (default $WERF_STAGES_STORAGE_REPO_HARBOR_USERNAME or $WERF_REPO_HARBOR_USERNAME).")
-
-	cmdData.StagesStorageRepoHarborUsername = new(string)
-	cmd.Flags().StringVarP(
-		cmdData.StagesStorageRepoHarborUsername,
-		"stages-storage-repo-harbor-username",
-		"",
-		defaultValue,
-		usage,
-	)
-
-	_ = cmd.Flags().MarkHidden("stages-storage-repo-harbor-username")
-}
-
-func setupStagesStorageRepoHarborPassword(cmdData *CmdData, cmd *cobra.Command) {
-	var defaultValue string
-	for _, value := range []string{
-		os.Getenv("WERF_STAGES_STORAGE_REPO_HARBOR_PASSWORD"),
-		os.Getenv("WERF_REPO_HARBOR_PASSWORD"),
-	} {
-		if value != "" {
-			defaultValue = value
-			break
-		}
-	}
-
-	usage := fmt.Sprintf("Harbor password for stages storage repo implementation (default $WERF_STAGES_STORAGE_REPO_HARBOR_PASSWORD or $WERF_REPO_HARBOR_PASSWORD).")
-
-	cmdData.StagesStorageRepoHarborPassword = new(string)
-	cmd.Flags().StringVarP(
-		cmdData.StagesStorageRepoHarborPassword,
-		"stages-storage-repo-harbor-password",
-		"",
-		defaultValue,
-		usage,
-	)
-
-	_ = cmd.Flags().MarkHidden("stages-storage-repo-harbor-password")
+	SetupImplementationForRepoData(cmdData.StagesStorageRepoData, cmd, "stages-storage-repo-implementation", []string{"WERF_STAGES_STORAGE_REPO_IMPLEMENTATION", "WERF_REPO_IMPLEMENTATION"})
+	SetupDockerHubUsernameForRepoData(cmdData.StagesStorageRepoData, cmd, "stages-storage-repo-docker-hub-username", []string{"WERF_STAGES_STORAGE_REPO_DOCKER_HUB_USERNAME", "WERF_REPO_DOCKER_HUB_USERNAME"})
+	SetupDockerHubPasswordForRepoData(cmdData.StagesStorageRepoData, cmd, "stages-storage-repo-docker-hub-password", []string{"WERF_STAGES_STORAGE_REPO_DOCKER_HUB_PASSWORD", "WERF_REPO_DOCKER_HUB_PASSWORD"})
+	SetupDockerHubTokenForRepoData(cmdData.StagesStorageRepoData, cmd, "stages-storage-repo-docker-hub-token", []string{"WERF_STAGES_STORAGE_REPO_DOCKER_HUB_TOKEN", "WERF_REPO_DOCKER_HUB_TOKEN"})
+	SetupGithubTokenForRepoData(cmdData.StagesStorageRepoData, cmd, "stages-storage-repo-github-token", []string{"WERF_STAGES_STORAGE_REPO_GITHUB_TOKEN", "WERF_REPO_GITHUB_TOKEN"})
+	SetupHarborUsernameForRepoData(cmdData.StagesStorageRepoData, cmd, "stages-storage-repo-harbor-username", []string{"WERF_STAGES_STORAGE_REPO_HARBOR_USERNAME", "WERF_REPO_HARBOR_USERNAME"})
+	SetupHarborPasswordForRepoData(cmdData.StagesStorageRepoData, cmd, "stages-storage-repo-harbor-password", []string{"WERF_STAGES_STORAGE_REPO_HARBOR_PASSWORD", "WERF_REPO_HARBOR_PASSWORD"})
 }
 
 func setupStagesStorage(cmdData *CmdData, cmd *cobra.Command) {
@@ -663,28 +362,26 @@ func hooksStatusProgressPeriodDefaultValue() *int64 {
 }
 
 func SetupImagesRepoOptions(cmdData *CmdData, cmd *cobra.Command) {
-	setupImagesRepo(cmdData, cmd)
-	setupImagesRepoMode(cmdData, cmd)
-
-	setupRepoImplementation(cmdData, cmd)
-	setupImagesRepoImplementation(cmdData, cmd)
-
-	setupRepoDockerHubToken(cmdData, cmd)
-	setupRepoDockerHubUsername(cmdData, cmd)
-	setupRepoDockerHubPassword(cmdData, cmd)
-	setupRepoGitHubToken(cmdData, cmd)
-	setupRepoHarborUsername(cmdData, cmd)
-	setupRepoHarborPassword(cmdData, cmd)
-	setupImagesRepoDockerHubToken(cmdData, cmd)
-	setupImagesRepoDockerHubUsername(cmdData, cmd)
-	setupImagesRepoDockerHubPassword(cmdData, cmd)
-	setupImagesRepoGitHubToken(cmdData, cmd)
-	setupImagesRepoHarborUsername(cmdData, cmd)
-	setupImagesRepoHarborPassword(cmdData, cmd)
-
 	// TODO: add the following options for images repo
 	SetupInsecureRegistry(cmdData, cmd)
 	SetupSkipTlsVerifyRegistry(cmdData, cmd)
+
+	if cmdData.CommonRepoData == nil {
+		SetupCommonRepoData(cmdData, cmd)
+	}
+
+	setupImagesRepo(cmdData, cmd)
+	setupImagesRepoMode(cmdData, cmd)
+
+	cmdData.ImagesRepoData = &RepoData{DesignationStorageName: "images repo"}
+
+	SetupImplementationForRepoData(cmdData.ImagesRepoData, cmd, "images-repo-implementation", []string{"WERF_IMAGES_REPO_IMPLEMENTATION", "WERF_REPO_IMPLEMENTATION"})
+	SetupDockerHubUsernameForRepoData(cmdData.ImagesRepoData, cmd, "images-repo-docker-hub-username", []string{"WERF_IMAGES_REPO_DOCKER_HUB_USERNAME", "WERF_REPO_DOCKER_HUB_USERNAME"})
+	SetupDockerHubPasswordForRepoData(cmdData.ImagesRepoData, cmd, "images-repo-docker-hub-password", []string{"WERF_IMAGES_REPO_DOCKER_HUB_PASSWORD", "WERF_REPO_DOCKER_HUB_PASSWORD"})
+	SetupDockerHubTokenForRepoData(cmdData.ImagesRepoData, cmd, "images-repo-docker-hub-token", []string{"WERF_IMAGES_REPO_DOCKER_HUB_TOKEN", "WERF_REPO_DOCKER_HUB_TOKEN"})
+	SetupGithubTokenForRepoData(cmdData.ImagesRepoData, cmd, "images-repo-github-token", []string{"WERF_IMAGES_REPO_GITHUB_TOKEN", "WERF_REPO_GITHUB_TOKEN"})
+	SetupHarborUsernameForRepoData(cmdData.ImagesRepoData, cmd, "images-repo-harbor-username", []string{"WERF_IMAGES_REPO_HARBOR_USERNAME", "WERF_REPO_HARBOR_USERNAME"})
+	SetupHarborPasswordForRepoData(cmdData.ImagesRepoData, cmd, "images-repo-harbor-password", []string{"WERF_IMAGES_REPO_HARBOR_PASSWORD", "WERF_REPO_HARBOR_PASSWORD"})
 }
 
 func setupImagesRepo(cmdData *CmdData, cmd *cobra.Command) {
@@ -702,182 +399,6 @@ func setupImagesRepoMode(cmdData *CmdData, cmd *cobra.Command) {
 
 	cmd.Flags().StringVarP(cmdData.ImagesRepoMode, "images-repo-mode", "", defaultValue, fmt.Sprintf(`Define how to store in images repo: %s or %s.
 Default $WERF_IMAGES_REPO_MODE or auto mode`, docker_registry.MultirepoRepoMode, docker_registry.MonorepoRepoMode))
-}
-
-func setupImagesRepoImplementation(cmdData *CmdData, cmd *cobra.Command) {
-	var defaultValue string
-	for _, value := range []string{
-		os.Getenv("WERF_IMAGES_REPO_IMPLEMENTATION"),
-		os.Getenv("WERF_REPO_IMPLEMENTATION"),
-	} {
-		if value != "" {
-			defaultValue = value
-			break
-		}
-	}
-
-	usage := fmt.Sprintf(`Choose images repo implementation.
-The following docker registry implementations are supported: %s.
-Default $WERF_IMAGES_REPO_IMPLEMENTATION, $WERF_REPO_IMPLEMENTATION or auto mode (detect implementation by a registry).`,
-		strings.Join(docker_registry.ImplementationList(), ", "),
-	)
-
-	cmdData.ImagesRepoImplementation = new(string)
-	cmd.Flags().StringVarP(
-		cmdData.ImagesRepoImplementation,
-		"images-repo-implementation",
-		"",
-		defaultValue,
-		usage,
-	)
-}
-
-func setupImagesRepoDockerHubToken(cmdData *CmdData, cmd *cobra.Command) {
-	var defaultValue string
-	for _, value := range []string{
-		os.Getenv("WERF_IMAGES_REPO_DOCKER_HUB_TOKEN"),
-		os.Getenv("WERF_REPO_DOCKER_HUB_TOKEN"),
-	} {
-		if value != "" {
-			defaultValue = value
-			break
-		}
-	}
-
-	usage := fmt.Sprintf("Docker Hub token for images repo implementation (default $WERF_IMAGES_REPO_DOCKER_HUB_TOKEN or $WERF_REPO_DOCKER_HUB_TOKEN).")
-
-	cmdData.ImagesRepoDockerHubToken = new(string)
-	cmd.Flags().StringVarP(
-		cmdData.ImagesRepoDockerHubToken,
-		"images-repo-docker-hub-token",
-		"",
-		defaultValue,
-		usage,
-	)
-}
-
-func setupImagesRepoDockerHubUsername(cmdData *CmdData, cmd *cobra.Command) {
-	var defaultValue string
-	for _, value := range []string{
-		os.Getenv("WERF_IMAGES_REPO_DOCKER_HUB_USERNAME"),
-		os.Getenv("WERF_REPO_DOCKER_HUB_USERNAME"),
-	} {
-		if value != "" {
-			defaultValue = value
-			break
-		}
-	}
-
-	usage := fmt.Sprintf("Docker Hub username for images repo implementation (default $WERF_IMAGES_REPO_DOCKER_HUB_USERNAME or $WERF_REPO_DOCKER_HUB_USERNAME).")
-
-	cmdData.ImagesRepoDockerHubUsername = new(string)
-	cmd.Flags().StringVarP(
-		cmdData.ImagesRepoDockerHubUsername,
-		"images-repo-docker-hub-username",
-		"",
-		defaultValue,
-		usage,
-	)
-}
-
-func setupImagesRepoDockerHubPassword(cmdData *CmdData, cmd *cobra.Command) {
-	var defaultValue string
-	for _, value := range []string{
-		os.Getenv("WERF_IMAGES_REPO_DOCKER_HUB_PASSWORD"),
-		os.Getenv("WERF_REPO_DOCKER_HUB_PASSWORD"),
-	} {
-		if value != "" {
-			defaultValue = value
-			break
-		}
-	}
-
-	usage := fmt.Sprintf("Docker Hub password for images repo implementation (default $WERF_IMAGES_REPO_DOCKER_HUB_PASSWORD or $WERF_REPO_DOCKER_HUB_PASSWORD).")
-
-	cmdData.ImagesRepoDockerHubPassword = new(string)
-	cmd.Flags().StringVarP(
-		cmdData.ImagesRepoDockerHubPassword,
-		"images-repo-docker-hub-password",
-		"",
-		defaultValue,
-		usage,
-	)
-}
-
-func setupImagesRepoGitHubToken(cmdData *CmdData, cmd *cobra.Command) {
-	var defaultValue string
-	for _, value := range []string{
-		os.Getenv("WERF_IMAGES_REPO_GITHUB_TOKEN"),
-		os.Getenv("WERF_REPO_GITHUB_TOKEN"),
-	} {
-		if value != "" {
-			defaultValue = value
-			break
-		}
-	}
-
-	usage := fmt.Sprintf("GitHub token for images repo implementation (default $WERF_IMAGES_REPO_GITHUB_TOKEN or $WERF_REPO_GITHUB_TOKEN).")
-
-	cmdData.ImagesRepoGitHubToken = new(string)
-	cmd.Flags().StringVarP(
-		cmdData.ImagesRepoGitHubToken,
-		"images-repo-github-token",
-		"",
-		defaultValue,
-		usage,
-	)
-}
-
-func setupImagesRepoHarborUsername(cmdData *CmdData, cmd *cobra.Command) {
-	var defaultValue string
-	for _, value := range []string{
-		os.Getenv("WERF_IMAGES_REPO_HARBOR_USERNAME"),
-		os.Getenv("WERF_REPO_HARBOR_USERNAME"),
-	} {
-		if value != "" {
-			defaultValue = value
-			break
-		}
-	}
-
-	usage := fmt.Sprintf("Harbor username for images repo implementation (default $WERF_IMAGES_REPO_HARBOR_USERNAME or $WERF_REPO_HARBOR_USERNAME).")
-
-	cmdData.ImagesRepoHarborUsername = new(string)
-	cmd.Flags().StringVarP(
-		cmdData.ImagesRepoHarborUsername,
-		"images-repo-harbor-username",
-		"",
-		defaultValue,
-		usage,
-	)
-
-	_ = cmd.Flags().MarkHidden("images-repo-harbor-username")
-}
-
-func setupImagesRepoHarborPassword(cmdData *CmdData, cmd *cobra.Command) {
-	var defaultValue string
-	for _, value := range []string{
-		os.Getenv("WERF_IMAGES_REPO_HARBOR_PASSWORD"),
-		os.Getenv("WERF_REPO_HARBOR_PASSWORD"),
-	} {
-		if value != "" {
-			defaultValue = value
-			break
-		}
-	}
-
-	usage := fmt.Sprintf("Harbor password for images repo implementation (default $WERF_IMAGES_REPO_HARBOR_PASSWORD or $WERF_REPO_HARBOR_PASSWORD).")
-
-	cmdData.ImagesRepoHarborPassword = new(string)
-	cmd.Flags().StringVarP(
-		cmdData.ImagesRepoHarborPassword,
-		"images-repo-harbor-password",
-		"",
-		defaultValue,
-		usage,
-	)
-
-	_ = cmd.Flags().MarkHidden("images-repo-harbor-password")
 }
 
 func SetupInsecureRegistry(cmdData *CmdData, cmd *cobra.Command) {
@@ -1315,43 +836,10 @@ func getImagesRepo(projectName string, cmdData *CmdData, optionalStubRepoAddress
 		return nil, err
 	}
 
-	imagesRepoImplementation := *cmdData.ImagesRepoImplementation
-	if imagesRepoImplementation == "" {
-		imagesRepoImplementation = *cmdData.RepoImplementation
-	}
+	repoData := MergeRepoData(cmdData.ImagesRepoData, cmdData.CommonRepoData)
 
-	if err := validateRepoImplementation(imagesRepoImplementation); err != nil {
+	if err := ValidateRepoImplementation(*repoData.Implementation); err != nil {
 		return nil, err
-	}
-
-	imagesRepoDockerHubToken := *cmdData.ImagesRepoDockerHubToken
-	if imagesRepoDockerHubToken == "" {
-		imagesRepoDockerHubToken = *cmdData.RepoDockerHubToken
-	}
-
-	imagesRepoDockerHubUsername := *cmdData.ImagesRepoDockerHubUsername
-	if imagesRepoDockerHubUsername == "" {
-		imagesRepoDockerHubUsername = *cmdData.RepoDockerHubUsername
-	}
-
-	imagesRepoDockerHubPassword := *cmdData.ImagesRepoDockerHubPassword
-	if imagesRepoDockerHubPassword == "" {
-		imagesRepoDockerHubPassword = *cmdData.RepoDockerHubPassword
-	}
-
-	imagesRepoGitHubToken := *cmdData.ImagesRepoGitHubToken
-	if imagesRepoGitHubToken == "" {
-		imagesRepoGitHubToken = *cmdData.RepoGitHubToken
-	}
-
-	imagesRepoHarborUsername := *cmdData.ImagesRepoHarborUsername
-	if imagesRepoHarborUsername == "" {
-		imagesRepoHarborUsername = *cmdData.RepoHarborUsername
-	}
-
-	imagesRepoHarborPassword := *cmdData.ImagesRepoHarborPassword
-	if imagesRepoHarborPassword == "" {
-		imagesRepoHarborPassword = *cmdData.RepoHarborPassword
 	}
 
 	return storage.NewImagesRepo(
@@ -1360,16 +848,15 @@ func getImagesRepo(projectName string, cmdData *CmdData, optionalStubRepoAddress
 		imagesRepoMode,
 		storage.ImagesRepoOptions{
 			DockerImagesRepoOptions: storage.DockerImagesRepoOptions{
-				Implementation: imagesRepoImplementation,
+				Implementation: *repoData.Implementation,
 				DockerRegistryOptions: docker_registry.DockerRegistryOptions{
 					InsecureRegistry:      *cmdData.InsecureRegistry,
 					SkipTlsVerifyRegistry: *cmdData.SkipTlsVerifyRegistry,
-					DockerHubToken:        imagesRepoDockerHubToken,
-					DockerHubUsername:     imagesRepoDockerHubUsername,
-					DockerHubPassword:     imagesRepoDockerHubPassword,
-					GitHubToken:           imagesRepoGitHubToken,
-					HarborUsername:        imagesRepoHarborUsername,
-					HarborPassword:        imagesRepoHarborPassword,
+					DockerHubUsername:     *repoData.DockerHubUsername,
+					DockerHubPassword:     *repoData.DockerHubPassword,
+					GitHubToken:           *repoData.GitHubToken,
+					HarborUsername:        *repoData.HarborUsername,
+					HarborPassword:        *repoData.HarborPassword,
 				},
 			},
 		},
@@ -1382,38 +869,10 @@ func GetStagesStorage(containerRuntime container_runtime.ContainerRuntime, cmdDa
 		return nil, err
 	}
 
-	stagesStorageRepoImplementation := *cmdData.StagesStorageRepoImplementation
-	if stagesStorageRepoImplementation == "" {
-		stagesStorageRepoImplementation = *cmdData.RepoImplementation
-	}
+	repoData := MergeRepoData(cmdData.StagesStorageRepoData, cmdData.CommonRepoData)
 
-	if err := validateRepoImplementation(stagesStorageRepoImplementation); err != nil {
+	if err := ValidateRepoImplementation(*repoData.Implementation); err != nil {
 		return nil, err
-	}
-
-	stagesStorageRepoGitHubToken := *cmdData.StagesStorageRepoGitHubToken
-	if stagesStorageRepoGitHubToken == "" {
-		stagesStorageRepoGitHubToken = *cmdData.RepoGitHubToken
-	}
-
-	stagesStorageRepoDockerHubUsername := *cmdData.StagesStorageRepoDockerHubUsername
-	if stagesStorageRepoDockerHubUsername == "" {
-		stagesStorageRepoDockerHubUsername = *cmdData.RepoDockerHubUsername
-	}
-
-	stagesStorageRepoDockerHubPassword := *cmdData.StagesStorageRepoDockerHubPassword
-	if stagesStorageRepoDockerHubPassword == "" {
-		stagesStorageRepoDockerHubPassword = *cmdData.RepoDockerHubPassword
-	}
-
-	stagesStorageRepoHarborUsername := *cmdData.StagesStorageRepoHarborUsername
-	if stagesStorageRepoHarborUsername == "" {
-		stagesStorageRepoHarborUsername = *cmdData.RepoHarborUsername
-	}
-
-	stagesStorageRepoHarborPassword := *cmdData.StagesStorageRepoHarborPassword
-	if stagesStorageRepoHarborPassword == "" {
-		stagesStorageRepoHarborPassword = *cmdData.RepoHarborPassword
 	}
 
 	return storage.NewStagesStorage(
@@ -1421,15 +880,16 @@ func GetStagesStorage(containerRuntime container_runtime.ContainerRuntime, cmdDa
 		containerRuntime,
 		storage.StagesStorageOptions{
 			RepoStagesStorageOptions: storage.RepoStagesStorageOptions{
-				Implementation: stagesStorageRepoImplementation,
+				Implementation: *repoData.Implementation,
 				DockerRegistryOptions: docker_registry.DockerRegistryOptions{
 					InsecureRegistry:      *cmdData.InsecureRegistry,
 					SkipTlsVerifyRegistry: *cmdData.SkipTlsVerifyRegistry,
-					DockerHubToken:        stagesStorageRepoGitHubToken,
-					DockerHubUsername:     stagesStorageRepoDockerHubUsername,
-					DockerHubPassword:     stagesStorageRepoDockerHubPassword,
-					HarborUsername:        stagesStorageRepoHarborUsername,
-					HarborPassword:        stagesStorageRepoHarborPassword,
+					DockerHubUsername:     *repoData.DockerHubUsername,
+					DockerHubPassword:     *repoData.DockerHubPassword,
+					DockerHubToken:        *repoData.DockerHubToken,
+					GitHubToken:           *repoData.GitHubToken,
+					HarborUsername:        *repoData.HarborUsername,
+					HarborPassword:        *repoData.HarborPassword,
 				},
 			},
 		},
@@ -1662,7 +1122,7 @@ func DockerRegistryInit(cmdData *CmdData) error {
 	return docker_registry.Init(*cmdData.InsecureRegistry, *cmdData.SkipTlsVerifyRegistry)
 }
 
-func validateRepoImplementation(implementation string) error {
+func ValidateRepoImplementation(implementation string) error {
 	supportedValues := docker_registry.ImplementationList()
 	supportedValues = append(supportedValues, "auto", "")
 

--- a/cmd/werf/common/storage_repo_data.go
+++ b/cmd/werf/common/storage_repo_data.go
@@ -1,0 +1,205 @@
+package common
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/flant/werf/pkg/docker_registry"
+	"github.com/spf13/cobra"
+)
+
+type RepoData struct {
+	IsCommon               bool
+	DesignationStorageName string
+
+	Implementation    *string
+	DockerHubUsername *string
+	DockerHubPassword *string
+	DockerHubToken    *string
+	GitHubToken       *string
+	HarborUsername    *string
+	HarborPassword    *string
+}
+
+func MergeRepoData(repoDataArr ...*RepoData) *RepoData {
+	res := &RepoData{}
+
+	for _, repoData := range repoDataArr {
+		if res.Implementation ==    nil || *res.Implementation == "" {
+			res.Implementation = repoData.Implementation
+		}
+		if res.DockerHubUsername == nil || *res.DockerHubUsername == "" {
+			res.DockerHubUsername = repoData.DockerHubUsername
+		}
+		if res.DockerHubPassword == nil || *res.DockerHubPassword == "" {
+			res.DockerHubPassword = repoData.DockerHubPassword
+		}
+		if res.DockerHubToken == nil || *res.DockerHubToken == "" {
+			res.DockerHubToken = repoData.DockerHubToken
+		}
+		if res.GitHubToken == nil ||  *res.GitHubToken == "" {
+			res.GitHubToken = repoData.GitHubToken
+		}
+		if res.HarborUsername == nil ||  *res.HarborUsername == "" {
+			res.HarborUsername = repoData.HarborUsername
+		}
+		if res.HarborPassword == nil || *res.HarborPassword == "" {
+			res.HarborPassword = repoData.HarborPassword
+		}
+	}
+
+	return res
+}
+
+func SetupImplementationForRepoData(repoData *RepoData, cmd *cobra.Command, paramName string, paramEnvNames []string) {
+	var usageTitle string
+	if repoData.IsCommon {
+		usageTitle = "Choose common repo implementation for any stages storage or images repo specified for the command"
+	} else {
+		usageTitle = fmt.Sprintf("Choose repo implementation for %s", repoData.DesignationStorageName)
+	}
+
+	repoData.Implementation = new(string)
+	cmd.Flags().StringVarP(
+		repoData.Implementation,
+		paramName,
+		"",
+		getDefaultValueByParamEnvNames(paramEnvNames),
+		fmt.Sprintf(`%s.
+The following docker registry implementations are supported: %s.
+Default %s or auto mode (detect implementation by a registry).`,
+			usageTitle,
+			strings.Join(docker_registry.ImplementationList(), ", "),
+			strings.Join(getParamEnvNamesForUsageDescription(paramEnvNames), ", "),
+		),
+	)
+}
+
+func SetupDockerHubUsernameForRepoData(repoData *RepoData, cmd *cobra.Command, paramName string, paramEnvNames []string) {
+	var usage string
+	if repoData.IsCommon {
+		usage = fmt.Sprintf("Common Docker Hub username for any stages storage or images repo specified for the command (default %s)", strings.Join(getParamEnvNamesForUsageDescription(paramEnvNames), ", "))
+	} else {
+		usage = fmt.Sprintf("Docker Hub username for %s (default %s)", repoData.DesignationStorageName, strings.Join(getParamEnvNamesForUsageDescription(paramEnvNames), ", "))
+	}
+
+	repoData.DockerHubUsername = new(string)
+	cmd.Flags().StringVarP(
+		repoData.DockerHubUsername,
+		paramName,
+		"",
+		getDefaultValueByParamEnvNames(paramEnvNames),
+		usage,
+	)
+}
+
+func SetupDockerHubPasswordForRepoData(repoData *RepoData, cmd *cobra.Command, paramName string, paramEnvNames []string) {
+	var usage string
+	if repoData.IsCommon {
+		usage = fmt.Sprintf("Common Docker Hub password for any stages storage or images repo specified for the command (default %s)", strings.Join(getParamEnvNamesForUsageDescription(paramEnvNames), ", "))
+	} else {
+		usage = fmt.Sprintf("Docker Hub password for %s (default %s)", repoData.DesignationStorageName, strings.Join(getParamEnvNamesForUsageDescription(paramEnvNames), ", "))
+	}
+
+	repoData.DockerHubPassword = new(string)
+	cmd.Flags().StringVarP(
+		repoData.DockerHubPassword,
+		paramName,
+		"",
+		getDefaultValueByParamEnvNames(paramEnvNames),
+		usage,
+	)
+}
+
+func SetupDockerHubTokenForRepoData(repoData *RepoData, cmd *cobra.Command, paramName string, paramEnvNames []string) {
+	var usage string
+	if repoData.IsCommon {
+		usage = fmt.Sprintf("Common Docker Hub token for any stages storage or images repo specified for the command (default %s)", strings.Join(getParamEnvNamesForUsageDescription(paramEnvNames), ", "))
+	} else {
+		usage = fmt.Sprintf("Docker Hub token for %s (default %s)", repoData.DesignationStorageName, strings.Join(getParamEnvNamesForUsageDescription(paramEnvNames), ", "))
+	}
+
+	repoData.DockerHubToken = new(string)
+	cmd.Flags().StringVarP(
+		repoData.DockerHubToken,
+		paramName,
+		"",
+		getDefaultValueByParamEnvNames(paramEnvNames),
+		usage,
+	)
+}
+
+func SetupGithubTokenForRepoData(repoData *RepoData, cmd *cobra.Command, paramName string, paramEnvNames []string) {
+	var usage string
+	if repoData.IsCommon {
+		usage = fmt.Sprintf("Common GitHub token for any stages storage or images repo specified for the command (default %s)", strings.Join(getParamEnvNamesForUsageDescription(paramEnvNames), ", "))
+	} else {
+		usage = fmt.Sprintf("GitHub token for %s (default %s)", repoData.DesignationStorageName, strings.Join(getParamEnvNamesForUsageDescription(paramEnvNames), ", "))
+	}
+
+	repoData.GitHubToken = new(string)
+	cmd.Flags().StringVarP(
+		repoData.GitHubToken,
+		paramName,
+		"",
+		getDefaultValueByParamEnvNames(paramEnvNames),
+		usage,
+	)
+}
+
+func SetupHarborUsernameForRepoData(repoData *RepoData, cmd *cobra.Command, paramName string, paramEnvNames []string) {
+	var usage string
+	if repoData.IsCommon {
+		usage = fmt.Sprintf("Common Harbor username for any stages storage or images repo specified for the command (default %s)", strings.Join(getParamEnvNamesForUsageDescription(paramEnvNames), ", "))
+	} else {
+		usage = fmt.Sprintf("Harbor username for %s (default %s)", repoData.DesignationStorageName, strings.Join(getParamEnvNamesForUsageDescription(paramEnvNames), ", "))
+	}
+
+	repoData.HarborUsername = new(string)
+	cmd.Flags().StringVarP(
+		repoData.HarborUsername,
+		paramName,
+		"",
+		getDefaultValueByParamEnvNames(paramEnvNames),
+		usage,
+	)
+}
+
+func SetupHarborPasswordForRepoData(repoData *RepoData, cmd *cobra.Command, paramName string, paramEnvNames []string) {
+	var usage string
+	if repoData.IsCommon {
+		usage = fmt.Sprintf("Common Harbor password for any stages storage or images repo specified for the command (default %s)", strings.Join(getParamEnvNamesForUsageDescription(paramEnvNames), ", "))
+	} else {
+		usage = fmt.Sprintf("Harbor password for %s (default %s)", repoData.DesignationStorageName, strings.Join(getParamEnvNamesForUsageDescription(paramEnvNames), ", "))
+	}
+
+	repoData.HarborPassword = new(string)
+	cmd.Flags().StringVarP(
+		repoData.HarborPassword,
+		paramName,
+		"",
+		getDefaultValueByParamEnvNames(paramEnvNames),
+		usage,
+	)
+}
+
+func getDefaultValueByParamEnvNames(paramEnvNames []string) string {
+	var defaultValue string
+	for _, paramEnvName := range paramEnvNames {
+		value := os.Getenv(paramEnvName)
+		if value != "" {
+			defaultValue = value
+			break
+		}
+	}
+	return defaultValue
+}
+
+func getParamEnvNamesForUsageDescription(paramEnvNames []string) []string {
+	paramEnvNamesWithDollar := []string{}
+	for _, paramEnvName := range paramEnvNames {
+		paramEnvNamesWithDollar = append(paramEnvNamesWithDollar, "$"+paramEnvName)
+	}
+	return paramEnvNamesWithDollar
+}

--- a/cmd/werf/main.go
+++ b/cmd/werf/main.go
@@ -38,6 +38,7 @@ import (
 
 	stages_build "github.com/flant/werf/cmd/werf/stages/build"
 	stages_cleanup "github.com/flant/werf/cmd/werf/stages/cleanup"
+	stages_mv "github.com/flant/werf/cmd/werf/stages/mv"
 	stages_purge "github.com/flant/werf/cmd/werf/stages/purge"
 
 	stage_image "github.com/flant/werf/cmd/werf/stage/image"
@@ -194,6 +195,7 @@ func stagesCmd() *cobra.Command {
 		stages_build.NewCmd(),
 		stages_cleanup.NewCmd(),
 		stages_purge.NewCmd(),
+		stages_mv.NewCmd(),
 	)
 
 	return cmd

--- a/cmd/werf/stages/mv/main.go
+++ b/cmd/werf/stages/mv/main.go
@@ -1,0 +1,356 @@
+package mv
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/flant/werf/pkg/image"
+
+	"github.com/flant/werf/pkg/docker_registry"
+	"github.com/flant/werf/pkg/storage"
+
+	"github.com/flant/logboek"
+	"github.com/flant/shluz"
+	"github.com/flant/werf/cmd/werf/common"
+	"github.com/flant/werf/pkg/container_runtime"
+	"github.com/flant/werf/pkg/docker"
+	"github.com/flant/werf/pkg/werf"
+	"github.com/spf13/cobra"
+)
+
+var cmdData struct {
+	FromStagesStorage         *string
+	FromStagesStorageRepoData *common.RepoData
+
+	ToStagesStorage         *string
+	ToStagesStorageRepoData *common.RepoData
+}
+
+var commonCmdData common.CmdData
+
+func NewCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:                   "mv",
+		DisableFlagsInUseLine: true,
+		Short:                 "Move project stages from one stages storage to another",
+		Long:                  common.GetLongCommandDescription("Move project stages from one stages storage to another"),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := common.ProcessLogOptions(&commonCmdData); err != nil {
+				common.PrintHelp(cmd)
+				return err
+			}
+
+			common.LogVersion()
+
+			return common.LogRunningTime(func() error {
+				return runMv()
+			})
+		},
+	}
+
+	common.SetupDir(&commonCmdData, cmd)
+	common.SetupTmpDir(&commonCmdData, cmd)
+	common.SetupHomeDir(&commonCmdData, cmd)
+
+	common.SetupSynchronization(&commonCmdData, cmd)
+	common.SetupDockerConfig(&commonCmdData, cmd, "Command needs granted permissions to read, pull and delete images from the specified stages storages")
+	common.SetupInsecureRegistry(&commonCmdData, cmd)
+	common.SetupSkipTlsVerifyRegistry(&commonCmdData, cmd)
+
+	common.SetupLogOptions(&commonCmdData, cmd)
+	common.SetupLogProjectDir(&commonCmdData, cmd)
+
+	SetupFromStagesStorage(cmd)
+	SetupToStagesStorage(cmd)
+
+	return cmd
+}
+
+func SetupFromStagesStorage(cmd *cobra.Command) {
+	if commonCmdData.CommonRepoData == nil {
+		common.SetupCommonRepoData(&commonCmdData, cmd)
+	}
+
+	cmdData.FromStagesStorage = new(string)
+	cmd.Flags().StringVarP(cmdData.FromStagesStorage, "from-stages-storage", "", os.Getenv("WERF_FROM_STAGES_STORAGE"), fmt.Sprintf("Source stages storage from which stages will be moved (docker repo address or :local should be specified, default $WERF_FROM_STAGES_STORAGE environment)."))
+
+	cmdData.FromStagesStorageRepoData = &common.RepoData{DesignationStorageName: "source stages storage"}
+
+	common.SetupImplementationForRepoData(cmdData.FromStagesStorageRepoData, cmd, "from-stages-storage-repo-implementation", []string{"WERF_FROM_STAGES_STORAGE_REPO_IMPLEMENTATION", "WERF_REPO_IMPLEMENTATION"})
+	common.SetupDockerHubUsernameForRepoData(cmdData.FromStagesStorageRepoData, cmd, "from-stages-storage-repo-docker-hub-username", []string{"WERF_FROM_STAGES_STORAGE_REPO_DOCKER_HUB_USERNAME", "WERF_REPO_DOCKER_HUB_USERNAME"})
+	common.SetupDockerHubPasswordForRepoData(cmdData.FromStagesStorageRepoData, cmd, "from-stages-storage-repo-docker-hub-password", []string{"WERF_FROM_STAGES_STORAGE_REPO_DOCKER_HUB_PASSWORD", "WERF_REPO_DOCKER_HUB_PASSWORD"})
+	common.SetupGithubTokenForRepoData(cmdData.FromStagesStorageRepoData, cmd, "from-stages-storage-repo-github-token", []string{"WERF_FROM_STAGES_STORAGE_REPO_GITHUB_TOKEN", "WERF_REPO_GITHUB_TOKEN"})
+	common.SetupHarborUsernameForRepoData(cmdData.FromStagesStorageRepoData, cmd, "from-stages-storage-repo-harbor-username", []string{"WERF_FROM_STAGES_STORAGE_REPO_HARBOR_USERNAME", "WERF_REPO_HARBOR_USERNAME"})
+	common.SetupHarborPasswordForRepoData(cmdData.FromStagesStorageRepoData, cmd, "from-stages-storage-repo-harbor-password", []string{"WERF_FROM_STAGES_STORAGE_REPO_HARBOR_PASSWORD", "WERF_REPO_HARBOR_PASSWORD"})
+}
+
+func SetupToStagesStorage(cmd *cobra.Command) {
+	if commonCmdData.CommonRepoData == nil {
+		common.SetupCommonRepoData(&commonCmdData, cmd)
+	}
+
+	cmdData.ToStagesStorage = new(string)
+	cmd.Flags().StringVarP(cmdData.ToStagesStorage, "to-stages-storage", "", os.Getenv("WERF_TO_STAGES_STORAGE"), fmt.Sprintf("Destination stages storage to which stages will be moved (docker repo address or :local should be specified, default $WERF_TO_STAGES_STORAGE environment)."))
+
+	cmdData.ToStagesStorageRepoData = &common.RepoData{DesignationStorageName: "destination stages storage"}
+
+	common.SetupImplementationForRepoData(cmdData.ToStagesStorageRepoData, cmd, "to-stages-storage-repo-implementation", []string{"WERF_TO_STAGES_STORAGE_REPO_IMPLEMENTATION", "WERF_REPO_IMPLEMENTATION"})
+	common.SetupDockerHubUsernameForRepoData(cmdData.ToStagesStorageRepoData, cmd, "to-stages-storage-repo-docker-hub-username", []string{"WERF_TO_STAGES_STORAGE_REPO_DOCKER_HUB_USERNAME", "WERF_REPO_DOCKER_HUB_USERNAME"})
+	common.SetupDockerHubPasswordForRepoData(cmdData.ToStagesStorageRepoData, cmd, "to-stages-storage-repo-docker-hub-password", []string{"WERF_TO_STAGES_STORAGE_REPO_DOCKER_HUB_PASSWORD", "WERF_REPO_DOCKER_HUB_PASSWORD"})
+	common.SetupGithubTokenForRepoData(cmdData.ToStagesStorageRepoData, cmd, "to-stages-storage-repo-github-token", []string{"WERF_TO_STAGES_STORAGE_REPO_GITHUB_TOKEN", "WERF_REPO_GITHUB_TOKEN"})
+	common.SetupHarborUsernameForRepoData(cmdData.ToStagesStorageRepoData, cmd, "to-stages-storage-repo-harbor-username", []string{"WERF_TO_STAGES_STORAGE_REPO_HARBOR_USERNAME", "WERF_REPO_HARBOR_USERNAME"})
+	common.SetupHarborPasswordForRepoData(cmdData.ToStagesStorageRepoData, cmd, "to-stages-storage-repo-harbor-password", []string{"WERF_TO_STAGES_STORAGE_REPO_HARBOR_PASSWORD", "WERF_REPO_HARBOR_PASSWORD"})
+}
+
+func NewFromStagesStorage(containerRuntime container_runtime.ContainerRuntime) (storage.StagesStorage, error) {
+	if *cmdData.FromStagesStorage == "" {
+		return nil, fmt.Errorf("--from-stages-storage=ADDRESS param required")
+	}
+
+	repoData := common.MergeRepoData(cmdData.FromStagesStorageRepoData, commonCmdData.CommonRepoData)
+
+	if err := common.ValidateRepoImplementation(*repoData.Implementation); err != nil {
+		return nil, err
+	}
+
+	return NewStagesStorage(*cmdData.FromStagesStorage, repoData, containerRuntime)
+}
+
+func NewToStagesStorage(containerRuntime container_runtime.ContainerRuntime) (storage.StagesStorage, error) {
+	if *cmdData.ToStagesStorage == "" {
+		return nil, fmt.Errorf("--to-stages-storage=ADDRESS param required")
+	}
+
+	repoData := common.MergeRepoData(cmdData.ToStagesStorageRepoData, commonCmdData.CommonRepoData)
+
+	if err := common.ValidateRepoImplementation(*repoData.Implementation); err != nil {
+		return nil, err
+	}
+
+	return NewStagesStorage(*cmdData.ToStagesStorage, repoData, containerRuntime)
+}
+
+func NewStagesStorage(stagesStorageAddress string, repoData *common.RepoData, containerRuntime container_runtime.ContainerRuntime) (storage.StagesStorage, error) {
+	return storage.NewStagesStorage(
+		stagesStorageAddress,
+		containerRuntime,
+		storage.StagesStorageOptions{
+			RepoStagesStorageOptions: storage.RepoStagesStorageOptions{
+				Implementation: *repoData.Implementation,
+				DockerRegistryOptions: docker_registry.DockerRegistryOptions{
+					InsecureRegistry:      *commonCmdData.InsecureRegistry,
+					SkipTlsVerifyRegistry: *commonCmdData.SkipTlsVerifyRegistry,
+					DockerHubUsername:     *repoData.DockerHubUsername,
+					DockerHubPassword:     *repoData.DockerHubPassword,
+					DockerHubToken:        *repoData.DockerHubToken,
+					GitHubToken:           *repoData.GitHubToken,
+					HarborUsername:        *repoData.HarborUsername,
+					HarborPassword:        *repoData.HarborPassword,
+				},
+			},
+		},
+	)
+}
+
+func runMv() error {
+	if err := werf.Init(*commonCmdData.TmpDir, *commonCmdData.HomeDir); err != nil {
+		return fmt.Errorf("initialization error: %s", err)
+	}
+
+	if err := shluz.Init(filepath.Join(werf.GetServiceDir(), "locks")); err != nil {
+		return err
+	}
+
+	if err := common.DockerRegistryInit(&commonCmdData); err != nil {
+		return err
+	}
+
+	if err := docker.Init(*commonCmdData.DockerConfig, *commonCmdData.LogVerbose, *commonCmdData.LogDebug); err != nil {
+		return err
+	}
+
+	projectDir, err := common.GetProjectDir(&commonCmdData)
+	if err != nil {
+		return fmt.Errorf("getting project dir failed: %s", err)
+	}
+
+	common.ProcessLogProjectDir(&commonCmdData, projectDir)
+
+	werfConfig, err := common.GetRequiredWerfConfig(projectDir, true)
+	if err != nil {
+		return fmt.Errorf("unable to load werf config: %s", err)
+	}
+
+	logboek.LogOptionalLn()
+
+	projectName := werfConfig.Meta.Project
+
+	containerRuntime := &container_runtime.LocalDockerServerRuntime{} // TODO
+
+	fromStagesStorage, err := NewFromStagesStorage(containerRuntime)
+	if err != nil {
+		return err
+	}
+
+	toStagesStorage, err := NewToStagesStorage(containerRuntime)
+	if err != nil {
+		return err
+	}
+
+	_, err = common.GetSynchronization(&commonCmdData)
+	if err != nil {
+		return err
+	}
+
+	return SyncStages(projectName, fromStagesStorage, toStagesStorage, containerRuntime)
+}
+
+// SyncStages will make sure, that destination stages storage contains all stages from source stages storage.
+// Repeatedly calling SyncStages will copy stages from source stages storage to destination, that already exists in the destination.
+// SyncStages will not delete excess stages from destination storage, that does not exists in the source.
+func SyncStages(projectName string, fromStagesStorage storage.StagesStorage, toStagesStorage storage.StagesStorage, containerRuntime container_runtime.ContainerRuntime) error {
+	isOk := false
+	logboek.Default.LogProcessStart(fmt.Sprintf("Sync %q project stages", projectName), logboek.LevelLogProcessStartOptions{})
+	defer func() {
+		if isOk {
+			logboek.Default.LogProcessEnd(logboek.LevelLogProcessEndOptions{})
+		} else {
+			logboek.Default.LogProcessFail(logboek.LevelLogProcessFailOptions{})
+		}
+	}()
+
+	logboek.Default.LogFDetails("Source      — %s\n", fromStagesStorage.String())
+	logboek.Default.LogFDetails("Destination — %s\n", toStagesStorage.String())
+	logboek.Default.LogOptionalLn()
+
+	var errors []error
+
+	getAllRepoImagesFunc := func(logProcessMsg string, stagesStorage storage.StagesStorage) ([]*image.Info, error) {
+		logboek.Default.LogProcessStart(logProcessMsg, logboek.LevelLogProcessStartOptions{})
+		if repoImages, err := stagesStorage.GetRepoImages(projectName); err != nil {
+			logboek.Default.LogProcessFail(logboek.LevelLogProcessFailOptions{})
+			return nil, fmt.Errorf("unable to get repo images from %s: %s", fromStagesStorage.String(), err)
+		} else {
+			logboek.Default.LogFDetails("Stages count: %d\n", len(repoImages))
+			logboek.Default.LogProcessEnd(logboek.LevelLogProcessEndOptions{})
+			return repoImages, nil
+		}
+	}
+
+	var existingSourceRepoImages []*image.Info
+	var existingDestinationRepoImages []*image.Info
+
+	if repoImages, err := getAllRepoImagesFunc("Getting all repo images list from source stages storage", fromStagesStorage); err != nil {
+		return fmt.Errorf("unable to get repo images from source %s: %s", fromStagesStorage.String(), err)
+	} else {
+		existingSourceRepoImages = repoImages
+	}
+
+	if repoImages, err := getAllRepoImagesFunc("Getting all repo images list from destination stages storage", toStagesStorage); err != nil {
+		return fmt.Errorf("unable to get repo images from destination %s: %s", toStagesStorage.String(), err)
+	} else {
+		existingDestinationRepoImages = repoImages
+	}
+
+	var repoImagesToCopy []*image.Info
+FindingImagesToCopy:
+	for _, sourceImgInfo := range existingSourceRepoImages {
+		for _, destImgInfo := range existingDestinationRepoImages {
+			if sourceImgInfo.Signature == destImgInfo.Signature && sourceImgInfo.UniqueID == destImgInfo.UniqueID {
+				continue FindingImagesToCopy
+			}
+		}
+		repoImagesToCopy = append(repoImagesToCopy, sourceImgInfo)
+	}
+
+	logboek.Default.LogFDetails("Stages to copy: %d\n", len(repoImagesToCopy))
+
+	maxWorkers := 10
+	resultsChan := make(chan struct {
+		error
+		*image.Info
+	}, 1000)
+	jobsChan := make(chan *image.Info, 1000)
+
+	for w := 0; w < maxWorkers; w++ {
+		go runRopyWorker(projectName, fromStagesStorage, toStagesStorage, containerRuntime, w, jobsChan, resultsChan)
+	}
+
+	for _, imgInfo := range repoImagesToCopy {
+		jobsChan <- imgInfo
+	}
+	close(jobsChan)
+
+	failedCounter := 0
+	succeededCounter := 0
+	for i := 0; i < len(repoImagesToCopy); i++ {
+		desc := <-resultsChan
+
+		if desc.error != nil {
+			failedCounter++
+			logboek.LogErrorF("%5d/%d failed\n", failedCounter, len(repoImagesToCopy))
+			errors = append(errors, desc.error)
+		} else {
+			succeededCounter++
+			logboek.Default.LogF("%5d/%d synced\n", succeededCounter, len(repoImagesToCopy))
+		}
+	}
+
+	if len(errors) > 0 {
+		logboek.Default.LogLn()
+		logboek.Default.LogFHighlight("synced %d/%d, failed %d/%d\n", succeededCounter, len(repoImagesToCopy), failedCounter, len(repoImagesToCopy))
+
+		errorMsg := fmt.Sprintf("following errors occured:\n")
+		for _, err := range errors {
+			errorMsg += fmt.Sprintf(" - %s\n", err)
+		}
+		return fmt.Errorf("%s", errorMsg)
+	}
+
+	isOk = true
+	return nil
+}
+
+func runRopyWorker(projectName string, fromStagesStorage storage.StagesStorage, toStagesStorage storage.StagesStorage, containerRuntime container_runtime.ContainerRuntime, workerId int, jobs chan *image.Info, results chan struct {
+	error
+	*image.Info
+}) {
+	for imgInfo := range jobs {
+		results <- struct {
+			error
+			*image.Info
+		}{
+			copyStage(projectName, imgInfo, fromStagesStorage, toStagesStorage, containerRuntime),
+			imgInfo,
+		}
+	}
+}
+
+func copyStage(projectName string, repoImage *image.Info, fromStagesStorage storage.StagesStorage, toStagesStorage storage.StagesStorage, containerRuntime container_runtime.ContainerRuntime) error {
+	img := container_runtime.NewStageImage(nil, repoImage.Name, containerRuntime.(*container_runtime.LocalDockerServerRuntime))
+
+	logboek.Info.LogF("Fetching %s\n", img.Name())
+	if err := fromStagesStorage.FetchImage(&container_runtime.DockerImage{Image: img}); err != nil {
+		return fmt.Errorf("unable to fetch %s from %s: %s", repoImage.Name, fromStagesStorage.String(), err)
+	}
+
+	newImageName := toStagesStorage.ConstructStageImageName(projectName, repoImage.Signature, repoImage.UniqueID)
+	logboek.Info.LogF("Renaming image %s to %s\n", img.Name(), newImageName)
+	if err := containerRuntime.RenameImage(&container_runtime.DockerImage{Image: img}, newImageName); err != nil {
+		return err
+	}
+
+	logboek.Info.LogF("Storing %s\n", newImageName)
+	if err := toStagesStorage.StoreImage(&container_runtime.DockerImage{Image: img}); err != nil {
+		return fmt.Errorf("unable to store %s to %s: %s", repoImage.Name, toStagesStorage.String(), err)
+	}
+
+	//deleteOpts := storage.DeleteRepoImageOptions{RmiForce: true, RmForce: true, RmContainersThatUseImage: true}
+	//logboek.Default.LogF("Removing %s\n", repoImage.Name)
+	//if err := fromStagesStorage.DeleteRepoImage(deleteOpts, repoImage); err != nil {
+	//	return fmt.Errorf("unable to remove %s from %s: %s", repoImage.Name, fromStagesStorage.String(), err)
+	//}
+
+	return nil
+}

--- a/pkg/container_runtime/dockerfile_image_builder.go
+++ b/pkg/container_runtime/dockerfile_image_builder.go
@@ -18,11 +18,11 @@ func NewDockerfileImageBuilder() *DockerfileImageBuilder {
 	return &DockerfileImageBuilder{temporalId: uuid.New().String()}
 }
 
-func (b *DockerfileImageBuilder) GetBuiltId() (string, error) {
+func (b *DockerfileImageBuilder) GetBuiltId() string {
 	if !b.isBuilt {
-		return "", fmt.Errorf("dockerfile image %s not built yet", b.temporalId)
+		return ""
 	}
-	return b.temporalId, nil
+	return b.temporalId
 }
 
 func (b *DockerfileImageBuilder) AppendBuildArgs(buildArgs ...string) {

--- a/pkg/container_runtime/interface.go
+++ b/pkg/container_runtime/interface.go
@@ -24,7 +24,7 @@ type ImageInterface interface {
 	DockerfileImageBuilder() *DockerfileImageBuilder
 
 	Build(BuildOptions) error
-	GetBuiltId() (string, error)
+	GetBuiltId() string
 	TagBuiltImage(name string) error
 	Export(name string) error
 


### PR DESCRIPTION
 - Use `${CI_REGISTRY_IMAGE}/stages` by default as stages storage in `werf ci-env gitlab` command.
 - Refactored stages-storage and images-repo related cli options preparation.
 - 'werf stages mv' command to copy existing stages to another storage and switch werf project between different stage-storages.
   Multithreaded implementation of sync-stages procedure.

**NOTE** that already existing installations that use `-s :local` explicit param will continue to use local stages storage as long as this param is specified.
