### PR TITLE
Remote storages support: fix lockgate ConfigMap data key invalid

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -35,7 +35,7 @@ require (
 	github.com/docker/swarmkit v0.0.0-20180705210007-199cf49cd996
 	github.com/fatih/color v1.9.0
 	github.com/flant/kubedog v0.3.5-0.20200228135326-83b69f5024b7
-	github.com/flant/lockgate v0.0.0-20200421144738-26e2de457b66
+	github.com/flant/lockgate v0.0.0-20200422080457-cdd4264f705b
 	github.com/flant/logboek v0.3.4
 	github.com/flynn-archive/go-shlex v0.0.0-20150515145356-3f9db97f8568
 	github.com/ghodss/yaml v1.0.1-0.20190212211648-25d852aebe32

--- a/go.sum
+++ b/go.sum
@@ -290,6 +290,8 @@ github.com/flant/lockgate v0.0.0-20200414151337-a491a50f21f7 h1:D7q+jVYlVP4cwXhL
 github.com/flant/lockgate v0.0.0-20200414151337-a491a50f21f7/go.mod h1:r51aBxbaufxAzjs4WiA0FihS6a/a8Z2T+6TkGj4z+aE=
 github.com/flant/lockgate v0.0.0-20200421144738-26e2de457b66 h1:lKOQSfPSxScr3JeTLuDTRozhVU+YiAM3FLdkB2sLHvI=
 github.com/flant/lockgate v0.0.0-20200421144738-26e2de457b66/go.mod h1:r51aBxbaufxAzjs4WiA0FihS6a/a8Z2T+6TkGj4z+aE=
+github.com/flant/lockgate v0.0.0-20200422080457-cdd4264f705b h1:4FmA9jgqcEEdUyaWxpeLdPRWC9OvFeHa/e+NwXWavVg=
+github.com/flant/lockgate v0.0.0-20200422080457-cdd4264f705b/go.mod h1:r51aBxbaufxAzjs4WiA0FihS6a/a8Z2T+6TkGj4z+aE=
 github.com/flant/logboek v0.2.5/go.mod h1:eEQXX0UOWpyC8iaA9QOvzx8drZ64u0SRESiwQKnxF+I=
 github.com/flant/logboek v0.2.6-0.20190726104558-c32b60bb4a37/go.mod h1:eEQXX0UOWpyC8iaA9QOvzx8drZ64u0SRESiwQKnxF+I=
 github.com/flant/logboek v0.2.6-0.20190918091020-d00ba619a349/go.mod h1:eEQXX0UOWpyC8iaA9QOvzx8drZ64u0SRESiwQKnxF+I=
@@ -664,6 +666,7 @@ github.com/mholt/certmagic v0.6.2-0.20190624175158-6a42ef9fe8c2/go.mod h1:g4cOPx
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/miekg/dns v1.1.3/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/miekg/dns v1.1.4/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
+github.com/miekg/pkcs11 v1.0.3 h1:iMwmD7I5225wv84WxIG/bmxz9AXjWvTWIbM/TYHvWtw=
 github.com/miekg/pkcs11 v1.0.3/go.mod h1:XsNlhZGX73bx86s2hdc/FuaLm2CPZJemRLMA+WTFxgs=
 github.com/mindprince/gonvml v0.0.0-20171110221305-fee913ce8fb2/go.mod h1:2eu9pRWp8mo84xCg6KswZ+USQHjwgRhNp06sozOdsTY=
 github.com/mistifyio/go-zfs v2.1.1+incompatible/go.mod h1:8AuVvqP/mXw1px98n46wfvcGfQ4ci2FwoAjKYxuo3Z4=

--- a/pkg/werf/main.go
+++ b/pkg/werf/main.go
@@ -108,7 +108,7 @@ func DefaultLockerOnWait(lock lockgate.LockHandle, doWait func() error) error {
 }
 
 func DefaultLockerOnLostLease(lock lockgate.LockHandle) error {
-	panic(fmt.Sprintf("Locker has lost lease for locked %q id %s. Will crash current process immediately!", lock.LockName, lock.ID))
+	panic(fmt.Sprintf("Locker has lost lease for locked %q uuid %s. Will crash current process immediately!", lock.LockName, lock.UUID))
 }
 
 func Init(tmpDirOption, homeDirOption string) error {


### PR DESCRIPTION
https://github.com/flant/lockgate/pull/12

Refactor and fix kubernetes cm key name
 - Renamed LockHandle.ID to LockHandle.UUID to be more clear.
 - Use "lockgate.io/SHA3_224(lock-name)" for ConfigMap key names
   due to ConfigMap names restrictions.