### PR TITLE
Remote storages support: auto reset stages-storage-cache and retry action

### DIFF
--- a/cmd/werf/build_and_publish/main.go
+++ b/cmd/werf/build_and_publish/main.go
@@ -224,10 +224,13 @@ func runBuildAndPublish(imagesToProcess []string) error {
 	}
 
 	logboek.LogOptionalLn()
-	c := build.NewConveyor(werfConfig, imagesToProcess, projectDir, projectTmpDir, ssh_agent.SSHAuthSock, containerRuntime, stagesManager, imagesRepo, storageLockManager)
-	defer c.Terminate()
 
-	if err = c.BuildAndPublish(opts); err != nil {
+	conveyorWithRetry := build.NewConveyorWithRetryWrapper(werfConfig, imagesToProcess, projectDir, projectTmpDir, ssh_agent.SSHAuthSock, containerRuntime, stagesManager, imagesRepo, storageLockManager)
+	defer conveyorWithRetry.Terminate()
+
+	if err := conveyorWithRetry.WithRetryBlock(func(c *build.Conveyor) error {
+		return c.BuildAndPublish(opts)
+	}); err != nil {
 		return err
 	}
 

--- a/cmd/werf/images/publish/cmd_factory/main.go
+++ b/cmd/werf/images/publish/cmd_factory/main.go
@@ -179,10 +179,12 @@ func runImagesPublish(commonCmdData *common.CmdData, imagesToProcess []string) e
 		TagOptions:      tagOpts,
 	}
 
-	c := build.NewConveyor(werfConfig, imagesToProcess, projectDir, projectTmpDir, ssh_agent.SSHAuthSock, containerRuntime, stagesManager, imagesRepo, storageLockManager)
-	defer c.Terminate()
+	conveyorWithRetry := build.NewConveyorWithRetryWrapper(werfConfig, imagesToProcess, projectDir, projectTmpDir, ssh_agent.SSHAuthSock, containerRuntime, stagesManager, imagesRepo, storageLockManager)
+	defer conveyorWithRetry.Terminate()
 
