### PR TITLE
Remote storages support: 'werf switch-from-local' command implemented

### DIFF
--- a/cmd/werf/main.go
+++ b/cmd/werf/main.go
@@ -39,7 +39,7 @@ import (
 	stages_build "github.com/flant/werf/cmd/werf/stages/build"
 	stages_cleanup "github.com/flant/werf/cmd/werf/stages/cleanup"
 	stages_purge "github.com/flant/werf/cmd/werf/stages/purge"
-	stages_switch "github.com/flant/werf/cmd/werf/stages/switch"
+	stages_switch "github.com/flant/werf/cmd/werf/stages/switch_from_local"
 	stages_sync "github.com/flant/werf/cmd/werf/stages/sync"
 
 	stage_image "github.com/flant/werf/cmd/werf/stage/image"

--- a/cmd/werf/stages/common/sync_and_switch.go
+++ b/cmd/werf/stages/common/sync_and_switch.go
@@ -73,9 +73,15 @@ func SetupToStagesStorage(commonCmdData *common.CmdData, cmdData *SyncCmdData, c
 	common.SetupQuayTokenForRepoData(cmdData.ToStagesStorageRepoData, cmd, "to-repo-quay-token", []string{"WERF_TO_REPO_QUAY_TOKEN", "WERF_REPO_QUAY_TOKEN"})
 }
 
-func NewFromStagesStorage(commonCmdData *common.CmdData, cmdData *SyncCmdData, containerRuntime container_runtime.ContainerRuntime) (storage.StagesStorage, error) {
+func NewFromStagesStorage(commonCmdData *common.CmdData, cmdData *SyncCmdData, containerRuntime container_runtime.ContainerRuntime, defaultAddress string) (storage.StagesStorage, error) {
+	var address string
 	if *cmdData.FromStagesStorage == "" {
-		return nil, fmt.Errorf("--from=ADDRESS param required")
+		if defaultAddress == "" {
+			return nil, fmt.Errorf("--from=ADDRESS param required")
+		}
+		address = defaultAddress
+	} else {
+		address = *cmdData.FromStagesStorage
 	}
 
 	repoData := common.MergeRepoData(cmdData.FromStagesStorageRepoData, commonCmdData.CommonRepoData)
@@ -84,7 +90,7 @@ func NewFromStagesStorage(commonCmdData *common.CmdData, cmdData *SyncCmdData, c
 		return nil, err
 	}
 
-	return NewStagesStorage(commonCmdData, *cmdData.FromStagesStorage, repoData, containerRuntime)
+	return NewStagesStorage(commonCmdData, address, repoData, containerRuntime)
 }
 
 func NewToStagesStorage(commonCmdData *common.CmdData, cmdData *SyncCmdData, containerRuntime container_runtime.ContainerRuntime) (storage.StagesStorage, error) {

--- a/cmd/werf/stages/sync/main.go
+++ b/cmd/werf/stages/sync/main.go
@@ -100,7 +100,7 @@ func runSync() error {
 
 	containerRuntime := &container_runtime.LocalDockerServerRuntime{} // TODO
 
-	fromStagesStorage, err := stages_common.NewFromStagesStorage(&commonCmdData, &cmdData, containerRuntime)
+	fromStagesStorage, err := stages_common.NewFromStagesStorage(&commonCmdData, &cmdData, containerRuntime, "")
 	if err != nil {
 		return err
 	}

--- a/pkg/stages_manager/sync_stages.go
+++ b/pkg/stages_manager/sync_stages.go
@@ -12,6 +12,7 @@ import (
 type SyncStagesOptions struct {
 	RemoveSource      bool
 	CleanupLocalCache bool
+	WithoutLock       bool
 }
 
 // SyncStages will make sure, that destination stages storage contains all stages from source stages storage.
@@ -28,10 +29,12 @@ func SyncStages(projectName string, fromStagesStorage storage.StagesStorage, toS
 		}
 	}()
 
-	if lock, err := storageLockManager.LockStagesAndImages(projectName, storage.LockStagesAndImagesOptions{GetOrCreateImagesOnly: true}); err != nil {
-		return fmt.Errorf("unable to lock stages and images of project %q: %s", projectName, err)
-	} else {
-		defer storageLockManager.Unlock(lock)
+	if !opts.WithoutLock {
+		if lock, err := storageLockManager.LockStagesAndImages(projectName, storage.LockStagesAndImagesOptions{GetOrCreateImagesOnly: true}); err != nil {
+			return fmt.Errorf("unable to lock stages and images of project %q: %s", projectName, err)
+		} else {
+			defer storageLockManager.Unlock(lock)
+		}
 	}
 
 	logboek.Default.LogFDetails("Source      — %s\n", fromStagesStorage.String())


### PR DESCRIPTION
werf switch-from-local --to registry.mycompany.com/mygroup/myproject

This command will:

 1. Sync existing local stages to the specified stages storage.
 2. Globally lock stages and images after sync.
 3. Set block to prevent any werf-command with --stages-storage=:local:
    user should change this param to the new stages-storage repo.
 4. Sync existing local stages to the specified stages storage second time.