### PR TITLE
Support import from certain artifact/image stage

### DIFF
--- a/cmd/werf/run/run.go
+++ b/cmd/werf/run/run.go
@@ -223,7 +223,7 @@ func runRun() error {
 		return err
 	}
 
-	dockerImageName := c.GetImageLastStageImageName(imageName)
+	dockerImageName := c.GetImageNameForLastImageStage(imageName)
 	var dockerRunArgs []string
 	dockerRunArgs = append(dockerRunArgs, cmdData.DockerOptions...)
 	dockerRunArgs = append(dockerRunArgs, dockerImageName)

--- a/cmd/werf/stage/image/main.go
+++ b/cmd/werf/stage/image/main.go
@@ -145,7 +145,7 @@ func run(imageName string) error {
 		return err
 	}
 
-	fmt.Println(c.GetImageLastStageImageName(imageName))
+	fmt.Println(c.GetImageNameForLastImageStage(imageName))
 
 	return nil
 }

--- a/pkg/build/build_phase.go
+++ b/pkg/build/build_phase.go
@@ -12,10 +12,10 @@ import (
 
 	"github.com/flant/logboek"
 
-	"github.com/flant/werf/pkg/stapel"
 	"github.com/flant/werf/pkg/build/stage"
 	"github.com/flant/werf/pkg/image"
 	imagePkg "github.com/flant/werf/pkg/image"
+	"github.com/flant/werf/pkg/stapel"
 	"github.com/flant/werf/pkg/storage"
 	"github.com/flant/werf/pkg/util"
 	"github.com/flant/werf/pkg/werf"
@@ -118,7 +118,7 @@ func (phase *BuildPhase) AfterImageStages(img *Image) error {
 	if err != nil {
 		return fmt.Errorf("unable to calculate image %s stages-signature: %s", img.GetName(), err)
 	}
-	img.SetStagesSignature(stagesSig)
+	img.SetContentSignature(stagesSig)
 
 	return nil
 }
@@ -313,6 +313,12 @@ func (phase *BuildPhase) calculateStageSignature(img *Image, stg stage.Interface
 		phase.PrevBuiltImage = phase.PrevImage
 		logboek.Debug.LogF("Set prev built image = %q\n", phase.PrevBuiltImage.Name())
 	}
+
+	stageContentSig, err := calculateSignature(fmt.Sprintf("%s-content", stg.Name()), "", phase.PrevNonEmptyStage, phase.Conveyor)
+	if err != nil {
+		return fmt.Errorf("unable to calculate stage %s content-signature: %s", stg.Name(), err)
+	}
+	stg.SetContentSignature(stageContentSig)
 
 	return nil
 }