-	if err = c.PublishImages(opts); err != nil {
+	if err := conveyorWithRetry.WithRetryBlock(func(c *build.Conveyor) error {
+		return c.PublishImages(opts)
+	}); err != nil {
 		return err
 	}
 

--- a/cmd/werf/run/run.go
+++ b/cmd/werf/run/run.go
@@ -246,14 +246,24 @@ func runRun() error {
 	}
 
 	logboek.Info.LogOptionalLn()
-	c := build.NewConveyor(werfConfig, []string{imageName}, projectDir, projectTmpDir, ssh_agent.SSHAuthSock, containerRuntime, stagesManager, nil, storageLockManager)
-	defer c.Terminate()
 
-	if err = c.ShouldBeBuilt(); err != nil {
+	var dockerImageName string
+
+	conveyorWithRetry := build.NewConveyorWithRetryWrapper(werfConfig, []string{imageName}, projectDir, projectTmpDir, ssh_agent.SSHAuthSock, containerRuntime, stagesManager, nil, storageLockManager)
+	defer conveyorWithRetry.Terminate()
+
+	if err := conveyorWithRetry.WithRetryBlock(func(c *build.Conveyor) error {
+		if err := c.ShouldBeBuilt(build.ShouldBeBuiltOptions{FetchLastStage: true}); err != nil {
+			return err
+		}
+
+		dockerImageName = c.GetImageNameForLastImageStage(imageName)
+
+		return nil
+	}); err != nil {
 		return err
 	}
 
-	dockerImageName := c.GetImageNameForLastImageStage(imageName)
 	var dockerRunArgs []string
 	dockerRunArgs = append(dockerRunArgs, cmdData.DockerOptions...)
 	dockerRunArgs = append(dockerRunArgs, dockerImageName)

--- a/cmd/werf/stage/image/main.go
+++ b/cmd/werf/stage/image/main.go
@@ -169,14 +169,20 @@ func run(imageName string) error {
 		return err
 	}
 
-	c := build.NewConveyor(werfConfig, []string{imageName}, projectDir, projectTmpDir, ssh_agent.SSHAuthSock, containerRuntime, stagesManager, nil, storageLockManager)
-	defer c.Terminate()
+	conveyorWithRetry := build.NewConveyorWithRetryWrapper(werfConfig, []string{imageName}, projectDir, projectTmpDir, ssh_agent.SSHAuthSock, containerRuntime, stagesManager, nil, storageLockManager)
+	defer conveyorWithRetry.Terminate()
 
-	if err = c.ShouldBeBuilt(); err != nil {
+	if err := conveyorWithRetry.WithRetryBlock(func(c *build.Conveyor) error {
+		if err = c.ShouldBeBuilt(build.ShouldBeBuiltOptions{}); err != nil {
+			return err
+		}
+
+		fmt.Println(c.GetImageNameForLastImageStage(imageName))
+
+		return nil
+	}); err != nil {
 		return err
 	}
-
-	fmt.Println(c.GetImageNameForLastImageStage(imageName))
 
 	return nil
 }

--- a/pkg/build/conveyor.go
+++ b/pkg/build/conveyor.go
@@ -212,7 +212,11 @@ type TagOptions struct {
 	TagByStagesSignature bool
 }
 
-func (c *Conveyor) ShouldBeBuilt() error {
+type ShouldBeBuiltOptions struct {
+	FetchLastStage bool
+}
+
+func (c *Conveyor) ShouldBeBuilt(opts ShouldBeBuiltOptions) error {
 	if err := c.determineStages(); err != nil {
 		return err
 	}
@@ -221,7 +225,20 @@ func (c *Conveyor) ShouldBeBuilt() error {
 		NewBuildPhase(c, BuildPhaseOptions{ShouldBeBuiltMode: true}),
 	}
 
-	return c.runPhases(phases, false)
+	if err := c.runPhases(phases, false); err != nil {
+		return err
+	}
+
+	if opts.FetchLastStage {
+		for _, imageName := range c.imageNamesToProcess {
+			lastImageStage := c.GetImage(imageName).GetLastNonEmptyStage()
+			if err := c.StagesManager.FetchStage(lastImageStage); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
 }
 
 func (c *Conveyor) GetImageInfoGetters(configImages []*config.StapelImage, configImagesFromDockerfile []*config.ImageFromDockerfile, commonTag string, tagStrategy tag_strategy.TagStrategy, withoutRegistry bool) []images_manager.ImageInfoGetter {
@@ -474,23 +491,6 @@ func (c *Conveyor) runPhases(phases []Phase, logImages bool) error {
 
 	return nil
 }
-
-/*
-TODO: locks and log
-func (c *Conveyor) runPhases(phases []Phase) error {
-		logboek.LogOptionalLn()
-
-		for _, phase := range phases {
-			err := phase.Run(c)
-
-			if err != nil {
-				c.StorageLockManager.ReleaseAllStageLocks()
-				return err
-			}
-		}
-	return nil
-}
-*/
 
 func (c *Conveyor) projectName() string {
 	return c.werfConfig.Meta.Project

--- a/pkg/build/conveyor_with_retry.go
+++ b/pkg/build/conveyor_with_retry.go
@@ -1,0 +1,79 @@
+package build
+
+import (
+	"fmt"
+
+	"github.com/flant/werf/pkg/config"
+	"github.com/flant/werf/pkg/container_runtime"
+	"github.com/flant/werf/pkg/stages_manager"
+	"github.com/flant/werf/pkg/storage"
+)
+
+type ConveyorWithRetryWrapper struct {
+	WerfConfig          *config.WerfConfig
+	ImageNamesToProcess []string
+	ProjectDir          string
+	BaseTmpDir          string
+	SshAuthSock         string
+	ContainerRuntime    container_runtime.ContainerRuntime
+	StagesManager       *stages_manager.StagesManager
+	ImagesRepo          storage.ImagesRepo
+	StorageLockManager  storage.LockManager
+
+	conveyorsToTerminate []*Conveyor
+}
+
+func NewConveyorWithRetryWrapper(werfConfig *config.WerfConfig, imageNamesToProcess []string, projectDir, baseTmpDir, sshAuthSock string, containerRuntime container_runtime.ContainerRuntime, stagesManager *stages_manager.StagesManager, imagesRepo storage.ImagesRepo, storageLockManager storage.LockManager) *ConveyorWithRetryWrapper {
+	return &ConveyorWithRetryWrapper{
+		WerfConfig:          werfConfig,
+		ImageNamesToProcess: imageNamesToProcess,
+		ProjectDir:          projectDir,
+		BaseTmpDir:          baseTmpDir,
+		SshAuthSock:         sshAuthSock,
+		ContainerRuntime:    containerRuntime,
+		StagesManager:       stagesManager,
+		ImagesRepo:          imagesRepo,
+		StorageLockManager:  storageLockManager,
+	}
+}
+
+func (wrapper *ConveyorWithRetryWrapper) Terminate() error {
+	var terminateErrors []error
+	for _, conveyorToTerminate := range wrapper.conveyorsToTerminate {
+		if err := conveyorToTerminate.Terminate(); err != nil {
+			terminateErrors = append(terminateErrors, err)
+		}
+	}
+
+	if len(terminateErrors) > 0 {
+		return fmt.Errorf("there were errors during conveyors termination")
+	}
+	return nil
+}
+
+func (wrapper *ConveyorWithRetryWrapper) WithRetryBlock(f func(c *Conveyor) error) error {
+Retry:
+	newConveyor := NewConveyor(
+		wrapper.WerfConfig,
+		wrapper.ImageNamesToProcess,
+		wrapper.ProjectDir,
+		wrapper.BaseTmpDir,
+		wrapper.SshAuthSock,
+		wrapper.ContainerRuntime,
+		wrapper.StagesManager,
+		wrapper.ImagesRepo,
+		wrapper.StorageLockManager,
+	)
+	wrapper.conveyorsToTerminate = append(wrapper.conveyorsToTerminate, newConveyor)
+
+	if err := f(newConveyor); stages_manager.ShouldResetStagesStorageCache(err) {
+		if err := newConveyor.StagesManager.ResetStagesStorageCache(); err != nil {
+			return err
+		}
+		goto Retry
+	} else if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/storage/kubernetes_stages_storage_cache.go
+++ b/pkg/storage/kubernetes_stages_storage_cache.go
@@ -27,6 +27,10 @@ type KubernetesStagesStorageCacheData struct {
 	StagesBySignature map[string][]image.StageID `json:"stagesBySignature"`
 }
 
+func (cache *KubernetesStagesStorageCache) String() string {
+	return fmt.Sprintf("kuberntes ns/%s", cache.Namespace)
+}
+
 func (cache *KubernetesStagesStorageCache) extractCacheData(obj *v1.ConfigMap) (*KubernetesStagesStorageCacheData, error) {
 	if data, hasKey := obj.Data[StagesStorageCacheConfigMapKey]; hasKey {
 		var cacheData *KubernetesStagesStorageCacheData
@@ -38,6 +42,12 @@ func (cache *KubernetesStagesStorageCache) extractCacheData(obj *v1.ConfigMap) (
 		return cacheData, nil
 	} else {
 		return nil, nil
+	}
+}
+
+func (cache *KubernetesStagesStorageCache) unsetCacheData(obj *v1.ConfigMap) {
+	if obj.Data != nil {
+		delete(obj.Data, StagesStorageCacheConfigMapKey)
 	}
 }
 
@@ -65,6 +75,13 @@ func (cache *KubernetesStagesStorageCache) GetAllStages(projectName string) (boo
 		return true, res, nil
 	}
 	return false, nil, nil
+}
+
+func (cache *KubernetesStagesStorageCache) DeleteAllStages(projectName string) error {
+	return cache.changeCacheData(projectName, func(obj *v1.ConfigMap, cacheData *KubernetesStagesStorageCacheData) error {
+		cache.unsetCacheData(obj)
+		return nil
+	})
 }
 
 func (cache *KubernetesStagesStorageCache) GetStagesBySignature(projectName, signature string) (bool, []image.StageID, error) {

--- a/pkg/storage/stages_storage_cache.go
+++ b/pkg/storage/stages_storage_cache.go
@@ -4,7 +4,10 @@ import "github.com/flant/werf/pkg/image"
 
 type StagesStorageCache interface {
 	GetAllStages(projectName string) (bool, []image.StageID, error)
+	DeleteAllStages(projectName string) error
 	GetStagesBySignature(projectName, signature string) (bool, []image.StageID, error)
 	StoreStagesBySignature(projectName, signature string, stages []image.StageID) error
 	DeleteStagesBySignature(projectName, signature string) error
+
+	String() string
 }


### PR DESCRIPTION
 - Added conveyor wrapper that catches stages-storage-cache should be reset error,
   deletes stages-storage cache for the project and then automatically restarts an action.

 - Added DeleteAllStages method for StagesStorageCache, implemented for
   file cache and kubernetes cache.