### PR TITLE
Hotfix go-build: remove lockgate replace from go.mod and update to actual master

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -35,7 +35,7 @@ require (
 	github.com/docker/swarmkit v0.0.0-20180705210007-199cf49cd996
 	github.com/fatih/color v1.9.0
 	github.com/flant/kubedog v0.3.5-0.20200228135326-83b69f5024b7
-	github.com/flant/lockgate v0.0.0-20200409203617-8b0e1ecca1c2
+	github.com/flant/lockgate v0.0.0-20200414151337-a491a50f21f7
 	github.com/flant/logboek v0.3.4
 	github.com/flynn-archive/go-shlex v0.0.0-20150515145356-3f9db97f8568
 	github.com/ghodss/yaml v1.0.1-0.20190212211648-25d852aebe32
@@ -174,6 +174,5 @@ replace github.com/docker/cli => github.com/docker/cli v0.0.0-20190321234815-f40
 
 replace golang.org/x/sys => golang.org/x/sys v0.0.0-20190813064441-fde4db37ae7a
 
-replace github.com/flant/lockgate => ../lockgate
 
 go 1.13

--- a/go.sum
+++ b/go.sum
@@ -286,10 +286,8 @@ github.com/flant/kubedog v0.3.5-0.20200220095422-0f37f3ed1897 h1:VIA/WAUnDM88stp
 github.com/flant/kubedog v0.3.5-0.20200220095422-0f37f3ed1897/go.mod h1:Tkg/l35Ep+mhIlDi8N2cSqOckllKjXSsJrDZnpJ/Wg4=
 github.com/flant/kubedog v0.3.5-0.20200228135326-83b69f5024b7 h1:MxWMApTpuVPnsFU/Di/Ltv60stjqz+6/hJDWFv760vM=
 github.com/flant/kubedog v0.3.5-0.20200228135326-83b69f5024b7/go.mod h1:Tkg/l35Ep+mhIlDi8N2cSqOckllKjXSsJrDZnpJ/Wg4=
-github.com/flant/lockgate v0.0.0-20200409155252-27db8576fe77 h1:KYvte7h9HEzIqCBrf+5FonXhXOyzzNxCrI4UU52rEcs=
-github.com/flant/lockgate v0.0.0-20200409155252-27db8576fe77/go.mod h1:WdrDHtPFsPIQtNMe2WNh342XoEc0zexChNzO4sesTuA=
-github.com/flant/lockgate v0.0.0-20200409203617-8b0e1ecca1c2 h1:QNyH0ESsGzgtdnm9noBrRHEr0Q8Rb4HYLsGm9nNUv0s=
-github.com/flant/lockgate v0.0.0-20200409203617-8b0e1ecca1c2/go.mod h1:WdrDHtPFsPIQtNMe2WNh342XoEc0zexChNzO4sesTuA=
+github.com/flant/lockgate v0.0.0-20200414151337-a491a50f21f7 h1:D7q+jVYlVP4cwXhLfM2egwSDQHjmvYwFI0HUziD6sV4=
+github.com/flant/lockgate v0.0.0-20200414151337-a491a50f21f7/go.mod h1:r51aBxbaufxAzjs4WiA0FihS6a/a8Z2T+6TkGj4z+aE=
 github.com/flant/logboek v0.2.5/go.mod h1:eEQXX0UOWpyC8iaA9QOvzx8drZ64u0SRESiwQKnxF+I=
 github.com/flant/logboek v0.2.6-0.20190726104558-c32b60bb4a37/go.mod h1:eEQXX0UOWpyC8iaA9QOvzx8drZ64u0SRESiwQKnxF+I=
 github.com/flant/logboek v0.2.6-0.20190918091020-d00ba619a349/go.mod h1:eEQXX0UOWpyC8iaA9QOvzx8drZ64u0SRESiwQKnxF+I=


### PR DESCRIPTION
https://github.com/flant/lockgate/pull/9