### PR TITLE
Remote storages support: separate image-manifest-cache, store only stage ids in the stages storage and big refactor

### DIFF
--- a/cmd/werf/build_and_publish/main.go
+++ b/cmd/werf/build_and_publish/main.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"path/filepath"
 
+	"github.com/flant/werf/pkg/image"
+
 	"github.com/flant/werf/pkg/stages_manager"
 
 	"github.com/spf13/cobra"
@@ -105,6 +107,10 @@ If one or more IMAGE_NAME parameters specified, werf will build images stages an
 func runBuildAndPublish(imagesToProcess []string) error {
 	if err := werf.Init(*commonCmdData.TmpDir, *commonCmdData.HomeDir); err != nil {
 		return fmt.Errorf("initialization error: %s", err)
+	}
+
+	if err := image.Init(); err != nil {
+		return err
 	}
 
 	if err := shluz.Init(filepath.Join(werf.GetServiceDir(), "locks")); err != nil {

--- a/cmd/werf/cleanup/cleanup.go
+++ b/cmd/werf/cleanup/cleanup.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"path/filepath"
 
+	"github.com/flant/werf/pkg/image"
+
 	"github.com/flant/werf/pkg/stages_manager"
 	"github.com/flant/werf/pkg/storage"
 
@@ -78,6 +80,10 @@ It is safe to run this command periodically (daily is enough) by automated clean
 func runCleanup() error {
 	if err := werf.Init(*commonCmdData.TmpDir, *commonCmdData.HomeDir); err != nil {
 		return fmt.Errorf("initialization error: %s", err)
+	}
+
+	if err := image.Init(); err != nil {
+		return err
 	}
 
 	if err := shluz.Init(filepath.Join(werf.GetServiceDir(), "locks")); err != nil {

--- a/cmd/werf/deploy/main.go
+++ b/cmd/werf/deploy/main.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/flant/werf/pkg/image"
+
 	"github.com/flant/werf/pkg/stages_manager"
 
 	"github.com/spf13/cobra"
@@ -118,6 +120,10 @@ Read more info about Helm chart structure, Helm Release name, Kubernetes Namespa
 func runDeploy() error {
 	if err := werf.Init(*commonCmdData.TmpDir, *commonCmdData.HomeDir); err != nil {
 		return fmt.Errorf("initialization error: %s", err)
+	}
+
+	if err := image.Init(); err != nil {
+		return err
 	}
 
 	if err := shluz.Init(filepath.Join(werf.GetServiceDir(), "locks")); err != nil {

--- a/cmd/werf/dismiss/dismiss.go
+++ b/cmd/werf/dismiss/dismiss.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"path/filepath"
 
+	"github.com/flant/werf/pkg/image"
+
 	"github.com/spf13/cobra"
 
 	"github.com/flant/kubedog/pkg/kube"
@@ -85,6 +87,10 @@ Read more info about Helm Release name, Kubernetes Namespace and how to change i
 func runDismiss() error {
 	if err := werf.Init(*commonCmdData.TmpDir, *commonCmdData.HomeDir); err != nil {
 		return fmt.Errorf("initialization error: %s", err)
+	}
+
+	if err := image.Init(); err != nil {
+		return err
 	}
 
 	if err := shluz.Init(filepath.Join(werf.GetServiceDir(), "locks")); err != nil {

--- a/cmd/werf/helm/deploy_chart/main.go
+++ b/cmd/werf/helm/deploy_chart/main.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/flant/werf/pkg/image"
+
 	"github.com/flant/shluz"
 
 	"github.com/spf13/cobra"
@@ -106,6 +108,10 @@ func NewCmd() *cobra.Command {
 func runDeployChart(chartDirOrChartReference string, releaseName string) error {
 	if err := werf.Init(*commonCmdData.TmpDir, *commonCmdData.HomeDir); err != nil {
 		return fmt.Errorf("initialization error: %s", err)
+	}
+
+	if err := image.Init(); err != nil {
+		return err
 	}
 
 	if err := shluz.Init(filepath.Join(werf.GetServiceDir(), "locks")); err != nil {

--- a/cmd/werf/helm/get_autogenerated_values/main.go
+++ b/cmd/werf/helm/get_autogenerated_values/main.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"path/filepath"
 
+	"github.com/flant/werf/pkg/image"
+
 	"github.com/spf13/cobra"
 
 	"github.com/flant/logboek"
@@ -68,6 +70,10 @@ func runGetServiceValues() error {
 
 	if err := werf.Init(*commonCmdData.TmpDir, *commonCmdData.HomeDir); err != nil {
 		return fmt.Errorf("initialization error: %s", err)
+	}
+
+	if err := image.Init(); err != nil {
+		return err
 	}
 
 	if err := shluz.Init(filepath.Join(werf.GetServiceDir(), "locks")); err != nil {

--- a/cmd/werf/host/cleanup/cleanup.go
+++ b/cmd/werf/host/cleanup/cleanup.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"path/filepath"
 
+	"github.com/flant/werf/pkg/image"
+
 	"github.com/spf13/cobra"
 
 	"github.com/flant/logboek"
@@ -60,6 +62,10 @@ It is safe to run this command periodically by automated cleanup job in parallel
 func runGC() error {
 	if err := werf.Init(*commonCmdData.TmpDir, *commonCmdData.HomeDir); err != nil {
 		return fmt.Errorf("initialization error: %s", err)
+	}
+
+	if err := image.Init(); err != nil {
+		return err
 	}
 
 	if err := shluz.Init(filepath.Join(werf.GetServiceDir(), "locks")); err != nil {

--- a/cmd/werf/host/project/purge/purge.go
+++ b/cmd/werf/host/project/purge/purge.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"path/filepath"
 
+	"github.com/flant/werf/pkg/image"
+
 	"github.com/flant/werf/pkg/stages_manager"
 	"github.com/flant/werf/pkg/storage"
 
@@ -67,6 +69,10 @@ func NewCmd() *cobra.Command {
 func run(projectNames ...string) error {
 	if err := werf.Init(*commonCmdData.TmpDir, *commonCmdData.HomeDir); err != nil {
 		return fmt.Errorf("initialization error: %s", err)
+	}
+
+	if err := image.Init(); err != nil {
+		return err
 	}
 
 	if err := shluz.Init(filepath.Join(werf.GetServiceDir(), "locks")); err != nil {

--- a/cmd/werf/host/purge/purge.go
+++ b/cmd/werf/host/purge/purge.go
@@ -12,6 +12,7 @@ import (
 	"github.com/flant/werf/cmd/werf/common"
 	"github.com/flant/werf/pkg/docker"
 	"github.com/flant/werf/pkg/host_cleaning"
+	"github.com/flant/werf/pkg/image"
 	"github.com/flant/werf/pkg/werf"
 )
 
@@ -65,6 +66,10 @@ WARNING: Do not run this command during any other werf command is working on the
 func runReset() error {
 	if err := werf.Init(*commonCmdData.TmpDir, *commonCmdData.HomeDir); err != nil {
 		return fmt.Errorf("initialization error: %s", err)
+	}
+
+	if err := image.Init(); err != nil {
+		return err
 	}
 
 	if err := shluz.Init(filepath.Join(werf.GetServiceDir(), "locks")); err != nil {

--- a/cmd/werf/images/cleanup/cleanup.go
+++ b/cmd/werf/images/cleanup/cleanup.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"path/filepath"
 
+	"github.com/flant/werf/pkg/image"
+
 	"github.com/spf13/cobra"
 
 	"github.com/flant/kubedog/pkg/kube"
@@ -70,6 +72,10 @@ func NewCmd() *cobra.Command {
 func runCleanup() error {
 	if err := werf.Init(*commonCmdData.TmpDir, *commonCmdData.HomeDir); err != nil {
 		return fmt.Errorf("initialization error: %s", err)
+	}
+
+	if err := image.Init(); err != nil {
+		return err
 	}
 
 	if err := shluz.Init(filepath.Join(werf.GetServiceDir(), "locks")); err != nil {

--- a/cmd/werf/images/publish/cmd_factory/main.go
+++ b/cmd/werf/images/publish/cmd_factory/main.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"path/filepath"
 
+	"github.com/flant/werf/pkg/image"
+
 	"github.com/flant/werf/pkg/stages_manager"
 
 	"github.com/spf13/cobra"
@@ -73,6 +75,10 @@ If one or more IMAGE_NAME parameters specified, werf will publish only these ima
 func runImagesPublish(commonCmdData *common.CmdData, imagesToProcess []string) error {
 	if err := werf.Init(*commonCmdData.TmpDir, *commonCmdData.HomeDir); err != nil {
 		return fmt.Errorf("initialization error: %s", err)
+	}
+
+	if err := image.Init(); err != nil {
+		return err
 	}
 
 	if err := shluz.Init(filepath.Join(werf.GetServiceDir(), "locks")); err != nil {

--- a/cmd/werf/images/purge/purge.go
+++ b/cmd/werf/images/purge/purge.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"path/filepath"
 
+	"github.com/flant/werf/pkg/image"
+
 	"github.com/spf13/cobra"
 
 	"github.com/flant/logboek"
@@ -59,6 +61,10 @@ func NewCmd() *cobra.Command {
 func runPurge() error {
 	if err := werf.Init(*commonCmdData.TmpDir, *commonCmdData.HomeDir); err != nil {
 		return fmt.Errorf("initialization error: %s", err)
+	}
+
+	if err := image.Init(); err != nil {
+		return err
 	}
 
 	if err := shluz.Init(filepath.Join(werf.GetServiceDir(), "locks")); err != nil {

--- a/cmd/werf/managed_images/add/add.go
+++ b/cmd/werf/managed_images/add/add.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"path/filepath"
 
+	"github.com/flant/werf/pkg/image"
+
 	"github.com/spf13/cobra"
 
 	"github.com/flant/shluz"
@@ -57,6 +59,10 @@ func NewCmd() *cobra.Command {
 func run(imageName string) error {
 	if err := werf.Init(*commonCmdData.TmpDir, *commonCmdData.HomeDir); err != nil {
 		return fmt.Errorf("initialization error: %s", err)
+	}
+
+	if err := image.Init(); err != nil {
+		return err
 	}
 
 	if err := shluz.Init(filepath.Join(werf.GetServiceDir(), "locks")); err != nil {

--- a/cmd/werf/managed_images/ls/ls.go
+++ b/cmd/werf/managed_images/ls/ls.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"path/filepath"
 
+	"github.com/flant/werf/pkg/image"
+
 	"github.com/spf13/cobra"
 
 	"github.com/flant/shluz"
@@ -54,6 +56,10 @@ func NewCmd() *cobra.Command {
 func run() error {
 	if err := werf.Init(*commonCmdData.TmpDir, *commonCmdData.HomeDir); err != nil {
 		return fmt.Errorf("initialization error: %s", err)
+	}
+
+	if err := image.Init(); err != nil {
+		return err
 	}
 
 	if err := shluz.Init(filepath.Join(werf.GetServiceDir(), "locks")); err != nil {

--- a/cmd/werf/managed_images/rm/rm.go
+++ b/cmd/werf/managed_images/rm/rm.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/flant/werf/pkg/image"
+
 	"github.com/flant/shluz"
 	"github.com/spf13/cobra"
 
@@ -57,6 +59,10 @@ func NewCmd() *cobra.Command {
 func run(imageNames []string) error {
 	if err := werf.Init(*commonCmdData.TmpDir, *commonCmdData.HomeDir); err != nil {
 		return fmt.Errorf("initialization error: %s", err)
+	}
+
+	if err := image.Init(); err != nil {
+		return err
 	}
 
 	if err := shluz.Init(filepath.Join(werf.GetServiceDir(), "locks")); err != nil {

--- a/cmd/werf/purge/purge.go
+++ b/cmd/werf/purge/purge.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"path/filepath"
 
+	"github.com/flant/werf/pkg/image"
+
 	"github.com/flant/werf/pkg/stages_manager"
 	"github.com/flant/werf/pkg/storage"
 
@@ -72,6 +74,10 @@ WARNING: Do not run this command during any other werf command is working on the
 func runPurge() error {
 	if err := werf.Init(*commonCmdData.TmpDir, *commonCmdData.HomeDir); err != nil {
 		return fmt.Errorf("initialization error: %s", err)
+	}
+
+	if err := image.Init(); err != nil {
+		return err
 	}
 
 	if err := shluz.Init(filepath.Join(werf.GetServiceDir(), "locks")); err != nil {

--- a/cmd/werf/run/run.go
+++ b/cmd/werf/run/run.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/flant/werf/pkg/image"
+
 	"github.com/flant/werf/pkg/stages_manager"
 
 	"github.com/spf13/cobra"
@@ -154,6 +156,10 @@ func processArgs(cmd *cobra.Command, args []string) error {
 func runRun() error {
 	if err := werf.Init(*commonCmdData.TmpDir, *commonCmdData.HomeDir); err != nil {
 		return fmt.Errorf("initialization error: %s", err)
+	}
+
+	if err := image.Init(); err != nil {
+		return err
 	}
 
 	if err := shluz.Init(filepath.Join(werf.GetServiceDir(), "locks")); err != nil {

--- a/cmd/werf/stage/image/main.go
+++ b/cmd/werf/stage/image/main.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"path/filepath"
 
+	"github.com/flant/werf/pkg/image"
+
 	"github.com/flant/werf/pkg/stages_manager"
 
 	"github.com/spf13/cobra"
@@ -79,6 +81,10 @@ func run(imageName string) error {
 	}
 
 	tmp_manager.AutoGCEnabled = false
+
+	if err := image.Init(); err != nil {
+		return err
+	}
 
 	if err := shluz.Init(filepath.Join(werf.GetServiceDir(), "locks")); err != nil {
 		return err

--- a/cmd/werf/stages/build/cmd_factory/main.go
+++ b/cmd/werf/stages/build/cmd_factory/main.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"path/filepath"
 
+	"github.com/flant/werf/pkg/image"
+
 	"github.com/flant/werf/pkg/stages_manager"
 
 	"github.com/spf13/cobra"
@@ -96,6 +98,10 @@ If one or more IMAGE_NAME parameters specified, werf will build only these image
 func runStagesBuild(cmdData *CmdData, commonCmdData *common.CmdData, imagesToProcess []string) error {
 	if err := werf.Init(*commonCmdData.TmpDir, *commonCmdData.HomeDir); err != nil {
 		return fmt.Errorf("initialization error: %s", err)
+	}
+
+	if err := image.Init(); err != nil {
+		return err
 	}
 
 	if err := shluz.Init(filepath.Join(werf.GetServiceDir(), "locks")); err != nil {

--- a/cmd/werf/stages/cleanup/cleanup.go
+++ b/cmd/werf/stages/cleanup/cleanup.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"path/filepath"
 
+	"github.com/flant/werf/pkg/image"
+
 	"github.com/flant/werf/pkg/stages_manager"
 
 	"github.com/spf13/cobra"
@@ -65,6 +67,10 @@ func NewCmd() *cobra.Command {
 func runSync() error {
 	if err := werf.Init(*commonCmdData.TmpDir, *commonCmdData.HomeDir); err != nil {
 		return fmt.Errorf("initialization error: %s", err)
+	}
+
+	if err := image.Init(); err != nil {
+		return err
 	}
 
 	if err := shluz.Init(filepath.Join(werf.GetServiceDir(), "locks")); err != nil {

--- a/cmd/werf/stages/purge/purge.go
+++ b/cmd/werf/stages/purge/purge.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"path/filepath"
 
+	"github.com/flant/werf/pkg/image"
+
 	"github.com/flant/werf/pkg/stages_manager"
 	"github.com/flant/werf/pkg/storage"
 
@@ -68,6 +70,10 @@ func NewCmd() *cobra.Command {
 func runPurge() error {
 	if err := werf.Init(*commonCmdData.TmpDir, *commonCmdData.HomeDir); err != nil {
 		return fmt.Errorf("initialization error: %s", err)
+	}
+
+	if err := image.Init(); err != nil {
+		return err
 	}
 
 	if err := shluz.Init(filepath.Join(werf.GetServiceDir(), "locks")); err != nil {

--- a/pkg/build/build_phase.go
+++ b/pkg/build/build_phase.go
@@ -3,7 +3,6 @@ package build
 import (
 	"fmt"
 	"strings"
-	"time"
 
 	"github.com/google/uuid"
 
@@ -110,8 +109,8 @@ func (phase *BuildPhase) AfterImageStages(img *Image) error {
 
 func (phase *BuildPhase) getPrevNonEmptyStageImageSize() int64 {
 	if phase.StagesIterator.PrevNonEmptyStage != nil {
-		if phase.StagesIterator.PrevNonEmptyStage.GetImage().GetStagesStorageImageInfo() != nil {
-			return phase.StagesIterator.PrevNonEmptyStage.GetImage().GetStagesStorageImageInfo().Size
+		if phase.StagesIterator.PrevNonEmptyStage.GetImage().GetStageDescription() != nil {
+			return phase.StagesIterator.PrevNonEmptyStage.GetImage().GetStageDescription().Info.Size
 		}
 	}
 	return 0
@@ -148,7 +147,7 @@ func (phase *BuildPhase) onImageStage(img *Image, stg stage.Interface, isEmpty b
 		}
 
 		// Stage is cached in the stages storage
-		if stg.GetImage().GetStagesStorageImageInfo() != nil {
+		if stg.GetImage().GetStageDescription() != nil {
 			logboek.Default.LogFHighlight("Use cache image for %s\n", stg.LogDetailedName())
 
 			logImageInfo(stg.GetImage(), phase.getPrevNonEmptyStageImageSize(), true)
@@ -176,7 +175,7 @@ func (phase *BuildPhase) onImageStage(img *Image, stg stage.Interface, isEmpty b
 			return err
 		}
 
-		if stg.GetImage().GetStagesStorageImageInfo() == nil {
+		if stg.GetImage().GetStageDescription() == nil {
 			panic(fmt.Sprintf("expected stage %s image %q built image info (image name = %s) to be set!", stg.Name(), img.GetName(), stg.GetImage().Name()))
 		}
 
@@ -211,49 +210,20 @@ func (phase *BuildPhase) calculateStage(img *Image, stg stage.Interface) error {
 	}
 	stg.SetSignature(stageSig)
 
-	var i *container_runtime.StageImage
-	var suitableImageFound bool
-
-	cacheExists, cacheImagesDescs, err := phase.Conveyor.StagesManager.GetImagesBySignatureFromCache(string(stg.Name()), stageSig)
-	if err != nil {
+	if stages, err := phase.Conveyor.StagesManager.GetStagesBySignature(stg.LogDetailedName(), stageSig); err != nil {
 		return err
-	}
-
-	if cacheExists {
-		if imgInfo, err := phase.Conveyor.StagesManager.SelectSuitableStagesStorageImage(stg, cacheImagesDescs); err != nil {
-			return err
-		} else if imgInfo != nil {
-			suitableImageFound = true
-			i = phase.Conveyor.GetOrCreateStageImage(phase.StagesIterator.GetPrevImage(img, stg).(*container_runtime.StageImage), imgInfo.Name)
-			i.SetStagesStorageImageInfo(imgInfo)
-			stg.SetImage(i)
-		}
 	} else {
-		logboek.Info.LogF(
-			"Stage %q cache by signature %s is not exists in stages storage cache: resetting stages storage cache\n",
-			stg.Name(), stageSig,
-		)
-
-		imagesDescs, err := phase.Conveyor.StagesManager.AtomicGetImagesBySignatureFromStagesStorageWithCacheReset(stg.LogDetailedName(), stageSig)
-		if err != nil {
+		if stageDesc, err := phase.Conveyor.StagesManager.SelectSuitableStage(stg, stages); err != nil {
 			return err
-		}
-
-		if imgInfo, err := phase.Conveyor.StagesManager.SelectSuitableStagesStorageImage(stg, imagesDescs); err != nil {
-			return err
-		} else if imgInfo != nil {
-			suitableImageFound = true
-
-			i = phase.Conveyor.GetOrCreateStageImage(phase.StagesIterator.GetPrevImage(img, stg).(*container_runtime.StageImage), imgInfo.Name)
-			i.SetStagesStorageImageInfo(imgInfo)
+		} else if stageDesc != nil {
+			i := phase.Conveyor.GetOrCreateStageImage(phase.StagesIterator.GetPrevImage(img, stg).(*container_runtime.StageImage), stageDesc.Info.Name)
+			i.SetStageDescription(stageDesc)
+			stg.SetImage(i)
+		} else {
+			// Will build a new image
+			i := phase.Conveyor.GetOrCreateStageImage(phase.StagesIterator.GetPrevImage(img, stg).(*container_runtime.StageImage), uuid.New().String())
 			stg.SetImage(i)
 		}
-	}
-
-	if !suitableImageFound {
-		// Will build a new image
-		i = phase.Conveyor.GetOrCreateStageImage(phase.StagesIterator.GetPrevImage(img, stg).(*container_runtime.StageImage), uuid.New().String())
-		stg.SetImage(i)
 	}
 
 	if err = stg.AfterSignatureCalculated(phase.Conveyor); err != nil {
@@ -370,86 +340,56 @@ func (phase *BuildPhase) atomicBuildStageImage(img *Image, stg stage.Interface) 
 	}
 	defer phase.Conveyor.StorageLockManager.UnlockStage(phase.Conveyor.projectName(), stg.GetSignature())
 
-	imagesDescs, err := phase.Conveyor.StagesManager.AtomicGetImagesBySignatureFromStagesStorageWithCacheReset(string(stg.Name()), stg.GetSignature())
-	if err != nil {
+	if stages, err := phase.Conveyor.StagesManager.GetStagesBySignature(stg.LogDetailedName(), stg.GetSignature()); err != nil {
 		return err
-	}
-
-	if len(imagesDescs) > 0 {
-		var imgInfo *image.Info
-		if err := logboek.Info.LogProcess(
-			fmt.Sprintf("Selecting suitable image for stage %s by signature %s", stg.Name(), stg.GetSignature()),
-			logboek.LevelLogProcessOptions{},
-			func() error {
-				imgInfo, err = stg.SelectCacheImage(imagesDescs)
-				return err
-			},
-		); err != nil {
+	} else {
+		if stageDesc, err := phase.Conveyor.StagesManager.SelectSuitableStage(stg, stages); err != nil {
 			return err
-		}
-
-		if imgInfo != nil {
+		} else if stageDesc != nil {
 			logboek.Default.LogF(
 				"Discarding newly built image for stage %s by signature %s: detected already existing image %s in the stages storage\n",
-				stg.Name(), stg.GetSignature(), imgInfo.Name,
+				stg.LogDetailedName(), stg.GetSignature(), stageDesc.Info.Name,
 			)
-			i := phase.Conveyor.GetOrCreateStageImage(phase.StagesIterator.GetPrevImage(img, stg).(*container_runtime.StageImage), imgInfo.Name)
-			i.SetStagesStorageImageInfo(imgInfo)
+			i := phase.Conveyor.GetOrCreateStageImage(phase.StagesIterator.GetPrevImage(img, stg).(*container_runtime.StageImage), stageDesc.Info.Name)
+			i.SetStageDescription(stageDesc)
 			stg.SetImage(i)
-
 			return nil
-		}
-	}
+		} else {
+			newStageImageName, uniqueID := phase.Conveyor.StagesManager.GenerateStageUniqueID(stg.GetSignature(), stages)
+			repository, tag := image.ParseRepositoryAndTag(newStageImageName)
 
-	newStageImageName, uniqueID := phase.generateUniqueImageName(stg.GetSignature(), imagesDescs)
-	repository, tag := image.ParseRepositoryAndTag(newStageImageName)
+			stageImageObj := phase.Conveyor.GetStageImage(stageImage.Name())
+			phase.Conveyor.UnsetStageImage(stageImageObj.Name())
 
-	stageImageObj := phase.Conveyor.GetStageImage(stageImage.Name())
-	phase.Conveyor.UnsetStageImage(stageImageObj.Name())
+			stageImageObj.SetName(newStageImageName)
+			stageImageObj.GetStageDescription().Info.Name = newStageImageName
+			stageImageObj.GetStageDescription().Info.Repository = repository
+			stageImageObj.GetStageDescription().Info.Tag = tag
+			stageImageObj.GetStageDescription().StageID = &image.StageID{Signature: stg.GetSignature(), UniqueID: uniqueID}
 
-	stageImageObj.SetName(newStageImageName)
-	stageImageObj.GetStagesStorageImageInfo().Name = newStageImageName
-	stageImageObj.GetStagesStorageImageInfo().Repository = repository
-	stageImageObj.GetStagesStorageImageInfo().Tag = tag
-	stageImageObj.GetStagesStorageImageInfo().Signature = stg.GetSignature()
-	stageImageObj.GetStagesStorageImageInfo().UniqueID = uniqueID
+			phase.Conveyor.SetStageImage(stageImageObj)
 
-	phase.Conveyor.SetStageImage(stageImageObj)
-
-	if err := logboek.Default.LogProcess(
-		fmt.Sprintf("Store into stages storage"),
-		logboek.LevelLogProcessOptions{},
-		func() error {
-			// FIXME: StagesManager?
-			if err := phase.Conveyor.StagesManager.StagesStorage.StoreImage(&container_runtime.DockerImage{Image: stageImage}); err != nil {
-				return fmt.Errorf("unable to store stage %s signature %s image %s into stages storage %s: %s", stg.LogDetailedName(), stg.GetSignature(), stageImage.Name(), phase.Conveyor.StagesManager.StagesStorage.String(), err)
+			if err := logboek.Default.LogProcess(
+				fmt.Sprintf("Store into stages storage"),
+				logboek.LevelLogProcessOptions{},
+				func() error {
+					if err := phase.Conveyor.StagesManager.StagesStorage.StoreImage(&container_runtime.DockerImage{Image: stageImage}); err != nil {
+						return fmt.Errorf("unable to store stage %s signature %s image %s into stages storage %s: %s", stg.LogDetailedName(), stg.GetSignature(), stageImage.Name(), phase.Conveyor.StagesManager.StagesStorage.String(), err)
+					}
+					return nil
+				},
+			); err != nil {
+				return err
 			}
-			return nil
-		},
-	); err != nil {
-		return err
-	}
 
-	imagesDescs = append(imagesDescs, stageImage.GetStagesStorageImageInfo())
-	return phase.Conveyor.StagesManager.AtomicStoreStageCache(string(stg.Name()), stg.GetSignature(), imagesDescs)
-}
-
-// FIXME: move this image to StagesManager?
-func (phase *BuildPhase) generateUniqueImageName(signature string, imagesDescs []*image.Info) (string, string) {
-	var imageName string
-
-	for {
-		timeNow := time.Now().UTC()
-		timeNowMicroseconds := timeNow.Unix()*1000 + int64(timeNow.Nanosecond()/1000000)
-		uniqueID := fmt.Sprintf("%d", timeNowMicroseconds)
-		imageName = phase.Conveyor.StagesManager.StagesStorage.ConstructStageImageName(phase.Conveyor.projectName(), signature, uniqueID)
-
-		for _, imgInfo := range imagesDescs {
-			if imgInfo.Name == imageName {
-				continue
+			var stageIDs []image.StageID
+			for _, stageDesc := range stages {
+				stageIDs = append(stageIDs, *stageDesc.StageID)
 			}
+			stageIDs = append(stageIDs, *stageImage.GetStageDescription().StageID)
+
+			return phase.Conveyor.StagesManager.AtomicStoreStagesBySignatureToCache(string(stg.Name()), stg.GetSignature(), stageIDs)
 		}
-		return imageName, uniqueID
 	}
 }
 
@@ -475,14 +415,14 @@ var (
 func logImageInfo(img container_runtime.ImageInterface, prevStageImageSize int64, isUsingCache bool) {
 	repository, tag := image.ParseRepositoryAndTag(img.Name())
 	logboek.Default.LogFDetails(logImageInfoFormat, "repository", repository)
-	logboek.Default.LogFDetails(logImageInfoFormat, "image_id", stringid.TruncateID(img.GetStagesStorageImageInfo().ID))
-	logboek.Default.LogFDetails(logImageInfoFormat, "created", img.GetStagesStorageImageInfo().GetCreatedAt())
+	logboek.Default.LogFDetails(logImageInfoFormat, "image_id", stringid.TruncateID(img.GetStageDescription().Info.ID))
+	logboek.Default.LogFDetails(logImageInfoFormat, "created", img.GetStageDescription().Info.GetCreatedAt())
 	logboek.Default.LogFDetails(logImageInfoFormat, "tag", tag)
 
 	if prevStageImageSize == 0 {
-		logboek.Default.LogFDetails(logImageInfoFormat, "size", byteCountBinary(img.GetStagesStorageImageInfo().Size))
+		logboek.Default.LogFDetails(logImageInfoFormat, "size", byteCountBinary(img.GetStageDescription().Info.Size))
 	} else {
-		logboek.Default.LogFDetails(logImageInfoFormat, "diff", byteCountBinary(img.GetStagesStorageImageInfo().Size-prevStageImageSize))
+		logboek.Default.LogFDetails(logImageInfoFormat, "diff", byteCountBinary(img.GetStageDescription().Info.Size-prevStageImageSize))
 	}
 
 	if !isUsingCache {

--- a/pkg/build/conveyor.go
+++ b/pkg/build/conveyor.go
@@ -563,7 +563,7 @@ func (c *Conveyor) GetImageLastStageImageName(imageName string) string {
 }
 
 func (c *Conveyor) GetImageLastStageImageID(imageName string) string {
-	return c.GetImage(imageName).GetLastNonEmptyStage().GetImage().GetStagesStorageImageInfo().ID
+	return c.GetImage(imageName).GetLastNonEmptyStage().GetImage().GetStageDescription().Info.ID
 }
 
 func (c *Conveyor) SetBuildingGitStage(imageName string, stageName stage.StageName) {

--- a/pkg/build/image.go
+++ b/pkg/build/image.go
@@ -141,7 +141,10 @@ func (i *Image) FetchBaseImage(c *Conveyor) error {
 			return fmt.Errorf("unable to inspect local image %s: %s", i.baseImage.Name(), err)
 		} else if inspect != nil {
 			// TODO: do not use container_runtime.StageImage for base image
-			i.baseImage.SetStagesStorageImageInfo(image.NewInfoFromInspect(i.baseImage.Name(), inspect))
+			i.baseImage.SetStageDescription(&image.StageDescription{
+				StageID: nil, // this is not a stage actually, TODO
+				Info:    image.NewInfoFromInspect(i.baseImage.Name(), inspect),
+			})
 
 			baseImageRepoId, err := i.getFromBaseImageIdFromRegistry(c, i.baseImage.Name())
 			if baseImageRepoId == inspect.ID || err != nil {
@@ -167,8 +170,10 @@ func (i *Image) FetchBaseImage(c *Conveyor) error {
 		} else if inspect == nil {
 			return fmt.Errorf("unable to inspect local image %s after successful pull: image is not exists", i.baseImage.Name(), err)
 		} else {
-			// TODO: do not use container_runtime.StageImage for base image
-			i.baseImage.SetStagesStorageImageInfo(image.NewInfoFromInspect(i.baseImage.Name(), inspect))
+			i.baseImage.SetStageDescription(&image.StageDescription{
+				StageID: nil, // this is not a stage actually, TODO
+				Info:    image.NewInfoFromInspect(i.baseImage.Name(), inspect),
+			})
 		}
 	case StageAsBaseImage:
 		if err := c.ContainerRuntime.RefreshImageObject(&container_runtime.DockerImage{Image: i.baseImage}); err != nil {

--- a/pkg/build/publish_images_phase.go
+++ b/pkg/build/publish_images_phase.go
@@ -382,5 +382,5 @@ func (phase *PublishImagesPhase) checkImageAlreadyExists(existingTags []string, 
 		return false, fmt.Errorf("unable to get image %s parent id: %s", werfImageName, err)
 	}
 
-	return lastStageImage.GetStagesStorageImageInfo().ID == parentID, nil
+	return lastStageImage.GetStageDescription().Info.ID == parentID, nil
 }

--- a/pkg/build/should_be_built_phase.go
+++ b/pkg/build/should_be_built_phase.go
@@ -50,7 +50,7 @@ func (phase *ShouldBeBuiltPhase) OnImageStage(img *Image, stg stage.Interface) e
 	}
 
 	// stage is not empty and stages-storage does not contain suitable cached image
-	if stg.GetImage().GetStagesStorageImageInfo() == nil {
+	if stg.GetImage().GetStageDescription() == nil {
 		phase.BadStagesByImage[img.GetName()] = append(phase.BadStagesByImage[img.GetName()], stg)
 	}
 

--- a/pkg/build/stage/base.go
+++ b/pkg/build/stage/base.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/flant/werf/pkg/container_runtime"
+	"github.com/flant/werf/pkg/image"
 
 	"github.com/flant/logboek"
 
@@ -118,8 +119,8 @@ func (s *BaseStage) GetNextStageDependencies(_ Conveyor) (string, error) {
 func (s *BaseStage) getNextStageGitDependencies(_ Conveyor) (string, error) {
 	var args []string
 	for _, gitMapping := range s.gitMappings {
-		if s.image.GetStagesStorageImageInfo() != nil {
-			args = append(args, gitMapping.GetGitCommitFromImageLabels(s.image.GetStagesStorageImageInfo().Labels))
+		if s.image.GetStageDescription() != nil {
+			args = append(args, gitMapping.GetGitCommitFromImageLabels(s.image.GetStageDescription().Info.Labels))
 		} else {
 			latestCommit, err := gitMapping.LatestCommit()
 			if err != nil {
@@ -141,7 +142,7 @@ func (s *BaseStage) IsEmpty(_ Conveyor, _ container_runtime.ImageInterface) (boo
 
 func (s *BaseStage) ShouldBeReset(builtImage container_runtime.ImageInterface) (bool, error) {
 	for _, gitMapping := range s.gitMappings {
-		commit := gitMapping.GetGitCommitFromImageLabels(builtImage.GetStagesStorageImageInfo().Labels)
+		commit := gitMapping.GetGitCommitFromImageLabels(builtImage.GetStageDescription().Info.Labels)
 		if commit == "" {
 			return false, nil
 		} else if exist, err := gitMapping.GitRepo().IsCommitExists(commit); err != nil {
@@ -154,20 +155,20 @@ func (s *BaseStage) ShouldBeReset(builtImage container_runtime.ImageInterface) (
 	return false, nil
 }
 
-func (s *BaseStage) selectCacheImageByOldestCreationTimestamp(images []*imagePkg.Info) (*imagePkg.Info, error) {
-	var oldestImage *imagePkg.Info
-	for _, img := range images {
-		if oldestImage == nil {
-			oldestImage = img
-		} else if img.GetCreatedAt().Before(oldestImage.GetCreatedAt()) {
-			oldestImage = img
+func (s *BaseStage) selectStageByOldestCreationTimestamp(stages []*image.StageDescription) (*image.StageDescription, error) {
+	var oldestStage *image.StageDescription
+	for _, stageDesc := range stages {
+		if oldestStage == nil {
+			oldestStage = stageDesc
+		} else if stageDesc.Info.GetCreatedAt().Before(oldestStage.Info.GetCreatedAt()) {
+			oldestStage = stageDesc
 		}
 	}
-	return oldestImage, nil
+	return oldestStage, nil
 }
 
-func (s *BaseStage) selectCacheImagesAncestorsByGitMappings(images []*imagePkg.Info) ([]*imagePkg.Info, error) {
-	suitableImages := []*imagePkg.Info{}
+func (s *BaseStage) selectStagesAncestorsByGitMappings(stages []*image.StageDescription) ([]*image.StageDescription, error) {
+	suitableStages := []*image.StageDescription{}
 	currentCommits := make(map[string]string)
 
 	for _, gitMapping := range s.gitMappings {
@@ -179,11 +180,11 @@ func (s *BaseStage) selectCacheImagesAncestorsByGitMappings(images []*imagePkg.I
 	}
 
 ScanImages:
-	for _, img := range images {
+	for _, stageDesc := range stages {
 		for _, gitMapping := range s.gitMappings {
 			currentCommit := currentCommits[gitMapping.Name]
 
-			commit := gitMapping.GetGitCommitFromImageLabels(img.Labels)
+			commit := gitMapping.GetGitCommitFromImageLabels(stageDesc.Info.Labels)
 			if commit != "" {
 				isOurAncestor, err := gitMapping.GitRepo().IsAncestor(commit, currentCommit)
 				if err != nil {
@@ -191,28 +192,28 @@ ScanImages:
 				}
 
 				if !isOurAncestor {
-					logboek.Debug.LogF("%s is not ancestor of %s for git repo %s: ignore image %s\n", commit, currentCommit, gitMapping.GitRepo().String(), img.Name)
+					logboek.Debug.LogF("%s is not ancestor of %s for git repo %s: ignore image %s\n", commit, currentCommit, gitMapping.GitRepo().String(), stageDesc.Info.Name)
 					continue ScanImages
 				}
 
 				logboek.Debug.LogF(
 					"%s is ancestor of %s for git repo %s: image %s is suitable for git archive stage\n",
-					commit, currentCommit, gitMapping.GitRepo().String(), img.Name,
+					commit, currentCommit, gitMapping.GitRepo().String(), stageDesc.Info.Name,
 				)
 			} else {
-				logboek.Debug.LogF("WARNING: No git commit found in image %s, skipping\n", img.Name)
+				logboek.Debug.LogF("WARNING: No git commit found in image %s, skipping\n", stageDesc.Info.Name)
 				continue ScanImages
 			}
 		}
 
-		suitableImages = append(suitableImages, img)
+		suitableStages = append(suitableStages, stageDesc)
 	}
 
-	return suitableImages, nil
+	return suitableStages, nil
 }
 
-func (s *BaseStage) SelectCacheImage(images []*imagePkg.Info) (*imagePkg.Info, error) {
-	return s.selectCacheImageByOldestCreationTimestamp(images)
+func (s *BaseStage) SelectSuitableStage(stages []*image.StageDescription) (*image.StageDescription, error) {
+	return s.selectStageByOldestCreationTimestamp(stages)
 }
 
 func (s *BaseStage) PrepareImage(_ Conveyor, prevBuiltImage, image container_runtime.ImageInterface) error {
@@ -253,7 +254,7 @@ func (s *BaseStage) getServiceMountsFromLabels(prevBuiltImage container_runtime.
 
 	var labels map[string]string
 	if prevBuiltImage != nil {
-		labels = prevBuiltImage.GetStagesStorageImageInfo().Labels
+		labels = prevBuiltImage.GetStageDescription().Info.Labels
 	}
 
 	for _, labelMountType := range []struct{ Label, MountType string }{
@@ -341,7 +342,7 @@ func (s *BaseStage) getCustomMountsFromLabels(prevBuiltImage container_runtime.I
 
 	var labels map[string]string
 	if prevBuiltImage != nil {
-		labels = prevBuiltImage.GetStagesStorageImageInfo().Labels
+		labels = prevBuiltImage.GetStageDescription().Info.Labels
 	}
 	for k, v := range labels {
 		if !strings.HasPrefix(k, imagePkg.WerfMountCustomDirLabelPrefix) {

--- a/pkg/build/stage/git.go
+++ b/pkg/build/stage/git.go
@@ -21,7 +21,7 @@ func (s *GitStage) isEmpty() bool {
 }
 
 func (s *GitStage) AfterSignatureCalculated(c Conveyor) error {
-	if s.image.GetStagesStorageImageInfo() == nil {
+	if s.image.GetStageDescription() == nil {
 		stageName := c.GetBuildingGitStage(s.imageName)
 		if stageName == "" {
 			c.SetBuildingGitStage(s.imageName, s.Name())

--- a/pkg/build/stage/git_archive.go
+++ b/pkg/build/stage/git_archive.go
@@ -4,8 +4,9 @@ import (
 	"fmt"
 	"sort"
 
-	"github.com/flant/werf/pkg/container_runtime"
 	"github.com/flant/werf/pkg/image"
+
+	"github.com/flant/werf/pkg/container_runtime"
 	"github.com/flant/werf/pkg/util"
 )
 
@@ -36,12 +37,12 @@ type GitArchiveStage struct {
 	ContainerScriptsDir  string
 }
 
-func (s *GitArchiveStage) SelectCacheImage(images []*image.Info) (*image.Info, error) {
-	ancestorsImages, err := s.selectCacheImagesAncestorsByGitMappings(images)
+func (s *GitArchiveStage) SelectSuitableStage(stages []*image.StageDescription) (*image.StageDescription, error) {
+	ancestorsStages, err := s.selectStagesAncestorsByGitMappings(stages)
 	if err != nil {
 		return nil, fmt.Errorf("unable to select cache images ancestors by git mappings: %s", err)
 	}
-	return s.selectCacheImageByOldestCreationTimestamp(ancestorsImages)
+	return s.selectStageByOldestCreationTimestamp(ancestorsStages)
 }
 
 func (s *GitArchiveStage) GetDependencies(_ Conveyor, _, _ container_runtime.ImageInterface) (string, error) {

--- a/pkg/build/stage/git_cache.go
+++ b/pkg/build/stage/git_cache.go
@@ -20,12 +20,12 @@ type GitCacheStage struct {
 	*GitPatchStage
 }
 
-func (s *GitCacheStage) SelectCacheImage(images []*image.Info) (*image.Info, error) {
-	ancestorsImages, err := s.selectCacheImagesAncestorsByGitMappings(images)
+func (s *GitCacheStage) SelectSuitableStage(stages []*image.StageDescription) (*image.StageDescription, error) {
+	ancestorsImages, err := s.selectStagesAncestorsByGitMappings(stages)
 	if err != nil {
 		return nil, fmt.Errorf("unable to select cache images ancestors by git mappings: %s", err)
 	}
-	return s.selectCacheImageByOldestCreationTimestamp(ancestorsImages)
+	return s.selectStageByOldestCreationTimestamp(ancestorsImages)
 }
 
 func (s *GitCacheStage) IsEmpty(c Conveyor, prevBuiltImage container_runtime.ImageInterface) (bool, error) {
@@ -57,7 +57,7 @@ func (s *GitCacheStage) GetDependencies(_ Conveyor, _, prevBuiltImage container_
 func (s *GitCacheStage) gitMappingsPatchSize(prevBuiltImage container_runtime.ImageInterface) (int64, error) {
 	var size int64
 	for _, gitMapping := range s.gitMappings {
-		commit := gitMapping.GetGitCommitFromImageLabels(prevBuiltImage.GetStagesStorageImageInfo().Labels)
+		commit := gitMapping.GetGitCommitFromImageLabels(prevBuiltImage.GetStageDescription().Info.Labels)
 		if commit == "" {
 			return 0, fmt.Errorf("invalid stage image: can not find git commit in stage image labels: delete stage image %s manually and retry the build", prevBuiltImage.Name())
 		}

--- a/pkg/build/stage/git_latest_patch.go
+++ b/pkg/build/stage/git_latest_patch.go
@@ -26,7 +26,7 @@ func (s *GitLatestPatchStage) IsEmpty(c Conveyor, prevBuiltImage container_runti
 
 	isEmpty := true
 	for _, gitMapping := range s.gitMappings {
-		commit := gitMapping.GetGitCommitFromImageLabels(prevBuiltImage.GetStagesStorageImageInfo().Labels)
+		commit := gitMapping.GetGitCommitFromImageLabels(prevBuiltImage.GetStageDescription().Info.Labels)
 		if exist, err := gitMapping.GitRepo().IsCommitExists(commit); err != nil {
 			return false, err
 		} else if !exist {

--- a/pkg/build/stage/git_mapping.go
+++ b/pkg/build/stage/git_mapping.go
@@ -270,7 +270,7 @@ func (gm *GitMapping) ApplyPatchCommand(prevBuiltImage, image container_runtime.
 }
 
 func (gm *GitMapping) GetCommitsToPatch(prevBuiltImage container_runtime.ImageInterface) (string, string, error) {
-	fromCommit := gm.GetGitCommitFromImageLabels(prevBuiltImage.GetStagesStorageImageInfo().Labels)
+	fromCommit := gm.GetGitCommitFromImageLabels(prevBuiltImage.GetStageDescription().Info.Labels)
 	if fromCommit == "" {
 		panic("Commit should be in prev built image labels!")
 	}
@@ -303,7 +303,7 @@ func (gm *GitMapping) ImageGitCommitLabel() string {
 }
 
 func (gm *GitMapping) baseApplyPatchCommand(fromCommit, toCommit string, prevBuiltImage container_runtime.ImageInterface) ([]string, error) {
-	archiveType := git_repo.ArchiveType(prevBuiltImage.GetStagesStorageImageInfo().Labels[gm.getArchiveTypeLabelName()])
+	archiveType := git_repo.ArchiveType(prevBuiltImage.GetStageDescription().Info.Labels[gm.getArchiveTypeLabelName()])
 
 	patchOpts := git_repo.PatchOptions{
 		FilterOptions: gm.getRepoFilterOptions(),

--- a/pkg/build/stage/git_patch.go
+++ b/pkg/build/stage/git_patch.go
@@ -72,7 +72,7 @@ func (s *GitPatchStage) willGitLatestCommitBeBuiltOnPrevGitStage(c Conveyor) (bo
 
 func (s *GitPatchStage) hasPrevBuiltStageHadActualGitMappings(prevBuiltImage container_runtime.ImageInterface) (bool, error) {
 	for _, gitMapping := range s.gitMappings {
-		commit := gitMapping.GetGitCommitFromImageLabels(prevBuiltImage.GetStagesStorageImageInfo().Labels)
+		commit := gitMapping.GetGitCommitFromImageLabels(prevBuiltImage.GetStageDescription().Info.Labels)
 		latestCommit, err := gitMapping.LatestCommit()
 		if err != nil {
 			return false, err

--- a/pkg/build/stage/interface.go
+++ b/pkg/build/stage/interface.go
@@ -29,5 +29,5 @@ type Interface interface {
 	SetGitMappings([]*GitMapping)
 	GetGitMappings() []*GitMapping
 
-	SelectCacheImage(images []*image.Info) (*image.Info, error)
+	SelectSuitableStage(stages []*image.StageDescription) (*image.StageDescription, error)
 }

--- a/pkg/build/stage/user_with_git_patch.go
+++ b/pkg/build/stage/user_with_git_patch.go
@@ -22,12 +22,12 @@ type UserWithGitPatchStage struct {
 	GitPatchStage *GitPatchStage
 }
 
-func (s *UserWithGitPatchStage) SelectCacheImage(images []*image.Info) (*image.Info, error) {
-	ancestorsImages, err := s.selectCacheImagesAncestorsByGitMappings(images)
+func (s *UserWithGitPatchStage) SelectSuitableStage(stages []*image.StageDescription) (*image.StageDescription, error) {
+	ancestorsImages, err := s.selectStagesAncestorsByGitMappings(stages)
 	if err != nil {
 		return nil, fmt.Errorf("unable to select cache images ancestors by git mappings: %s", err)
 	}
-	return s.selectCacheImageByOldestCreationTimestamp(ancestorsImages)
+	return s.selectStageByOldestCreationTimestamp(ancestorsImages)
 }
 
 func (s *UserWithGitPatchStage) GetNextStageDependencies(c Conveyor) (string, error) {

--- a/pkg/build/stages_iterator.go
+++ b/pkg/build/stages_iterator.go
@@ -62,12 +62,12 @@ func (iterator *StagesIterator) OnImageStage(img *Image, stg stage.Interface, on
 		iterator.PrevNonEmptyStage = stg
 		logboek.Debug.LogF("Set prev non empty stage = %q %s\n", iterator.PrevNonEmptyStage.Name(), iterator.PrevNonEmptyStage.GetSignature())
 
-		if iterator.PrevNonEmptyStage.GetImage().GetStagesStorageImageInfo() != nil {
-			iterator.PrevNonEmptyStageImageSize = iterator.PrevNonEmptyStage.GetImage().GetStagesStorageImageInfo().Size
+		if iterator.PrevNonEmptyStage.GetImage().GetStageDescription() != nil {
+			iterator.PrevNonEmptyStageImageSize = iterator.PrevNonEmptyStage.GetImage().GetStageDescription().Info.Size
 			logboek.Debug.LogF("Set prev non empty stage image size = %d %q %s\n", iterator.PrevNonEmptyStageImageSize, iterator.PrevNonEmptyStage.Name(), iterator.PrevNonEmptyStage.GetSignature())
 		}
 
-		if stg.GetImage().GetStagesStorageImageInfo() != nil {
+		if stg.GetImage().GetStageDescription() != nil {
 			iterator.PrevBuiltStage = stg
 			logboek.Debug.LogF("Set prev built stage = %q (image %s)\n", iterator.PrevBuiltStage.Name(), iterator.PrevBuiltStage.GetImage().Name())
 		}

--- a/pkg/cleaning/stages_purge.go
+++ b/pkg/cleaning/stages_purge.go
@@ -54,13 +54,14 @@ func (m *stagesPurgeManager) run() error {
 	lockName := fmt.Sprintf("stages-purge.%s", m.ProjectName)
 	return shluz.WithLock(lockName, shluz.LockOptions{Timeout: time.Second * 600}, func() error {
 		logboek.Default.LogProcessStart("Deleting stages", logboek.LevelLogProcessStartOptions{})
-		stagesImageList, err := m.StagesManager.GetAllStages()
+
+		stages, err := m.StagesManager.GetAllStages()
 		if err != nil {
 			logboek.Default.LogProcessFail(logboek.LevelLogProcessFailOptions{})
 			return err
 		}
 
-		if err := deleteStageInStagesStorage(m.StagesManager, deleteImageOptions, m.DryRun, stagesImageList...); err != nil {
+		if err := deleteStageInStagesStorage(m.StagesManager, deleteImageOptions, m.DryRun, stages...); err != nil {
 			logboek.Default.LogProcessFail(logboek.LevelLogProcessFailOptions{})
 			return err
 		}

--- a/pkg/container_runtime/base_image.go
+++ b/pkg/container_runtime/base_image.go
@@ -3,15 +3,16 @@ package container_runtime
 import (
 	"fmt"
 
+	"github.com/flant/werf/pkg/image"
+
 	"github.com/docker/docker/api/types"
 	"github.com/flant/werf/pkg/docker"
-	"github.com/flant/werf/pkg/image"
 )
 
 type baseImage struct {
-	name    string
-	inspect *types.ImageInspect
-	imgInfo *image.Info
+	name             string
+	inspect          *types.ImageInspect
+	stageDesc *image.StageDescription
 
 	LocalDockerServerRuntime *LocalDockerServerRuntime
 }
@@ -66,12 +67,12 @@ func (i *baseImage) Untag() error {
 	return nil
 }
 
-func (i *baseImage) SetStagesStorageImageInfo(imgInfo *image.Info) {
-	i.imgInfo = imgInfo
+func (i *baseImage) SetStageDescription(stageDesc *image.StageDescription) {
+	i.stageDesc = stageDesc
 }
 
-func (i *baseImage) GetStagesStorageImageInfo() *image.Info {
-	return i.imgInfo
+func (i *baseImage) GetStageDescription() *image.StageDescription {
+	return i.stageDesc
 }
 
 func (i *baseImage) IsExistsLocally() bool {

--- a/pkg/container_runtime/interface.go
+++ b/pkg/container_runtime/interface.go
@@ -32,8 +32,9 @@ type ImageInterface interface {
 
 	SetInspect(inspect *types.ImageInspect)
 	IsExistsLocally() bool
-	SetStagesStorageImageInfo(imgInfo *image.Info)
-	GetStagesStorageImageInfo() *image.Info
+
+	SetStageDescription(stage *image.StageDescription)
+	GetStageDescription() *image.StageDescription
 }
 
 type Container interface {

--- a/pkg/container_runtime/stage_image.go
+++ b/pkg/container_runtime/stage_image.go
@@ -46,7 +46,7 @@ func (i *StageImage) GetID() string {
 	if i.buildImage != nil {
 		return i.buildImage.Name()
 	} else {
-		return i.baseImage.GetStagesStorageImageInfo().ID
+		return i.baseImage.GetStageDescription().Info.ID
 	}
 }
 
@@ -114,7 +114,10 @@ func (i *StageImage) Build(options BuildOptions) error {
 		return err
 	} else {
 		i.SetInspect(inspect)
-		i.SetStagesStorageImageInfo(image.NewInfoFromInspect(i.Name(), inspect))
+		i.SetStageDescription(&image.StageDescription{
+			StageID: nil, // stage id does not available at the moment
+			Info:    image.NewInfoFromInspect(i.Name(), inspect),
+		})
 	}
 
 	return nil
@@ -211,7 +214,7 @@ func (i *StageImage) Import(name string) error {
 		return err
 	}
 
-	importedImageId := importedImage.GetStagesStorageImageInfo().ID
+	importedImageId := importedImage.GetStageDescription().Info.ID
 
 	if err := docker.CliTag(importedImageId, i.name); err != nil {
 		return err

--- a/pkg/image/info.go
+++ b/pkg/image/info.go
@@ -11,12 +11,11 @@ import (
 )
 
 type Info struct {
-	Signature         string            `json:"signature"`
-	UniqueID          string            `json:"uniqueID"`
-	Name              string            `json:"name"`
-	Repository        string            `json:"repository"`
-	Tag               string            `json:"tag"`
-	RepoDigest        string            `json:"repoDigest"`
+	Name       string `json:"name"`
+	Repository string `json:"repository"`
+	Tag        string `json:"tag"`
+	RepoDigest string `json:"repoDigest"`
+
 	ID                string            `json:"ID"`
 	ParentID          string            `json:"parentID"`
 	Labels            map[string]string `json:"labels"`

--- a/pkg/image/init.go
+++ b/pkg/image/init.go
@@ -1,0 +1,14 @@
+package image
+
+import (
+	"path/filepath"
+
+	"github.com/flant/werf/pkg/werf"
+)
+
+var CommonManifestCache *ManifestCache
+
+func Init() error {
+	CommonManifestCache = NewManifestCache(filepath.Join(werf.GetLocalCacheDir(), "manifest_cache", ManifestCacheVersion))
+	return nil
+}

--- a/pkg/image/manifest_cache.go
+++ b/pkg/image/manifest_cache.go
@@ -1,0 +1,118 @@
+package image
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/flant/werf/pkg/util"
+
+	"github.com/flant/shluz"
+)
+
+const (
+	ManifestCacheVersion = "1"
+)
+
+type ManifestCache struct {
+	CacheDir string
+}
+
+type ManifestCacheRecord struct {
+	AccessTimestamp int64
+	Info            *Info
+}
+
+func NewManifestCache(cacheDir string) *ManifestCache {
+	return &ManifestCache{CacheDir: cacheDir}
+}
+
+func (cache *ManifestCache) GetImageInfo(imageName string) (*Info, error) {
+	if err := cache.lock(); err != nil {
+		return nil, err
+	}
+	defer cache.unlock()
+
+	now := time.Now()
+
+	if record, err := cache.readRecord(imageName); err != nil {
+		return nil, err
+	} else if record != nil {
+		record.AccessTimestamp = now.Unix()
+		if err := cache.writeRecord(record); err != nil {
+			return nil, err
+		}
+		return record.Info, nil
+	} else {
+		return nil, nil
+	}
+}
+
+func (cache *ManifestCache) StoreImageInfo(imgInfo *Info) error {
+	if err := cache.lock(); err != nil {
+		return err
+	}
+	defer cache.unlock()
+
+	record := &ManifestCacheRecord{
+		AccessTimestamp: time.Now().Unix(),
+		Info:            imgInfo,
+	}
+	return cache.writeRecord(record)
+}
+
+func (cache *ManifestCache) readRecord(imageName string) (*ManifestCacheRecord, error) {
+	filePath := cache.constructFilePathForImage(imageName)
+
+	if _, err := os.Stat(filePath); os.IsNotExist(err) {
+		return nil, nil
+	} else if err != nil {
+		return nil, fmt.Errorf("error accessing %s: %s", filePath, err)
+	}
+
+	if dataBytes, err := ioutil.ReadFile(filePath); err != nil {
+		return nil, fmt.Errorf("error reading %s: %s", filePath, err)
+	} else {
+		record := &ManifestCacheRecord{}
+		if err := json.Unmarshal(dataBytes, record); err != nil {
+			return nil, fmt.Errorf("error unmarshalling json from %s: %s", filePath, err)
+		}
+		return record, nil
+	}
+}
+
+func (cache *ManifestCache) writeRecord(record *ManifestCacheRecord) error {
+	filePath := cache.constructFilePathForImage(record.Info.Name)
+
+	dirPath := filepath.Dir(filePath)
+	if err := os.MkdirAll(dirPath, os.ModePerm); err != nil {
+		return fmt.Errorf("error creating dir %s: %s", dirPath, err)
+	}
+
+	if dataBytes, err := json.Marshal(record); err != nil {
+		return fmt.Errorf("error marshalling json: %s", err)
+	} else {
+		if err := ioutil.WriteFile(filePath, append(dataBytes, []byte("\n")...), 0644); err != nil {
+			return fmt.Errorf("error writing %s: %s", filePath, err)
+		}
+		return nil
+	}
+}
+
+func (cache *ManifestCache) constructFilePathForImage(imageName string) string {
+	return filepath.Join(cache.CacheDir, util.Sha256Hash(imageName))
+}
+
+func (cache *ManifestCache) lock() error {
+	if err := shluz.Lock(cache.CacheDir, shluz.LockOptions{}); err != nil {
+		return fmt.Errorf("shluz lock %s failed: %s", cache.CacheDir, err)
+	}
+	return nil
+}
+
+func (cache *ManifestCache) unlock() error {
+	return shluz.Unlock(cache.CacheDir)
+}

--- a/pkg/image/stage.go
+++ b/pkg/image/stage.go
@@ -1,0 +1,17 @@
+package image
+
+import "fmt"
+
+type StageID struct {
+	Signature string `json:"signature"`
+	UniqueID  string `json:"uniqueID"`
+}
+
+func (id StageID) String() string {
+	return fmt.Sprintf("signature:%s uniqueID:%s", id.Signature, id.UniqueID)
+}
+
+type StageDescription struct {
+	StageID *StageID `json:"stageID"`
+	Info    *Info    `json:"info"`
+}

--- a/pkg/storage/stages_storage.go
+++ b/pkg/storage/stages_storage.go
@@ -11,22 +11,21 @@ const (
 )
 
 type StagesStorage interface {
-	GetAllStages(projectName string) ([]*image.Info, error)
-	DeleteStages(options DeleteImageOptions, imageList ...*image.Info) error
-
-	CreateRepo() error
-	DeleteRepo() error
-
-	GetRepoImagesBySignature(projectName, signature string) ([]*image.Info, error)
+	GetAllStages(projectName string) ([]image.StageID, error)
+	GetStagesBySignature(projectName, signature string) ([]image.StageID, error)
+	GetStageDescription(projectName, signature, uniqueID string) (*image.StageDescription, error)
+	DeleteStages(options DeleteImageOptions, stages ...*image.StageDescription) error
 
 	ConstructStageImageName(projectName, signature, uniqueID string) string
-	GetImageInfo(projectName, signature, uniqueID string) (*image.Info, error)
 
 	// FetchImage will create a local image in the container-runtime
 	FetchImage(img container_runtime.Image) error
 	// StoreImage will store a local image into the container-runtime, local built image should exist prior running store
 	StoreImage(img container_runtime.Image) error
 	ShouldFetchImage(img container_runtime.Image) (bool, error)
+
+	CreateRepo() error
+	DeleteRepo() error
 
 	AddManagedImage(projectName, imageName string) error
 	RmManagedImage(projectName, imageName string) error

--- a/pkg/storage/stages_storage_cache.go
+++ b/pkg/storage/stages_storage_cache.go
@@ -3,8 +3,8 @@ package storage
 import "github.com/flant/werf/pkg/image"
 
 type StagesStorageCache interface {
-	GetAllStages(projectName string) (bool, []*image.Info, error)
-	GetStagesBySignature(projectName, signature string) (bool, []*image.Info, error)
-	StoreStagesBySignature(projectName, signature string, imageInfo []*image.Info) error
+	GetAllStages(projectName string) (bool, []image.StageID, error)
+	GetStagesBySignature(projectName, signature string) (bool, []image.StageID, error)
+	StoreStagesBySignature(projectName, signature string, stages []image.StageID) error
 	DeleteStagesBySignature(projectName, signature string) error
 }


### PR DESCRIPTION
 - New image types: image.StageID, image.StageDescription (which is stage-id + info).
 - StagesStorage GetAllStages and GetStagesBySignature always return StageID. This optimization significantly reduced stages sync time.
 - Introduced new manifest-cache, which is separate from stages-storage-cache:
   - reside in `~/.werf/local_cache/manifest_cache/MANIFEST_CACHE_VERSION/IMAGE_NAME_SHA256`;
   - cache records has an last-access-timestamp, by which cleanup will occur in the future.
 - StagesStorageCache now contains only a list of stage-ids by signature. This cache significantly reduces build time both with :local or remote stages-storage. This is strongly coherent cache, which should represent the state of stages-storage. In the case when this cache is out-of-sync with stages-storage there will be an error requiring to remove stages-storage-cache manually for now.
