### PR TITLE
[dockerfile] Fix COPY/ADD source path with trailing backslash is not counted in the signature

### DIFF
--- a/pkg/path_matcher/base_path_matcher.go
+++ b/pkg/path_matcher/base_path_matcher.go
@@ -1,13 +1,15 @@
 package path_matcher
 
-import "path/filepath"
+import (
+	"path/filepath"
+)
 
 type basePathMatcher struct {
 	basePath string
 }
 
-func (f *basePathMatcher) TrimFileBaseFilepath(filePath string) string {
-	return trimFileBasePath(filePath, f.basePath)
+func (f *basePathMatcher) TrimFileBaseFilepath(path string) string {
+	return trimFileBasePath(formatPath(path), f.basePath)
 }
 
 func trimFileBasePath(filePath, basePath string) string {
@@ -32,4 +34,21 @@ func rel(targetPath, basePath string) string {
 	}
 
 	return relPath
+}
+
+func formatPaths(paths []string) []string {
+	var result []string
+	for _, path := range paths {
+		result = append(result, formatPath(path))
+	}
+
+	return result
+}
+
+func formatPath(path string) string {
+	if path == "" || path == "." {
+		return ""
+	}
+
+	return filepath.Clean(path)
 }

--- a/pkg/path_matcher/dockerfile_ignore.go
+++ b/pkg/path_matcher/dockerfile_ignore.go
@@ -11,7 +11,7 @@ import (
 
 func NewDockerfileIgnorePathMatcher(basePath string, patternMatcher *fileutils.PatternMatcher, greedySearch bool) *DockerfileIgnorePathMatcher {
 	return &DockerfileIgnorePathMatcher{
-		basePathMatcher:  basePathMatcher{basePath: basePath},
+		basePathMatcher:  basePathMatcher{basePath: formatPath(basePath)},
 		patternMatcher:   patternMatcher,
 		isGreedySearchOn: greedySearch,
 	}
@@ -32,6 +32,8 @@ func (f *DockerfileIgnorePathMatcher) String() string {
 }
 
 func (f *DockerfileIgnorePathMatcher) MatchPath(path string) bool {
+	path = formatPath(path)
+
 	if !isRel(path, f.basePath) {
 		return false
 	} else if f.patternMatcher == nil || path == f.basePath {
@@ -59,7 +61,7 @@ type pattern struct {
 }
 
 func (f *DockerfileIgnorePathMatcher) ProcessDirOrSubmodulePath(path string) (bool, bool) {
-	isMatched, shouldGoThrough := f.processDirOrSubmodulePath(path)
+	isMatched, shouldGoThrough := f.processDirOrSubmodulePath(formatPath(path))
 	if f.isGreedySearchOn {
 		return false, isMatched || shouldGoThrough
 	} else {

--- a/pkg/path_matcher/git_mapping.go
+++ b/pkg/path_matcher/git_mapping.go
@@ -11,9 +11,9 @@ import (
 
 func NewGitMappingPathMatcher(basePath string, includePaths, excludePaths []string, greedySearch bool) *GitMappingPathMatcher {
 	return &GitMappingPathMatcher{
-		basePathMatcher:  basePathMatcher{basePath: basePath},
-		includePaths:     includePaths,
-		excludePaths:     excludePaths,
+		basePathMatcher:  basePathMatcher{basePath: formatPath(basePath)},
+		includePaths:     formatPaths(includePaths),
+		excludePaths:     formatPaths(excludePaths),
 		isGreedySearchOn: greedySearch,
 	}
 }
@@ -34,6 +34,8 @@ func (f *GitMappingPathMatcher) String() string {
 }
 
 func (f *GitMappingPathMatcher) MatchPath(path string) bool {
+	path = formatPath(path)
+
 	if !isRel(path, f.basePath) {
 		return false
 	}
@@ -56,7 +58,7 @@ func (f *GitMappingPathMatcher) MatchPath(path string) bool {
 }
 
 func (f *GitMappingPathMatcher) ProcessDirOrSubmodulePath(path string) (bool, bool) {
-	isMatched, shouldGoThrough := f.processDirOrSubmodulePath(path)
+	isMatched, shouldGoThrough := f.processDirOrSubmodulePath(formatPath(path))
 	if f.isGreedySearchOn {
 		return false, isMatched || shouldGoThrough
 	} else {

--- a/pkg/path_matcher/git_mapping_test.go
+++ b/pkg/path_matcher/git_mapping_test.go
@@ -1,6 +1,7 @@
 package path_matcher
 
 import (
+	"fmt"
 	"path/filepath"
 
 	. "github.com/onsi/ginkgo/extensions/table"
@@ -177,20 +178,20 @@ var _ = DescribeTable("git mapping path matcher (ProcessDirOrSubmodulePath)", fu
 
 	for _, matchedPath := range e.matchedPaths {
 		isMatched, shouldWalkThrough := pathMatcher.ProcessDirOrSubmodulePath(matchedPath)
-		Ω(isMatched).Should(BeTrue())
-		Ω(shouldWalkThrough).Should(BeFalse())
+		Ω(isMatched).Should(BeTrue(), fmt.Sprintln(pathMatcher, "==", matchedPath))
+		Ω(shouldWalkThrough).Should(BeFalse(), fmt.Sprintln(pathMatcher, "!=", matchedPath))
 	}
 
 	for _, shouldWalkThroughPath := range e.shouldWalkThroughPaths {
 		isMatched, shouldWalkThrough := pathMatcher.ProcessDirOrSubmodulePath(shouldWalkThroughPath)
-		Ω(isMatched).Should(BeFalse())
-		Ω(shouldWalkThrough).Should(BeTrue())
+		Ω(isMatched).Should(BeFalse(), fmt.Sprintln(pathMatcher, "!=", shouldWalkThroughPath))
+		Ω(shouldWalkThrough).Should(BeTrue(), fmt.Sprintln(pathMatcher, "==", shouldWalkThroughPath))
 	}
 
 	for _, notMatchedPath := range e.notMatchedPaths {
 		isMatched, shouldWalkThrough := pathMatcher.ProcessDirOrSubmodulePath(notMatchedPath)
-		Ω(isMatched).Should(BeFalse())
-		Ω(shouldWalkThrough).Should(BeFalse())
+		Ω(isMatched).Should(BeFalse(), fmt.Sprintln(pathMatcher, "!=", notMatchedPath))
+		Ω(shouldWalkThrough).Should(BeFalse(), fmt.Sprintln(pathMatcher, "!=", notMatchedPath))
 	}
 },
 	Entry("basePath is equal to the path (base)", gitMappingProcessDirOrSubmodulePath{

--- a/pkg/path_matcher/simple.go
+++ b/pkg/path_matcher/simple.go
@@ -8,8 +8,8 @@ import (
 
 func NewSimplePathMatcher(basePath string, paths []string, greedySearch bool) *SimplePathMatcher {
 	return &SimplePathMatcher{
-		basePathMatcher:  basePathMatcher{basePath: basePath},
-		paths:            paths,
+		basePathMatcher:  basePathMatcher{basePath: formatPath(basePath)},
+		paths:            formatPaths(paths),
 		isGreedySearchOn: greedySearch,
 	}
 }
@@ -33,6 +33,8 @@ func (f *SimplePathMatcher) String() string {
 }
 
 func (f *SimplePathMatcher) MatchPath(path string) bool {
+	path = formatPath(path)
+
 	if !isRel(path, f.basePath) {
 		return false
 	}
@@ -49,7 +51,7 @@ func (f *SimplePathMatcher) MatchPath(path string) bool {
 }
 
 func (f *SimplePathMatcher) ProcessDirOrSubmodulePath(path string) (bool, bool) {
-	isMatched, shouldGoThrough := f.processDirOrSubmodulePath(path)
+	isMatched, shouldGoThrough := f.processDirOrSubmodulePath(formatPath(path))
 	if f.isGreedySearchOn {
 		return false, isMatched || shouldGoThrough
 	} else {

--- a/pkg/path_matcher/simple_test.go
+++ b/pkg/path_matcher/simple_test.go
@@ -1,6 +1,7 @@
 package path_matcher
 
 import (
+	"fmt"
 	"path/filepath"
 
 	. "github.com/onsi/ginkgo/extensions/table"
@@ -18,11 +19,11 @@ var _ = DescribeTable("simple path matcher (MatchPath)", func(e simpleMatchPathE
 	pathMatcher := NewSimplePathMatcher(e.baseBase, e.paths, false)
 
 	for _, matchedPath := range e.matchedPaths {
-		Ω(pathMatcher.MatchPath(matchedPath)).Should(BeTrue())
+		Ω(pathMatcher.MatchPath(matchedPath)).Should(BeTrue(), fmt.Sprintln(pathMatcher, "==", matchedPath))
 	}
 
 	for _, notMatchedPath := range e.notMatchedPaths {
-		Ω(pathMatcher.MatchPath(notMatchedPath)).Should(BeFalse())
+		Ω(pathMatcher.MatchPath(notMatchedPath)).Should(BeFalse(), fmt.Sprintln(pathMatcher, "!=", notMatchedPath))
 	}
 },
 	Entry("basePath is equal to the path (paths)", simpleMatchPathEntry{


### PR DESCRIPTION
* Clean Path Matcher fields values during initialization: base path, include/exclude paths and so on
* Clean matched path