### PR TITLE
**INCOMPATIBLE CHANGE** Fix stages and images isolation problem for git-latest-patch and stages-signature

### DIFF
--- a/pkg/build/stage/git_latest_patch.go
+++ b/pkg/build/stage/git_latest_patch.go
@@ -3,6 +3,8 @@ package stage
 import (
 	"fmt"
 
+	"github.com/flant/werf/pkg/storage"
+
 	"github.com/flant/werf/pkg/image"
 	"github.com/flant/werf/pkg/util"
 )
@@ -57,4 +59,16 @@ func (s *GitLatestPatchStage) GetDependencies(_ Conveyor, _, prevBuiltImage imag
 	}
 
 	return util.Sha256Hash(args...), nil
+}
+
+func (s *GitLatestPatchStage) SelectCacheImage(images []*storage.ImageInfo) (*storage.ImageInfo, error) {
+	ancestorsImages, err := s.selectCacheImagesAncestorsByGitMappings(images)
+	if err != nil {
+		return nil, fmt.Errorf("unable to select cache images ancestors by git mappings: %s", err)
+	}
+	return s.selectCacheImageByOldestCreationTimestamp(ancestorsImages)
+}
+
+func (s *GitLatestPatchStage) GetNextStageDependencies(c Conveyor) (string, error) {
+	return s.BaseStage.getNextStageGitDependencies(c)
 }


### PR DESCRIPTION
 - gitLatestPatch stage was not isolated between different branches when the same changes
   has been made in two different commits: added commits ancestry check when selecting
   suitable stage from cache for gitLatestPatch. The signature of gitLatestPatch stage
   has not been changed.

 - Stages-signature was not isolated between different branches when the same
   changes has been maed in two different commits. **IMPORTANT** stages-signature
   calculation algorithm has been changed, stages-signature will change for all projects
   that use stages-signature tagging strategy (content-based).