### PR TITLE
Remote storages support: implement stages-storage-cache in ConfigMap

### DIFF
--- a/cmd/werf/common/synchronization.go
+++ b/cmd/werf/common/synchronization.go
@@ -16,9 +16,7 @@ func GetStagesStorageCache(synchronization string) (storage.StagesStorageCache, 
 	case storage.LocalStagesStorageAddress:
 		return storage.NewFileStagesStorageCache(werf.GetStagesStorageCacheDir()), nil
 	case storage.KubernetesStagesStorageAddress:
-		return storage.NewFileStagesStorageCache(werf.GetStagesStorageCacheDir()), nil
-		// TODO
-		//return storage.NewKubernetesStagesStorageCache(WerfSynchronizationKubernetesNamespace), nil
+		return storage.NewKubernetesStagesStorageCache(WerfSynchronizationKubernetesNamespace), nil
 	default:
 		panic(fmt.Sprintf("unknown synchronization param %q", synchronization))
 	}

--- a/pkg/storage/kubernetes_helpers.go
+++ b/pkg/storage/kubernetes_helpers.go
@@ -1,0 +1,76 @@
+package storage
+
+import (
+	"fmt"
+
+	"github.com/flant/kubedog/pkg/kube"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func createNamespaceIfNotExists(namespace string) error {
+	if _, err := kube.Kubernetes.CoreV1().Namespaces().Get(namespace, metav1.GetOptions{}); errors.IsNotFound(err) {
+		ns := &v1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{Name: namespace},
+		}
+
+		if _, err := kube.Kubernetes.CoreV1().Namespaces().Create(ns); errors.IsAlreadyExists(err) {
+			return nil
+		} else if err != nil {
+			return fmt.Errorf("create Namespace %s error: %s", namespace, err)
+		}
+	} else if err != nil {
+		return fmt.Errorf("get Namespace %s error: %s", namespace, err)
+	}
+	return nil
+}
+
+//func createConfigMapIfNotExists(namespace, configMapName string) error {
+//	if _, err := kube.Kubernetes.CoreV1().ConfigMaps(namespace).Get(configMapName, metav1.GetOptions{}); errors.IsNotFound(err) {
+//		cm := &v1.ConfigMap{
+//			ObjectMeta: metav1.ObjectMeta{Name: configMapName},
+//		}
+//
+//		if _, err := kube.Kubernetes.CoreV1().ConfigMaps(namespace).Create(cm); errors.IsAlreadyExists(err) {
+//			return nil
+//		} else if err != nil {
+//			return fmt.Errorf("create ConfigMap %s error: %s", configMapName, err)
+//		}
+//	} else if err != nil {
+//		return fmt.Errorf("get ConfigMap %s error: %s", configMapName, err)
+//	}
+//	return nil
+//}
+
+func getOrCreateConfigMapWithNamespaceIfNotExists(namespace, configMapName string) (*v1.ConfigMap, error) {
+	if obj, err := kube.Kubernetes.CoreV1().ConfigMaps(namespace).Get(configMapName, metav1.GetOptions{}); errors.IsNotFound(err) {
+		if err := createNamespaceIfNotExists(namespace); err != nil {
+			return nil, err
+		}
+
+		cm := &v1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: configMapName},
+		}
+
+		if obj, err := kube.Kubernetes.CoreV1().ConfigMaps(namespace).Create(cm); errors.IsAlreadyExists(err) {
+			if obj, err := kube.Kubernetes.CoreV1().ConfigMaps(namespace).Get(configMapName, metav1.GetOptions{}); err != nil {
+				return nil, fmt.Errorf("get ConfigMap %s error: %s", configMapName, err)
+			} else {
+				return obj, err
+			}
+		} else if err != nil {
+			return nil, fmt.Errorf("create ConfigMap %s error: %s", cm.Name, err)
+		} else {
+			return obj, nil
+		}
+	} else if err != nil {
+		return nil, fmt.Errorf("get ConfigMap %s error: %s", configMapName, err)
+	} else {
+		return obj, nil
+	}
+}
+
+func configMapName(projectName string) string {
+	return fmt.Sprintf("werf-%s", projectName)
+}

--- a/pkg/storage/kubernetes_stages_storage_cache.go
+++ b/pkg/storage/kubernetes_stages_storage_cache.go
@@ -1,6 +1,19 @@
 package storage
 
