### PR TITLE
Remote storages support: fix kubernetes locks, conveyor termination and managed-images race condition

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -35,7 +35,7 @@ require (
 	github.com/docker/swarmkit v0.0.0-20180705210007-199cf49cd996
 	github.com/fatih/color v1.9.0
 	github.com/flant/kubedog v0.3.5-0.20200228135326-83b69f5024b7
-	github.com/flant/lockgate v0.0.0-20200414151337-a491a50f21f7
+	github.com/flant/lockgate v0.0.0-20200421144738-26e2de457b66
 	github.com/flant/logboek v0.3.4
 	github.com/flynn-archive/go-shlex v0.0.0-20150515145356-3f9db97f8568
 	github.com/ghodss/yaml v1.0.1-0.20190212211648-25d852aebe32
@@ -173,6 +173,5 @@ replace github.com/docker/docker => github.com/docker/docker v1.4.2-0.2019031921
 replace github.com/docker/cli => github.com/docker/cli v0.0.0-20190321234815-f40f9c240ab0
 
 replace golang.org/x/sys => golang.org/x/sys v0.0.0-20190813064441-fde4db37ae7a
-
 
 go 1.13

--- a/go.sum
+++ b/go.sum
@@ -288,6 +288,8 @@ github.com/flant/kubedog v0.3.5-0.20200228135326-83b69f5024b7 h1:MxWMApTpuVPnsFU
 github.com/flant/kubedog v0.3.5-0.20200228135326-83b69f5024b7/go.mod h1:Tkg/l35Ep+mhIlDi8N2cSqOckllKjXSsJrDZnpJ/Wg4=
 github.com/flant/lockgate v0.0.0-20200414151337-a491a50f21f7 h1:D7q+jVYlVP4cwXhLfM2egwSDQHjmvYwFI0HUziD6sV4=
 github.com/flant/lockgate v0.0.0-20200414151337-a491a50f21f7/go.mod h1:r51aBxbaufxAzjs4WiA0FihS6a/a8Z2T+6TkGj4z+aE=
+github.com/flant/lockgate v0.0.0-20200421144738-26e2de457b66 h1:lKOQSfPSxScr3JeTLuDTRozhVU+YiAM3FLdkB2sLHvI=
+github.com/flant/lockgate v0.0.0-20200421144738-26e2de457b66/go.mod h1:r51aBxbaufxAzjs4WiA0FihS6a/a8Z2T+6TkGj4z+aE=
 github.com/flant/logboek v0.2.5/go.mod h1:eEQXX0UOWpyC8iaA9QOvzx8drZ64u0SRESiwQKnxF+I=
 github.com/flant/logboek v0.2.6-0.20190726104558-c32b60bb4a37/go.mod h1:eEQXX0UOWpyC8iaA9QOvzx8drZ64u0SRESiwQKnxF+I=
 github.com/flant/logboek v0.2.6-0.20190918091020-d00ba619a349/go.mod h1:eEQXX0UOWpyC8iaA9QOvzx8drZ64u0SRESiwQKnxF+I=


### PR DESCRIPTION
 - Fixed locks release and added shared mode for kubernetes locks in lockgate:
   - https://github.com/flant/lockgate/pull/10
   - https://github.com/flant/lockgate/pull/11
 - Fixed managed images race condition when repo-stages-storage is used (fixed by using local host locks).
 - Fixed conveyor retry termination: always immediately terminate old conveyor before retrying with new conveyor.