### PR TITLE
Remote storages support: refactor --synchronization param

### DIFF
--- a/cmd/werf/build_and_publish/main.go
+++ b/cmd/werf/build_and_publish/main.go
@@ -2,10 +2,9 @@ package build_and_publish
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/flant/kubedog/pkg/kube"
-	"github.com/flant/werf/pkg/storage"
-
 	"github.com/flant/werf/pkg/image"
 
 	"github.com/flant/werf/pkg/stages_manager"
@@ -161,11 +160,11 @@ func runBuildAndPublish(imagesToProcess []string) error {
 		return err
 	}
 
-	synchronization, err := common.GetSynchronization(&commonCmdData)
+	synchronization, err := common.GetSynchronization(&commonCmdData, stagesStorage.Address())
 	if err != nil {
 		return err
 	}
-	if synchronization == storage.KubernetesStagesStorageAddress {
+	if strings.HasPrefix(synchronization, "kubernetes://") {
 		if err := kube.Init(kube.InitOptions{KubeContext: *commonCmdData.KubeContext, KubeConfig: *commonCmdData.KubeConfig}); err != nil {
 			return fmt.Errorf("cannot initialize kube: %s", err)
 		}

--- a/cmd/werf/cleanup/cleanup.go
+++ b/cmd/werf/cleanup/cleanup.go
@@ -126,7 +126,7 @@ func runCleanup() error {
 		return err
 	}
 
-	synchronization, err := common.GetSynchronization(&commonCmdData)
+	synchronization, err := common.GetSynchronization(&commonCmdData, stagesStorage.Address())
 	if err != nil {
 		return err
 	}

--- a/cmd/werf/common/synchronization.go
+++ b/cmd/werf/common/synchronization.go
@@ -2,33 +2,30 @@ package common
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/flant/werf/pkg/storage"
 	"github.com/flant/werf/pkg/werf"
 )
 
-const (
-	WerfSynchronizationKubernetesNamespace = "werf-synchronization"
-)
-
 func GetStagesStorageCache(synchronization string) (storage.StagesStorageCache, error) {
-	switch synchronization {
-	case storage.LocalStagesStorageAddress:
+	if synchronization == storage.LocalStorageAddress {
 		return storage.NewFileStagesStorageCache(werf.GetStagesStorageCacheDir()), nil
-	case storage.KubernetesStagesStorageAddress:
-		return storage.NewKubernetesStagesStorageCache(WerfSynchronizationKubernetesNamespace), nil
-	default:
+	} else if strings.HasPrefix(synchronization, "kubernetes://") {
+		ns := strings.TrimPrefix(synchronization, "kubernetes://")
+		return storage.NewKubernetesStagesStorageCache(ns), nil
+	} else {
 		panic(fmt.Sprintf("unknown synchronization param %q", synchronization))
 	}
 }
 
 func GetStorageLockManager(synchronization string) (storage.LockManager, error) {
-	switch synchronization {
-	case storage.LocalStagesStorageAddress:
+	if synchronization == storage.LocalStorageAddress {
 		return storage.NewGenericLockManager(werf.GetHostLocker()), nil
-	case storage.KubernetesStagesStorageAddress:
-		return storage.NewKubernetesLockManager(WerfSynchronizationKubernetesNamespace), nil
-	default:
+	} else if strings.HasPrefix(synchronization, "kubernetes://") {
+		ns := strings.TrimPrefix(synchronization, "kubernetes://")
+		return storage.NewKubernetesLockManager(ns), nil
+	} else {
 		panic(fmt.Sprintf("unknown synchronization param %q", synchronization))
 	}
 }

--- a/cmd/werf/deploy/main.go
+++ b/cmd/werf/deploy/main.go
@@ -201,7 +201,7 @@ func runDeploy() error {
 			return err
 		}
 
-		synchronization, err := common.GetSynchronization(&commonCmdData)
+		synchronization, err := common.GetSynchronization(&commonCmdData, stagesStorage.Address())
 		if err != nil {
 			return err
 		}

--- a/cmd/werf/host/project/purge/purge.go
+++ b/cmd/werf/host/project/purge/purge.go
@@ -2,10 +2,9 @@ package list
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/flant/kubedog/pkg/kube"
-	"github.com/flant/werf/pkg/storage"
-
 	"github.com/flant/werf/pkg/image"
 
 	"github.com/flant/werf/pkg/stages_manager"
@@ -89,11 +88,11 @@ func run(projectNames ...string) error {
 		return err
 	}
 
-	synchronization, err := common.GetSynchronization(&commonCmdData)
+	synchronization, err := common.GetSynchronization(&commonCmdData, stagesStorage.Address())
 	if err != nil {
 		return err
 	}
-	if synchronization == storage.KubernetesStagesStorageAddress {
+	if strings.HasPrefix(synchronization, "kubernetes://") {
 		if err := kube.Init(kube.InitOptions{KubeContext: *commonCmdData.KubeContext, KubeConfig: *commonCmdData.KubeConfig}); err != nil {
 			return fmt.Errorf("cannot initialize kube: %s", err)
 		}

--- a/cmd/werf/images/cleanup/cleanup.go
+++ b/cmd/werf/images/cleanup/cleanup.go
@@ -120,7 +120,7 @@ func runCleanup() error {
 		return err
 	}
 
-	synchronization, err := common.GetSynchronization(&commonCmdData)
+	synchronization, err := common.GetSynchronization(&commonCmdData, stagesStorage.Address())
 	if err != nil {
 		return err
 	}

--- a/cmd/werf/images/publish/cmd_factory/main.go
+++ b/cmd/werf/images/publish/cmd_factory/main.go
@@ -2,10 +2,9 @@ package cmd_factory
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/flant/kubedog/pkg/kube"
-	"github.com/flant/werf/pkg/storage"
-
 	"github.com/flant/werf/pkg/image"
 
 	"github.com/flant/werf/pkg/stages_manager"
@@ -131,11 +130,11 @@ func runImagesPublish(commonCmdData *common.CmdData, imagesToProcess []string) e
 		return err
 	}
 
-	synchronization, err := common.GetSynchronization(commonCmdData)
+	synchronization, err := common.GetSynchronization(commonCmdData, stagesStorage.Address())
 	if err != nil {
 		return err
 	}
-	if synchronization == storage.KubernetesStagesStorageAddress {
+	if strings.HasPrefix(synchronization, "kubernetes://") {
 		if err := kube.Init(kube.InitOptions{KubeContext: *commonCmdData.KubeContext, KubeConfig: *commonCmdData.KubeConfig}); err != nil {
 			return fmt.Errorf("cannot initialize kube: %s", err)
 		}

--- a/cmd/werf/images/purge/purge.go
+++ b/cmd/werf/images/purge/purge.go
@@ -2,10 +2,9 @@ package purge
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/flant/kubedog/pkg/kube"
-	"github.com/flant/werf/pkg/storage"
-
 	"github.com/flant/werf/pkg/image"
 
 	"github.com/spf13/cobra"
@@ -98,11 +97,11 @@ func runPurge() error {
 		return err
 	}
 
-	synchronization, err := common.GetSynchronization(&commonCmdData)
+	synchronization, err := common.GetSynchronization(&commonCmdData, stagesStorage.Address())
 	if err != nil {
 		return err
 	}
-	if synchronization == storage.KubernetesStagesStorageAddress {
+	if strings.HasPrefix(synchronization, "kubernetes://") {
 		if err := kube.Init(kube.InitOptions{KubeContext: *commonCmdData.KubeContext, KubeConfig: *commonCmdData.KubeConfig}); err != nil {
 			return fmt.Errorf("cannot initialize kube: %s", err)
 		}

--- a/cmd/werf/managed_images/add/add.go
+++ b/cmd/werf/managed_images/add/add.go
@@ -2,10 +2,9 @@ package add
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/flant/kubedog/pkg/kube"
-	"github.com/flant/werf/pkg/storage"
-
 	"github.com/flant/werf/pkg/image"
 
 	"github.com/spf13/cobra"
@@ -108,11 +107,11 @@ func run(imageName string) error {
 		return err
 	}
 
-	synchronization, err := common.GetSynchronization(&commonCmdData)
+	synchronization, err := common.GetSynchronization(&commonCmdData, stagesStorage.Address())
 	if err != nil {
 		return err
 	}
-	if synchronization == storage.KubernetesStagesStorageAddress {
+	if strings.HasPrefix(synchronization, "kubernetes://") {
 		if err := kube.Init(kube.InitOptions{KubeContext: *commonCmdData.KubeContext, KubeConfig: *commonCmdData.KubeConfig}); err != nil {
 			return fmt.Errorf("cannot initialize kube: %s", err)
 		}

--- a/cmd/werf/managed_images/ls/ls.go
+++ b/cmd/werf/managed_images/ls/ls.go
@@ -2,10 +2,9 @@ package ls
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/flant/kubedog/pkg/kube"
-	"github.com/flant/werf/pkg/storage"
-
 	"github.com/flant/werf/pkg/image"
 
 	"github.com/spf13/cobra"
@@ -105,11 +104,11 @@ func run() error {
 		return err
 	}
 
-	synchronization, err := common.GetSynchronization(&commonCmdData)
+	synchronization, err := common.GetSynchronization(&commonCmdData, stagesStorage.Address())
 	if err != nil {
 		return err
 	}
-	if synchronization == storage.KubernetesStagesStorageAddress {
+	if strings.HasPrefix(synchronization, "kubernetes://") {
 		if err := kube.Init(kube.InitOptions{KubeContext: *commonCmdData.KubeContext, KubeConfig: *commonCmdData.KubeConfig}); err != nil {
 			return fmt.Errorf("cannot initialize kube: %s", err)
 		}

--- a/cmd/werf/managed_images/rm/rm.go
+++ b/cmd/werf/managed_images/rm/rm.go
@@ -5,8 +5,6 @@ import (
 	"strings"
 
 	"github.com/flant/kubedog/pkg/kube"
-	"github.com/flant/werf/pkg/storage"
-
 	"github.com/flant/werf/pkg/image"
 
 	"github.com/spf13/cobra"
@@ -109,11 +107,11 @@ func run(imageNames []string) error {
 		return err
 	}
 
-	synchronization, err := common.GetSynchronization(&commonCmdData)
+	synchronization, err := common.GetSynchronization(&commonCmdData, stagesStorage.Address())
 	if err != nil {
 		return err
 	}
-	if synchronization == storage.KubernetesStagesStorageAddress {
+	if strings.HasPrefix(synchronization, "kubernetes://") {
 		if err := kube.Init(kube.InitOptions{KubeContext: *commonCmdData.KubeContext, KubeConfig: *commonCmdData.KubeConfig}); err != nil {
 			return fmt.Errorf("cannot initialize kube: %s", err)
 		}

--- a/cmd/werf/purge/purge.go
+++ b/cmd/werf/purge/purge.go
@@ -2,10 +2,9 @@ package purge
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/flant/kubedog/pkg/kube"
-	"github.com/flant/werf/pkg/storage"
-
 	"github.com/flant/werf/pkg/image"
 
 	"github.com/flant/werf/pkg/stages_manager"
@@ -113,11 +112,11 @@ func runPurge() error {
 		return err
 	}
 
-	synchronization, err := common.GetSynchronization(&commonCmdData)
+	synchronization, err := common.GetSynchronization(&commonCmdData, stagesStorage.Address())
 	if err != nil {
 		return err
 	}
-	if synchronization == storage.KubernetesStagesStorageAddress {
+	if strings.HasPrefix(synchronization, "kubernetes://") {
 		if err := kube.Init(kube.InitOptions{KubeContext: *commonCmdData.KubeContext, KubeConfig: *commonCmdData.KubeConfig}); err != nil {
 			return fmt.Errorf("cannot initialize kube: %s", err)
 		}

--- a/cmd/werf/run/run.go
+++ b/cmd/werf/run/run.go
@@ -6,8 +6,6 @@ import (
 
 	"github.com/flant/kubedog/pkg/kube"
 	"github.com/flant/werf/pkg/image"
-	"github.com/flant/werf/pkg/storage"
-
 	"github.com/flant/werf/pkg/stages_manager"
 
 	"github.com/spf13/cobra"
@@ -222,11 +220,11 @@ func runRun() error {
 		return err
 	}
 
-	synchronization, err := common.GetSynchronization(&commonCmdData)
+	synchronization, err := common.GetSynchronization(&commonCmdData, stagesStorage.Address())
 	if err != nil {
 		return err
 	}
-	if synchronization == storage.KubernetesStagesStorageAddress {
+	if strings.HasPrefix(synchronization, "kubernetes://") {
 		if err := kube.Init(kube.InitOptions{KubeContext: *commonCmdData.KubeContext, KubeConfig: *commonCmdData.KubeConfig}); err != nil {
 			return fmt.Errorf("cannot initialize kube: %s", err)
 		}

--- a/cmd/werf/stage/image/main.go
+++ b/cmd/werf/stage/image/main.go
@@ -2,10 +2,9 @@ package run
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/flant/kubedog/pkg/kube"
-	"github.com/flant/werf/pkg/storage"
-
 	"github.com/flant/werf/pkg/image"
 
 	"github.com/flant/werf/pkg/stages_manager"
@@ -146,11 +145,11 @@ func run(imageName string) error {
 		return err
 	}
 
-	synchronization, err := common.GetSynchronization(&commonCmdData)
+	synchronization, err := common.GetSynchronization(&commonCmdData, stagesStorage.Address())
 	if err != nil {
 		return err
 	}
-	if synchronization == storage.KubernetesStagesStorageAddress {
+	if strings.HasPrefix(synchronization, "kubernetes://") {
 		if err := kube.Init(kube.InitOptions{KubeContext: *commonCmdData.KubeContext, KubeConfig: *commonCmdData.KubeConfig}); err != nil {
 			return fmt.Errorf("cannot initialize kube: %s", err)
 		}

--- a/cmd/werf/stages/build/cmd_factory/main.go
+++ b/cmd/werf/stages/build/cmd_factory/main.go
@@ -2,10 +2,9 @@ package cmd_factory
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/flant/kubedog/pkg/kube"
-	"github.com/flant/werf/pkg/storage"
-
 	"github.com/flant/werf/pkg/image"
 
 	"github.com/flant/werf/pkg/stages_manager"
@@ -152,11 +151,11 @@ func runStagesBuild(cmdData *CmdData, commonCmdData *common.CmdData, imagesToPro
 		return err
 	}
 
-	synchronization, err := common.GetSynchronization(commonCmdData)
+	synchronization, err := common.GetSynchronization(commonCmdData, stagesStorage.Address())
 	if err != nil {
 		return err
 	}
-	if synchronization == storage.KubernetesStagesStorageAddress {
+	if strings.HasPrefix(synchronization, "kubernetes://") {
 		if err := kube.Init(kube.InitOptions{KubeContext: *commonCmdData.KubeContext, KubeConfig: *commonCmdData.KubeConfig}); err != nil {
 			return fmt.Errorf("cannot initialize kube: %s", err)
 		}

--- a/cmd/werf/stages/cleanup/cleanup.go
+++ b/cmd/werf/stages/cleanup/cleanup.go
@@ -2,9 +2,9 @@ package cleanup
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/flant/kubedog/pkg/kube"
-	"github.com/flant/werf/pkg/storage"
 
 	"github.com/flant/werf/pkg/image"
 
@@ -113,11 +113,11 @@ func runSync() error {
 		return err
 	}
 
-	synchronization, err := common.GetSynchronization(&commonCmdData)
+	synchronization, err := common.GetSynchronization(&commonCmdData, stagesStorage.Address())
 	if err != nil {
 		return err
 	}
-	if synchronization == storage.KubernetesStagesStorageAddress {
+	if strings.HasPrefix(synchronization, "kubernetes://") {
 		if err := kube.Init(kube.InitOptions{KubeContext: *commonCmdData.KubeContext, KubeConfig: *commonCmdData.KubeConfig}); err != nil {
 			return fmt.Errorf("cannot initialize kube: %s", err)
 		}

--- a/cmd/werf/stages/purge/purge.go
+++ b/cmd/werf/stages/purge/purge.go
@@ -2,10 +2,9 @@ package purge
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/flant/kubedog/pkg/kube"
-	"github.com/flant/werf/pkg/storage"
-
 	"github.com/flant/werf/pkg/image"
 
 	"github.com/flant/werf/pkg/stages_manager"
@@ -109,11 +108,11 @@ func runPurge() error {
 		return err
 	}
 
-	synchronization, err := common.GetSynchronization(&commonCmdData)
+	synchronization, err := common.GetSynchronization(&commonCmdData, stagesStorage.Address())
 	if err != nil {
 		return err
 	}
-	if synchronization == storage.KubernetesStagesStorageAddress {
+	if strings.HasPrefix(synchronization, "kubernetes://") {
 		if err := kube.Init(kube.InitOptions{KubeContext: *commonCmdData.KubeContext, KubeConfig: *commonCmdData.KubeConfig}); err != nil {
 			return fmt.Errorf("cannot initialize kube: %s", err)
 		}

--- a/cmd/werf/stages/sync/main.go
+++ b/cmd/werf/stages/sync/main.go
@@ -2,10 +2,9 @@ package sync
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/flant/kubedog/pkg/kube"
-	"github.com/flant/werf/pkg/storage"
-
 	"github.com/flant/werf/pkg/stages_manager"
 
 	"github.com/flant/werf/pkg/image"
@@ -110,11 +109,11 @@ func runSync() error {
 		return err
 	}
 
-	synchronization, err := common.GetSynchronization(&commonCmdData)
+	synchronization, err := common.GetSynchronization(&commonCmdData, fromStagesStorage.Address())
 	if err != nil {
 		return err
 	}
-	if synchronization == storage.KubernetesStagesStorageAddress {
+	if strings.HasPrefix(synchronization, "kubernetes://") {
 		if err := kube.Init(kube.InitOptions{KubeContext: *commonCmdData.KubeContext, KubeConfig: *commonCmdData.KubeConfig}); err != nil {
 			return fmt.Errorf("cannot initialize kube: %s", err)
 		}

--- a/pkg/stages_manager/stages_manager.go
+++ b/pkg/stages_manager/stages_manager.go
@@ -86,7 +86,7 @@ func (m *StagesManager) getStagesSwitchFromLocalBlock() (string, error) {
 func (m *StagesManager) checkStagesSwitchFromLocalBlock(stagesStorageAddress string) error {
 	if switchFromLocalBlock, err := m.getStagesSwitchFromLocalBlock(); err != nil {
 		return err
-	} else if switchFromLocalBlock != "" && stagesStorageAddress == storage.LocalStagesStorageAddress {
+	} else if switchFromLocalBlock != "" && stagesStorageAddress == storage.LocalStorageAddress {
 		return fmt.Errorf(
 			`Project %q stages storage has been switched from %s to %s!
 
@@ -94,9 +94,9 @@ func (m *StagesManager) checkStagesSwitchFromLocalBlock(stagesStorageAddress str
  2. If 'werf ci-env' command is used, then WERF_STAGES_STORAGE already should be exported — make sure that WERF_STAGES_STORAGE equals %s in this case.
  3. Otherwise explicitly specify --stages-storage=%s (or export WERF_STAGES_STORAGE=%s).`,
 			m.ProjectName,
-			storage.LocalStagesStorageAddress,
+			storage.LocalStorageAddress,
 			switchFromLocalBlock,
-			storage.LocalStagesStorageAddress,
+			storage.LocalStorageAddress,
 			switchFromLocalBlock,
 			switchFromLocalBlock,
 			switchFromLocalBlock,

--- a/pkg/stages_manager/sync_stages.go
+++ b/pkg/stages_manager/sync_stages.go
@@ -150,7 +150,7 @@ func runSyncWorker(projectName string, fromStagesStorage storage.StagesStorage, 
 }
 
 func syncStage(projectName string, stageID image.StageID, fromStagesStorage storage.StagesStorage, toStagesStorage storage.StagesStorage, containerRuntime container_runtime.ContainerRuntime, opts SyncStagesOptions) error {
-	if fromStagesStorage.Address() == storage.LocalStagesStorageAddress || toStagesStorage.Address() == storage.LocalStagesStorageAddress {
+	if fromStagesStorage.Address() == storage.LocalStorageAddress || toStagesStorage.Address() == storage.LocalStorageAddress {
 		opts.CleanupLocalCache = false
 	}
 

--- a/pkg/storage/local_docker_server_stages_storage.go
+++ b/pkg/storage/local_docker_server_stages_storage.go
@@ -193,11 +193,11 @@ func (storage *LocalDockerServerStagesStorage) StoreImage(img container_runtime.
 }
 
 func (storage *LocalDockerServerStagesStorage) String() string {
-	return LocalStagesStorageAddress
+	return LocalStorageAddress
 }
 
 func (storage *LocalDockerServerStagesStorage) Address() string {
-	return LocalStagesStorageAddress
+	return LocalStorageAddress
 }
 
 type processRelatedContainersOptions struct {

--- a/pkg/storage/stages_storage.go
+++ b/pkg/storage/stages_storage.go
@@ -6,9 +6,9 @@ import (
 )
 
 const (
-	LocalStagesStorageAddress      = ":local"
-	KubernetesStagesStorageAddress = ":kubernetes"
-	NamelessImageRecordTag         = "__nameless__"
+	LocalStorageAddress             = ":local"
+	DefaultKubernetesStorageAddress = "kubernetes://werf-synchronization"
+	NamelessImageRecordTag          = "__nameless__"
 )
 
 type StagesStorage interface {
@@ -41,7 +41,7 @@ type StagesStorageOptions struct {
 }
 
 func NewStagesStorage(stagesStorageAddress string, containerRuntime container_runtime.ContainerRuntime, options StagesStorageOptions) (StagesStorage, error) {
-	if stagesStorageAddress == LocalStagesStorageAddress {
+	if stagesStorageAddress == LocalStorageAddress {
 		return NewLocalDockerServerStagesStorage(containerRuntime.(*container_runtime.LocalDockerServerRuntime)), nil
 	} else { // Docker registry based stages storage
 		return NewRepoStagesStorage(stagesStorageAddress, containerRuntime, options.RepoStagesStorageOptions)


### PR DESCRIPTION
 - `-S` shorthand;
 - synchronization=:local when stages-storage=:local by default;
 - synchronization=kubernetes://werf-synchronization when stages-storage != :local;
 - ability to specify arbitrary namespace with `--synchronization kubernetes://mynamespace`.