-import "github.com/flant/werf/pkg/image"
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/flant/kubedog/pkg/kube"
+	"k8s.io/apimachinery/pkg/api/errors"
+
+	"github.com/flant/werf/pkg/image"
+	v1 "k8s.io/api/core/v1"
+)
+
+const (
+	StagesStorageCacheConfigMapKey = "stagesStorageCache"
+)
 
 func NewKubernetesStagesStorageCache(namespace string) *KubernetesStagesStorageCache {
 	return &KubernetesStagesStorageCache{Namespace: namespace}
@@ -10,18 +23,115 @@ type KubernetesStagesStorageCache struct {
 	Namespace string
 }
 
+type KubernetesStagesStorageCacheData struct {
+	StagesBySignature map[string][]image.StageID `json:"stagesBySignature"`
+}
+
+func (cache *KubernetesStagesStorageCache) extractCacheData(obj *v1.ConfigMap) (*KubernetesStagesStorageCacheData, error) {
+	if data, hasKey := obj.Data[StagesStorageCacheConfigMapKey]; hasKey {
+		var cacheData *KubernetesStagesStorageCacheData
+
+		if err := json.Unmarshal([]byte(data), &cacheData); err != nil {
+			return nil, fmt.Errorf("invalid json in cm/%s by key %q: %s", obj.Name, StagesStorageCacheConfigMapKey, err)
+		}
+
+		return cacheData, nil
+	} else {
+		return nil, nil
+	}
+}
+
+func (cache *KubernetesStagesStorageCache) setCacheData(obj *v1.ConfigMap, cacheData *KubernetesStagesStorageCacheData) {
+	if data, err := json.Marshal(cacheData); err != nil {
+		panic(fmt.Sprintf("cannot marshal data %#v into json: %s", cacheData, err))
+	} else {
+		if obj.Data == nil {
+			obj.Data = make(map[string]string)
+		}
+		obj.Data[StagesStorageCacheConfigMapKey] = string(data)
+	}
+}
+
 func (cache *KubernetesStagesStorageCache) GetAllStages(projectName string) (bool, []image.StageID, error) {
-	panic("no")
+	if obj, err := getOrCreateConfigMapWithNamespaceIfNotExists(cache.Namespace, configMapName(projectName)); err != nil {
+		return false, nil, err
+	} else if cacheData, err := cache.extractCacheData(obj); err != nil {
+		return false, nil, err
+	} else if cacheData != nil {
+		var res []image.StageID
+		for _, stagesBySignature := range cacheData.StagesBySignature {
+			res = append(res, stagesBySignature...)
+		}
+		return true, res, nil
+	}
+	return false, nil, nil
 }
 
 func (cache *KubernetesStagesStorageCache) GetStagesBySignature(projectName, signature string) (bool, []image.StageID, error) {
-	panic("no")
+	if obj, err := getOrCreateConfigMapWithNamespaceIfNotExists(cache.Namespace, configMapName(projectName)); err != nil {
+		return false, nil, err
+	} else if cacheData, err := cache.extractCacheData(obj); err != nil {
+		return false, nil, err
+	} else if cacheData != nil {
+		if stages, hasKey := cacheData.StagesBySignature[signature]; hasKey {
+			return true, stages, nil
+		}
+		return false, nil, nil
+	}
+	return false, nil, nil
 }
 
 func (cache *KubernetesStagesStorageCache) StoreStagesBySignature(projectName, signature string, stages []image.StageID) error {
-	panic("no")
+	return cache.changeCacheData(projectName, func(obj *v1.ConfigMap, cacheData *KubernetesStagesStorageCacheData) error {
+		if cacheData == nil {
+			cacheData = &KubernetesStagesStorageCacheData{
+				StagesBySignature: make(map[string][]image.StageID),
+			}
+		}
+		cacheData.StagesBySignature[signature] = stages
+		cache.setCacheData(obj, cacheData)
+		return nil
+	})
 }
 
 func (cache *KubernetesStagesStorageCache) DeleteStagesBySignature(projectName, signature string) error {
-	panic("no")
+	return cache.changeCacheData(projectName, func(obj *v1.ConfigMap, cacheData *KubernetesStagesStorageCacheData) error {
+		if cacheData != nil {
+			delete(cacheData.StagesBySignature, signature)
+			cache.setCacheData(obj, cacheData)
+		}
+		return nil
+	})
+}
+
+func (cache *KubernetesStagesStorageCache) changeCacheData(projectName string, changeFunc func(obj *v1.ConfigMap, cacheData *KubernetesStagesStorageCacheData) error) error {
+RETRY_CHANGE:
+
+	if obj, err := getOrCreateConfigMapWithNamespaceIfNotExists(cache.Namespace, configMapName(projectName)); err != nil {
+		return err
+	} else if cacheData, err := cache.extractCacheData(obj); err != nil {
+		return err
+	} else if cacheData != nil {
+		if err := changeFunc(obj, cacheData); err != nil {
+			return err
+		}
+
+		if _, err := kube.Kubernetes.CoreV1().ConfigMaps(cache.Namespace).Update(obj); errors.IsConflict(err) {
+			goto RETRY_CHANGE
+		} else if err != nil {
+			return fmt.Errorf("update cm/%s error: %s", obj.Name, err)
+		}
+	} else {
+		if err := changeFunc(obj, cacheData); err != nil {
+			return err
+		}
+
+		if _, err := kube.Kubernetes.CoreV1().ConfigMaps(cache.Namespace).Update(obj); errors.IsConflict(err) {
+			goto RETRY_CHANGE
+		} else if err != nil {
+			return fmt.Errorf("update cm/%s error: %s", obj.Name, err)
+		}
+	}
+
+	return nil
 }


### PR DESCRIPTION
 - Store stages-storage-cache in ns/werf-synchronization cm/werf-PROJECT_NAME
   when `--synchronization=:kubernetes` has been specified.
   - The same ConfigMap also used for kubernetes-based locks in annotations
     when `--synchronization=:kubernetes` has been specified.