### PR TITLE
[v1.1.9] Fix gitLatestPatch not built when previous stage has been discarded during build

### DIFF
--- a/pkg/build/build_phase.go
+++ b/pkg/build/build_phase.go
@@ -235,10 +235,6 @@ func (phase *BuildPhase) calculateStage(img *Image, stg stage.Interface) error {
 		}
 	}
 
-	if err = stg.AfterSignatureCalculated(phase.Conveyor); err != nil {
-		return err
-	}
-
 	stageContentSig, err := calculateSignature(fmt.Sprintf("%s-content", stg.Name()), "", stg, phase.Conveyor)
 	if err != nil {
 		return fmt.Errorf("unable to calculate stage %s content-signature: %s", stg.Name(), err)

--- a/pkg/build/conveyor.go
+++ b/pkg/build/conveyor.go
@@ -52,10 +52,9 @@ type Conveyor struct {
 
 	imagesInOrder []*Image
 
-	stageImages                     map[string]*container_runtime.StageImage
-	buildingGitStageNameByImageName map[string]stage.StageName
-	localGitRepo                    *git_repo.Local
-	remoteGitRepos                  map[string]*git_repo.Remote
+	stageImages    map[string]*container_runtime.StageImage
+	localGitRepo   *git_repo.Local
+	remoteGitRepos map[string]*git_repo.Remote
 
 	tmpDir string
 
@@ -80,15 +79,14 @@ func NewConveyor(werfConfig *config.WerfConfig, imageNamesToProcess []string, pr
 
 		sshAuthSock: sshAuthSock,
 
-		stageImages:                     make(map[string]*container_runtime.StageImage),
-		gitReposCaches:                  make(map[string]*stage.GitRepoCache),
-		baseImagesRepoIdsCache:          make(map[string]string),
-		baseImagesRepoErrCache:          make(map[string]error),
-		imagesInOrder:                   []*Image{},
-		buildingGitStageNameByImageName: make(map[string]stage.StageName),
-		remoteGitRepos:                  make(map[string]*git_repo.Remote),
-		tmpDir:                          filepath.Join(baseTmpDir, string(util.GenerateConsistentRandomString(10))),
-		importServers:                   make(map[string]import_server.ImportServer),
+		stageImages:            make(map[string]*container_runtime.StageImage),
+		gitReposCaches:         make(map[string]*stage.GitRepoCache),
+		baseImagesRepoIdsCache: make(map[string]string),
+		baseImagesRepoErrCache: make(map[string]error),
+		imagesInOrder:          []*Image{},
+		remoteGitRepos:         make(map[string]*git_repo.Remote),
+		tmpDir:                 filepath.Join(baseTmpDir, string(util.GenerateConsistentRandomString(10))),
+		importServers:          make(map[string]import_server.ImportServer),
 
 		ContainerRuntime:   containerRuntime,
 		ImagesRepo:         imagesRepo,
@@ -608,19 +606,6 @@ func (c *Conveyor) GetImageIDForLastImageStage(imageName string) string {
 
 func (c *Conveyor) GetImageIDForImageStage(imageName, stageName string) string {
 	return c.getImageStage(imageName, stageName).GetImage().GetStageDescription().Info.ID
-}
-
-func (c *Conveyor) SetBuildingGitStage(imageName string, stageName stage.StageName) {
-	c.buildingGitStageNameByImageName[imageName] = stageName
-}
-
-func (c *Conveyor) GetBuildingGitStage(imageName string) stage.StageName {
-	stageName, ok := c.buildingGitStageNameByImageName[imageName]
-	if !ok {
-		return ""
-	}
-
-	return stageName
 }
 
 func (c *Conveyor) GetImageTmpDir(imageName string) string {

--- a/pkg/build/stage/base.go
+++ b/pkg/build/stage/base.go
@@ -238,10 +238,6 @@ func (s *BaseStage) PrepareImage(_ Conveyor, prevBuiltImage, image container_run
 	return nil
 }
 
-func (s *BaseStage) AfterSignatureCalculated(_ Conveyor) error {
-	return nil
-}
-
 func (s *BaseStage) PreRunHook(_ Conveyor) error {
 	return nil
 }

--- a/pkg/build/stage/conveyor.go
+++ b/pkg/build/stage/conveyor.go
@@ -12,7 +12,5 @@ type Conveyor interface {
 	GetImageNameForImageStage(imageName, stageName string) string
 	GetImageIDForImageStage(imageName, stageName string) string
 
-	SetBuildingGitStage(imageName string, stageName StageName)
-	GetBuildingGitStage(imageName string) StageName
 	GetImportServer(imageName, stageName string) (import_server.ImportServer, error)
 }

--- a/pkg/build/stage/git.go
+++ b/pkg/build/stage/git.go
@@ -20,17 +20,6 @@ func (s *GitStage) isEmpty() bool {
 	return len(s.gitMappings) == 0
 }
 
-func (s *GitStage) AfterSignatureCalculated(c Conveyor) error {
-	if s.image.GetStageDescription() == nil {
-		stageName := c.GetBuildingGitStage(s.imageName)
-		if stageName == "" {
-			c.SetBuildingGitStage(s.imageName, s.Name())
-		}
-	}
-
-	return nil
-}
-
 func (s *GitStage) PrepareImage(c Conveyor, prevBuiltImage, image container_runtime.ImageInterface) error {
 	if err := s.BaseStage.PrepareImage(c, prevBuiltImage, image); err != nil {
 		return err

--- a/pkg/build/stage/git_patch.go
+++ b/pkg/build/stage/git_patch.go
@@ -40,34 +40,13 @@ type GitPatchStage struct {
 }
 
 func (s *GitPatchStage) IsEmpty(c Conveyor, prevBuiltImage container_runtime.ImageInterface) (bool, error) {
-	if empty, err := s.willGitLatestCommitBeBuiltOnPrevGitStage(c); err != nil {
-		return false, err
-	} else if empty {
-		return true, nil
-	}
-
 	if empty, err := s.GitStage.IsEmpty(c, prevBuiltImage); err != nil {
 		return false, err
 	} else if empty {
 		return true, nil
 	}
 
-	if empty, err := s.hasPrevBuiltStageHadActualGitMappings(prevBuiltImage); err != nil {
-		return false, err
-	} else if empty {
-		return true, nil
-	}
-
-	return false, nil
-}
-
-func (s *GitPatchStage) willGitLatestCommitBeBuiltOnPrevGitStage(c Conveyor) (bool, error) {
-	stageName := c.GetBuildingGitStage(s.imageName)
-	if stageName != "" && stageName != s.Name() {
-		return true, nil
-	}
-
-	return false, nil
+	return s.hasPrevBuiltStageHadActualGitMappings(prevBuiltImage)
 }
 
 func (s *GitPatchStage) hasPrevBuiltStageHadActualGitMappings(prevBuiltImage container_runtime.ImageInterface) (bool, error) {

--- a/pkg/build/stage/interface.go
+++ b/pkg/build/stage/interface.go
@@ -17,7 +17,6 @@ type Interface interface {
 
 	PrepareImage(c Conveyor, prevBuiltImage, image container_runtime.ImageInterface) error
 
-	AfterSignatureCalculated(Conveyor) error
 	PreRunHook(Conveyor) error
 
 	SetSignature(signature string)

--- a/pkg/build/stage/user_with_git_patch.go
+++ b/pkg/build/stage/user_with_git_patch.go
@@ -34,28 +34,23 @@ func (s *UserWithGitPatchStage) GetNextStageDependencies(c Conveyor) (string, er
 	return s.BaseStage.getNextStageGitDependencies(c)
 }
 
+func (s *UserWithGitPatchStage) IsEmpty(c Conveyor, prevBuiltImage container_runtime.ImageInterface) (bool, error) {
+	if empty, err := s.UserStage.IsEmpty(c, prevBuiltImage); err != nil {
+		return false, err
+	} else if empty {
+		return true, nil
+	}
+
+	return s.GitPatchStage.IsEmpty(c, prevBuiltImage)
+}
+
 func (s *UserWithGitPatchStage) PrepareImage(c Conveyor, prevBuiltImage, image container_runtime.ImageInterface) error {
 	if err := s.BaseStage.PrepareImage(c, prevBuiltImage, image); err != nil {
 		return err
 	}
 
-	if !s.GitPatchStage.isEmpty() {
-		stageName := c.GetBuildingGitStage(s.imageName)
-		if stageName == s.Name() {
-			if err := s.GitPatchStage.prepareImage(c, prevBuiltImage, image); err != nil {
-				return err
-			}
-		}
-	}
-
-	return nil
-}
-
-func (s *UserWithGitPatchStage) AfterSignatureCalculated(c Conveyor) error {
-	if !s.GitPatchStage.isEmpty() {
-		if err := s.GitPatchStage.AfterSignatureCalculated(c); err != nil {
-			return err
-		}
+	if err := s.GitPatchStage.prepareImage(c, prevBuiltImage, image); err != nil {
+		return err
 	}
 
 	return nil

--- a/pkg/build/stages_iterator.go
+++ b/pkg/build/stages_iterator.go
@@ -44,6 +44,7 @@ func (iterator *StagesIterator) OnImageStage(img *Image, stg stage.Interface, on
 	if err != nil {
 		return fmt.Errorf("error checking stage %s is empty: %s", stg.Name(), err)
 	}
+	logboek.Debug.LogF("%s stage is empty: %v\n", stg.LogDetailedName(), isEmpty)
 
 	if stg.Name() != "from" && stg.Name() != "dockerfile" {
 		if iterator.PrevStage == nil {


### PR DESCRIPTION
 - remove git-building-stage map from Conveyor;
 - remove AfterSignatureCalculated Stage hook.