### PR TITLE
[v1.1.8] Fix gitLatestPatch not built when previous stage has been discarded during build

### DIFF
--- a/pkg/build/build_phase.go
+++ b/pkg/build/build_phase.go
@@ -301,10 +301,6 @@ func (phase *BuildPhase) calculateStageSignature(img *Image, stg stage.Interface
 		stg.SetImage(i)
 	}
 
-	if err = stg.AfterImageSyncDockerStateHook(phase.Conveyor); err != nil {
-		return err
-	}
-
 	phase.PrevNonEmptyStage = stg
 	logboek.Debug.LogF("Set prev non empty stage = %q %s\n", phase.PrevNonEmptyStage.Name(), phase.PrevNonEmptyStage.GetSignature())
 	phase.PrevImage = i

--- a/pkg/build/conveyor.go
+++ b/pkg/build/conveyor.go
@@ -51,11 +51,10 @@ type Conveyor struct {
 
 	imagesInOrder []*Image
 
-	stageImages                     map[string]*image.StageImage
-	buildingGitStageNameByImageName map[string]stage.StageName
-	localGitRepo                    *git_repo.Local
-	remoteGitRepos                  map[string]*git_repo.Remote
-	imagesBySignature               map[string]image.ImageInterface
+	stageImages       map[string]*image.StageImage
+	localGitRepo      *git_repo.Local
+	remoteGitRepos    map[string]*git_repo.Remote
+	imagesBySignature map[string]image.ImageInterface
 
 	tmpDir string
 
@@ -78,16 +77,15 @@ func NewConveyor(werfConfig *config.WerfConfig, imageNamesToProcess []string, pr
 
 		sshAuthSock: sshAuthSock,
 
-		stageImages:                     make(map[string]*image.StageImage),
-		gitReposCaches:                  make(map[string]*stage.GitRepoCache),
-		baseImagesRepoIdsCache:          make(map[string]string),
-		baseImagesRepoErrCache:          make(map[string]error),
-		imagesInOrder:                   []*Image{},
-		imagesBySignature:               make(map[string]image.ImageInterface),
-		buildingGitStageNameByImageName: make(map[string]stage.StageName),
-		remoteGitRepos:                  make(map[string]*git_repo.Remote),
-		tmpDir:                          filepath.Join(baseTmpDir, string(util.GenerateConsistentRandomString(10))),
-		importServers:                   make(map[string]import_server.ImportServer),
+		stageImages:            make(map[string]*image.StageImage),
+		gitReposCaches:         make(map[string]*stage.GitRepoCache),
+		baseImagesRepoIdsCache: make(map[string]string),
+		baseImagesRepoErrCache: make(map[string]error),
+		imagesInOrder:          []*Image{},
+		imagesBySignature:      make(map[string]image.ImageInterface),
+		remoteGitRepos:         make(map[string]*git_repo.Remote),
+		tmpDir:                 filepath.Join(baseTmpDir, string(util.GenerateConsistentRandomString(10))),
+		importServers:          make(map[string]import_server.ImportServer),
 
 		StagesStorage:      &storage.LocalStagesStorage{},
 		StorageLockManager: &storage.FileLockManager{},
@@ -612,19 +610,6 @@ func (c *Conveyor) GetImageIDForLastImageStage(imageName string) string {
 
 func (c *Conveyor) GetImageIDForImageStage(imageName, stageName string) string {
 	return c.getImageStage(imageName, stageName).GetImage().ID()
-}
-
-func (c *Conveyor) SetBuildingGitStage(imageName string, stageName stage.StageName) {
-	c.buildingGitStageNameByImageName[imageName] = stageName
-}
-
-func (c *Conveyor) GetBuildingGitStage(imageName string) stage.StageName {
-	stageName, ok := c.buildingGitStageNameByImageName[imageName]
-	if !ok {
-		return ""
-	}
-
-	return stageName
 }
 
 func (c *Conveyor) GetImageTmpDir(imageName string) string {

--- a/pkg/build/stage/base.go
+++ b/pkg/build/stage/base.go
@@ -236,10 +236,6 @@ func (s *BaseStage) PrepareImage(_ Conveyor, prevBuiltImage, image imagePkg.Imag
 	return nil
 }
 
-func (s *BaseStage) AfterImageSyncDockerStateHook(_ Conveyor) error {
-	return nil
-}
-
 func (s *BaseStage) PreRunHook(_ Conveyor) error {
 	return nil
 }

--- a/pkg/build/stage/conveyor.go
+++ b/pkg/build/stage/conveyor.go
@@ -12,7 +12,5 @@ type Conveyor interface {
 	GetImageNameForImageStage(imageName, stageName string) string
 	GetImageIDForImageStage(imageName, stageName string) string
 
-	SetBuildingGitStage(imageName string, stageName StageName)
-	GetBuildingGitStage(imageName string) StageName
 	GetImportServer(imageName, stageName string) (import_server.ImportServer, error)
 }

--- a/pkg/build/stage/git.go
+++ b/pkg/build/stage/git.go
@@ -22,17 +22,6 @@ func (s *GitStage) isEmpty() bool {
 	return len(s.gitMappings) == 0
 }
 
-func (s *GitStage) AfterImageSyncDockerStateHook(c Conveyor) error {
-	if !s.image.IsExists() {
-		stageName := c.GetBuildingGitStage(s.imageName)
-		if stageName == "" {
-			c.SetBuildingGitStage(s.imageName, s.Name())
-		}
-	}
-
-	return nil
-}
-
 func (s *GitStage) PrepareImage(c Conveyor, prevBuiltImage, image image.ImageInterface) error {
 	if err := s.BaseStage.PrepareImage(c, prevBuiltImage, image); err != nil {
 		return err

--- a/pkg/build/stage/git_patch.go
+++ b/pkg/build/stage/git_patch.go
@@ -40,34 +40,13 @@ type GitPatchStage struct {
 }
 
 func (s *GitPatchStage) IsEmpty(c Conveyor, prevBuiltImage image.ImageInterface) (bool, error) {
-	if empty, err := s.willGitLatestCommitBeBuiltOnPrevGitStage(c); err != nil {
-		return false, err
-	} else if empty {
-		return true, nil
-	}
-
 	if empty, err := s.GitStage.IsEmpty(c, prevBuiltImage); err != nil {
 		return false, err
 	} else if empty {
 		return true, nil
 	}
 
-	if empty, err := s.hasPrevBuiltStageHadActualGitMappings(prevBuiltImage); err != nil {
-		return false, err
-	} else if empty {
-		return true, nil
-	}
-
-	return false, nil
-}
-
-func (s *GitPatchStage) willGitLatestCommitBeBuiltOnPrevGitStage(c Conveyor) (bool, error) {
-	stageName := c.GetBuildingGitStage(s.imageName)
-	if stageName != "" && stageName != s.Name() {
-		return true, nil
-	}
-
-	return false, nil
+	return s.hasPrevBuiltStageHadActualGitMappings(prevBuiltImage)
 }
 
 func (s *GitPatchStage) hasPrevBuiltStageHadActualGitMappings(prevBuiltImage image.ImageInterface) (bool, error) {

--- a/pkg/build/stage/interface.go
+++ b/pkg/build/stage/interface.go
@@ -17,7 +17,6 @@ type Interface interface {
 
 	PrepareImage(c Conveyor, prevBuiltImage, image image.ImageInterface) error
 
-	AfterImageSyncDockerStateHook(Conveyor) error
 	PreRunHook(Conveyor) error
 
 	SetSignature(signature string)


### PR DESCRIPTION
 - remove git-building-stage map from Conveyor;
 - remove AfterImageSyncDockerStateHook Stage hook.