--- a/pkg/build/image.go
+++ b/pkg/build/image.go
@@ -21,7 +21,7 @@ type Image struct {
 
 	stages            []stage.Interface
 	lastNonEmptyStage stage.Interface
-	stagesSignature   string
+	contentSignature  string
 	baseImage         *image.StageImage
 	isArtifact        bool
 	isDockerfileImage bool
@@ -78,12 +78,12 @@ func (i *Image) GetLastNonEmptyStage() stage.Interface {
 	return i.lastNonEmptyStage
 }
 
-func (i *Image) SetStagesSignature(sig string) {
-	i.stagesSignature = sig
+func (i *Image) SetContentSignature(sig string) {
+	i.contentSignature = sig
 }
 
-func (i *Image) GetStagesSignature() string {
-	return i.stagesSignature
+func (i *Image) GetContentSignature() string {
+	return i.contentSignature
 }
 
 func (i *Image) GetStage(name stage.StageName) stage.Interface {

--- a/pkg/build/publish_images_phase.go
+++ b/pkg/build/publish_images_phase.go
@@ -227,8 +227,8 @@ func (phase *PublishImagesPhase) publishImage(img *Image) error {
 			logboek.LevelLogProcessOptions{Style: logboek.HighlightStyle()},
 			func() error {
 
-				if err := phase.publishImageByTag(img, img.GetStagesSignature(), tag_strategy.StagesSignature, existingTags); err != nil {
-					return fmt.Errorf("error publishing image %s by image signature %s: %s", img.GetName(), img.GetStagesSignature(), err)
+				if err := phase.publishImageByTag(img, img.GetContentSignature(), tag_strategy.StagesSignature, existingTags); err != nil {
+					return fmt.Errorf("error publishing image %s by image signature %s: %s", img.GetName(), img.GetContentSignature(), err)
 				}
 
 				return nil

--- a/pkg/build/stage/base.go
+++ b/pkg/build/stage/base.go
@@ -81,6 +81,7 @@ type BaseStage struct {
 	name             StageName
 	imageName        string
 	signature        string
+	contentSignature string
 	image            imagePkg.ImageInterface
 	gitMappings      []*GitMapping
 	imageTmpDir      string
@@ -412,6 +413,14 @@ func (s *BaseStage) SetSignature(signature string) {
 
 func (s *BaseStage) GetSignature() string {
 	return s.signature
+}
+
+func (s *BaseStage) SetContentSignature(contentSignature string) {
+	s.contentSignature = contentSignature
+}
+
+func (s *BaseStage) GetContentSignature() string {
+	return s.contentSignature
 }
 
 func (s *BaseStage) SetImage(image imagePkg.ImageInterface) {

--- a/pkg/build/stage/conveyor.go
+++ b/pkg/build/stage/conveyor.go
@@ -3,10 +3,16 @@ package stage
 import "github.com/flant/werf/pkg/build/import_server"
 
 type Conveyor interface {
-	GetImageStagesSignature(imageName string) string
-	GetImageLastStageImageName(imageName string) string
-	GetImageLastStageImageID(imageName string) string
+	GetImageStageContentSignature(imageName, stageName string) string
+	GetImageContentSignature(imageName string) string
+
+	GetImageNameForLastImageStage(imageName string) string
+	GetImageIDForLastImageStage(imageName string) string
+
+	GetImageNameForImageStage(imageName, stageName string) string
+	GetImageIDForImageStage(imageName, stageName string) string
+
 	SetBuildingGitStage(imageName string, stageName StageName)
 	GetBuildingGitStage(imageName string) StageName
-	GetImportServer(imageName string) (import_server.ImportServer, error)
+	GetImportServer(imageName, stageName string) (import_server.ImportServer, error)
 }

--- a/pkg/build/stage/from.go
+++ b/pkg/build/stage/from.go
@@ -61,7 +61,7 @@ func (s *FromStage) GetDependencies(c Conveyor, prevImage, _ image.ImageInterfac
 	}
 
 	if s.fromImageOrArtifactImageName != "" {
-		args = append(args, c.GetImageStagesSignature(s.fromImageOrArtifactImageName))
+		args = append(args, c.GetImageContentSignature(s.fromImageOrArtifactImageName))
 	} else {
 		args = append(args, prevImage.Name())
 	}

--- a/pkg/build/stage/interface.go
+++ b/pkg/build/stage/interface.go
@@ -23,6 +23,9 @@ type Interface interface {
 	SetSignature(signature string)
 	GetSignature() string
 
+	SetContentSignature(contentSignature string)
+	GetContentSignature() string
+
 	SetImage(image.ImageInterface)
 	GetImage() image.ImageInterface
 

--- a/pkg/config/import.go
+++ b/pkg/config/import.go
@@ -10,6 +10,7 @@ type Import struct {
 	ArtifactName string
 	Before       string
 	After        string
+	Stage        string
 
 	raw *rawImport
 }
@@ -35,10 +36,16 @@ func (c *Import) validate() error {
 		return newDetailedConfigError(fmt.Sprintf("invalid artifact stage `before: %s` for import: expected install or setup!", c.Before), c.raw, c.raw.rawStapelImage.doc)
 	} else if c.After != "" && checkInvalidRelation(c.After) {
 		return newDetailedConfigError(fmt.Sprintf("invalid artifact stage `after: %s` for import: expected install or setup!", c.After), c.raw, c.raw.rawStapelImage.doc)
+	} else if c.Stage != "" && checkInvalidStage(c.Stage) {
+		return newDetailedConfigError(fmt.Sprintf("invalid stage `stage: %s` for import: expected beforeInstall, install, beforeSetup or setup", c.Stage), c.raw, c.raw.rawStapelImage.doc)
 	}
 	return nil
 }
 
 func checkInvalidRelation(rel string) bool {
 	return !(rel == "install" || rel == "setup")
+}
+
+func checkInvalidStage(stage string) bool {
+	return !(stage == "beforeInstall" || stage == "install" || stage == "beforeSetup" || stage == "setup")
 }

--- a/pkg/config/raw_import.go
+++ b/pkg/config/raw_import.go
@@ -5,6 +5,7 @@ type rawImport struct {
 	ArtifactName string `yaml:"artifact,omitempty"`
 	Before       string `yaml:"before,omitempty"`
 	After        string `yaml:"after,omitempty"`
+	Stage        string `yaml:"stage,omitempty"`
 
 	rawArtifactExport `yaml:",inline"`
 	rawStapelImage    *rawStapelImage `yaml:"-"` // parent
@@ -59,6 +60,7 @@ func (c *rawImport) toDirective() (imp *Import, err error) {
 	imp.ArtifactName = c.ArtifactName
 	imp.Before = c.Before
 	imp.After = c.After
+	imp.Stage = c.Stage
 
 	imp.raw = c
 


### PR DESCRIPTION
Added ability to specify `stage` directive in the import directive to perform import from certain artifact or image stage:

```
import:
- add: /file
  to: /file
  artifact: myartifact
  before: setup
  stage: install
```

Note that image which imports some files from another image _stage_ will be rebuild only if this specified stage has been rebuilt.

This feature allows to avoid unnecessary imports of unchanged files.

*Implementation details*

 - image stages-signature has been renamed to image content-signature;
 - added content-signature to each stage, which differs from regular signature and represents content of the stage.