### PR TITLE
Remote storages support: fix deploy/dismiss stages-storage param and update locking

### DIFF
--- a/cmd/werf/common/common.go
+++ b/cmd/werf/common/common.go
@@ -856,6 +856,10 @@ func GetStagesStorageAddress(cmdData *CmdData) (string, error) {
 	return *cmdData.StagesStorage, nil
 }
 
+func GetOptionalStagesStorageAddress(cmdData *CmdData) string {
+	return *cmdData.StagesStorage
+}
+
 func GetImagesRepoWithOptionalStubRepoAddress(projectName string, cmdData *CmdData) (storage.ImagesRepo, error) {
 	return getImagesRepo(projectName, cmdData, true)
 }

--- a/cmd/werf/deploy/main.go
+++ b/cmd/werf/deploy/main.go
@@ -260,7 +260,11 @@ func runDeploy() error {
 			return err
 		}
 	} else {
-		synchronization, err := common.GetSynchronization(&commonCmdData, storage.LocalStorageAddress)
+		stagesStorageAddress := common.GetOptionalStagesStorageAddress(&commonCmdData)
+		if stagesStorageAddress == "" {
+			stagesStorageAddress = storage.LocalStorageAddress
+		}
+		synchronization, err := common.GetSynchronization(&commonCmdData, stagesStorageAddress)
 		if err != nil {
 			return err
 		}

--- a/docs/_includes/cli/werf_dismiss.md
+++ b/docs/_includes/cli/werf_dismiss.md
@@ -52,6 +52,8 @@ werf dismiss [options]
             help for dismiss
       --home-dir='':
             Use specified dir to store werf cache files and dirs (default $WERF_HOME or ~/.werf)
+      --insecure-registry=false:
+            Use plain HTTP requests when accessing a registry (default $WERF_INSECURE_REGISTRY)
       --kube-config='':
             Kubernetes config file path
       --kube-context='':
@@ -86,6 +88,55 @@ werf dismiss [options]
       --releases-history-max=0:
             Max releases to keep in release storage. Can be set by environment variable             
             $WERF_RELEASES_HISTORY_MAX. By default werf keeps all releases.
+      --repo-docker-hub-password='':
+            Common Docker Hub password for any stages storage or images repo specified for the      
+            command (default $WERF_REPO_DOCKER_HUB_PASSWORD)
+      --repo-docker-hub-token='':
+            Common Docker Hub token for any stages storage or images repo specified for the command 
+            (default $WERF_REPO_DOCKER_HUB_TOKEN)
+      --repo-docker-hub-username='':
+            Common Docker Hub username for any stages storage or images repo specified for the      
+            command (default $WERF_REPO_DOCKER_HUB_USERNAME)
+      --repo-github-token='':
+            Common GitHub token for any stages storage or images repo specified for the command     
+            (default $WERF_REPO_GITHUB_TOKEN)
+      --repo-implementation='':
+            Choose common repo implementation for any stages storage or images repo specified for   
+            the command.
+            The following docker registry implementations are supported: ecr, acr, default,         
+            dockerhub, gcr, github, gitlab, harbor, quay.
+            Default $WERF_REPO_IMPLEMENTATION or auto mode (detect implementation by a registry).
+      --skip-tls-verify-registry=false:
+            Skip TLS certificate validation when accessing a registry (default                      
+            $WERF_SKIP_TLS_VERIFY_REGISTRY)
+  -s, --stages-storage='':
+            Docker Repo to store stages or :local for non-distributed build (only :local is         
+            supported for now; default $WERF_STAGES_STORAGE environment).
+            More info about stages: https://werf.io/documentation/reference/stages_and_images.html
+      --stages-storage-repo-docker-hub-password='':
+            Docker Hub password for stages storage (default                                         
+            $WERF_STAGES_STORAGE_REPO_DOCKER_HUB_PASSWORD, $WERF_REPO_DOCKER_HUB_PASSWORD)
+      --stages-storage-repo-docker-hub-token='':
+            Docker Hub token for stages storage (default                                            
+            $WERF_STAGES_STORAGE_REPO_DOCKER_HUB_TOKEN, $WERF_REPO_DOCKER_HUB_TOKEN)
+      --stages-storage-repo-docker-hub-username='':
+            Docker Hub username for stages storage (default                                         
+            $WERF_STAGES_STORAGE_REPO_DOCKER_HUB_USERNAME, $WERF_REPO_DOCKER_HUB_USERNAME)
+      --stages-storage-repo-github-token='':
+            GitHub token for stages storage (default $WERF_STAGES_STORAGE_REPO_GITHUB_TOKEN,        
+            $WERF_REPO_GITHUB_TOKEN)
+      --stages-storage-repo-implementation='':
+            Choose repo implementation for stages storage.
+            The following docker registry implementations are supported: ecr, acr, default,         
+            dockerhub, gcr, github, gitlab, harbor, quay.
+            Default $WERF_STAGES_STORAGE_REPO_IMPLEMENTATION, $WERF_REPO_IMPLEMENTATION or auto     
+            mode (detect implementation by a registry).
+  -S, --synchronization='':
+            Address of synchronizer for multiple werf processes to work with a single stages        
+            storage (default :local if --stages-storage=:local or kubernetes://werf-synchronization 
+            if non-local stages-storage specified or $WERF_SYNCHRONIZATION if set). The same        
+            address should be specified for all werf processes that work with a single stages       
+            storage. :local address allows execution of werf processes from a single host only.
       --tmp-dir='':
             Use specified dir to store tmp files and dirs (default $WERF_TMP_DIR or system tmp dir)
       --with-hooks=true:

--- a/go.mod
+++ b/go.mod
@@ -35,7 +35,7 @@ require (
 	github.com/docker/swarmkit v0.0.0-20180705210007-199cf49cd996
 	github.com/fatih/color v1.9.0
 	github.com/flant/kubedog v0.3.5-0.20200228135326-83b69f5024b7
-	github.com/flant/lockgate v0.0.0-20200422080457-cdd4264f705b
+	github.com/flant/lockgate v0.0.0-20200423125832-32bcf5a35263
 	github.com/flant/logboek v0.3.4
 	github.com/flynn-archive/go-shlex v0.0.0-20150515145356-3f9db97f8568
 	github.com/ghodss/yaml v1.0.1-0.20190212211648-25d852aebe32

--- a/go.sum
+++ b/go.sum
@@ -292,6 +292,8 @@ github.com/flant/lockgate v0.0.0-20200421144738-26e2de457b66 h1:lKOQSfPSxScr3JeT
 github.com/flant/lockgate v0.0.0-20200421144738-26e2de457b66/go.mod h1:r51aBxbaufxAzjs4WiA0FihS6a/a8Z2T+6TkGj4z+aE=
 github.com/flant/lockgate v0.0.0-20200422080457-cdd4264f705b h1:4FmA9jgqcEEdUyaWxpeLdPRWC9OvFeHa/e+NwXWavVg=
 github.com/flant/lockgate v0.0.0-20200422080457-cdd4264f705b/go.mod h1:r51aBxbaufxAzjs4WiA0FihS6a/a8Z2T+6TkGj4z+aE=
+github.com/flant/lockgate v0.0.0-20200423125832-32bcf5a35263 h1:uPA08xQJzABlcaDfxuxSN6VwY284AfgiOmr9/4hy+MY=
+github.com/flant/lockgate v0.0.0-20200423125832-32bcf5a35263/go.mod h1:RBJF6PjUgAZADae/SC3skanE/vD9Jrnbs7F6hqLo7ik=
 github.com/flant/logboek v0.2.5/go.mod h1:eEQXX0UOWpyC8iaA9QOvzx8drZ64u0SRESiwQKnxF+I=
 github.com/flant/logboek v0.2.6-0.20190726104558-c32b60bb4a37/go.mod h1:eEQXX0UOWpyC8iaA9QOvzx8drZ64u0SRESiwQKnxF+I=
 github.com/flant/logboek v0.2.6-0.20190918091020-d00ba619a349/go.mod h1:eEQXX0UOWpyC8iaA9QOvzx8drZ64u0SRESiwQKnxF+I=

--- a/pkg/deploy/helm/tiller.go
+++ b/pkg/deploy/helm/tiller.go
@@ -45,7 +45,9 @@ var (
 )
 
 var (
-	HelmSettings helm_env.EnvSettings
+	HelmSettings                helm_env.EnvSettings
+	HelmReleaseStorageNamespace string
+	HelmReleaseStorageType      string
 
 	tillerReleaseServer          = &tiller.ReleaseServer{}
 	tillerSettings               = tiller_env.New()
@@ -116,6 +118,9 @@ func Init(options InitOptions) error {
 	HelmSettings.KubeConfig = options.KubeConfig
 	HelmSettings.KubeContext = options.KubeContext
 	HelmSettings.TillerNamespace = options.HelmReleaseStorageNamespace
+
+	HelmReleaseStorageNamespace = options.HelmReleaseStorageNamespace
+	HelmReleaseStorageType = options.HelmReleaseStorageType
 
 	configFlags := genericclioptions.NewConfigFlags(true)
 	configFlags.Context = &HelmSettings.KubeContext

--- a/pkg/storage/generic_lock_manager.go
+++ b/pkg/storage/generic_lock_manager.go
@@ -71,5 +71,5 @@ func genericStagesAndImagesLockName(projectName string) string {
 }
 
 func genericDeployReleaseLockName(projectName string, releaseName string, kubeContextName string) string {
-	return fmt.Sprintf("project/%s-release/%s-kube_context/%s", projectName, releaseName, kubeContextName)
+	return fmt.Sprintf("project/%s;release/%s;kube_context/%s", projectName, releaseName, kubeContextName)
 }

--- a/pkg/storage/kubernetes_lock_manager.go
+++ b/pkg/storage/kubernetes_lock_manager.go
@@ -125,5 +125,5 @@ func kuberntesStagesAndImagesLockName(_ string) string {
 }
 
 func kubernetesDeployReleaseLockName(_ string, releaseName string, kubeContextName string) string {
-	return fmt.Sprintf("release/%s-kube_context/%s", releaseName, kubeContextName)
+	return fmt.Sprintf("release/%s;kube-context/%s", releaseName, kubeContextName)
 }

--- a/pkg/werf/main.go
+++ b/pkg/werf/main.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"runtime"
 
+	"github.com/flant/lockgate/pkg/file_lock"
 	"github.com/flant/logboek"
 
 	"github.com/flant/lockgate"
@@ -147,6 +148,8 @@ func Init(tmpDirOption, homeDirOption string) error {
 	sharedContextDir = filepath.Join(homeDir, "shared_context")
 	localCacheDir = filepath.Join(homeDir, "local_cache")
 	serviceDir = filepath.Join(homeDir, "service")
+
+	file_lock.LegacyHashFunction = true
 
 	if locker, err := lockgate.NewFileLocker(filepath.Join(serviceDir, "locks")); err != nil {
 		return fmt.Errorf("error creating werf host file locker: %s", err)


### PR DESCRIPTION
 - update lockgate to latest version, use legacy murmurhash flag for files locker;
 - changed deploy locks name;
 - --stages-storage is an optional parameter for deploy and dismiss commands,
   it is used to determine --synchronization param default value,
   synchronization param value also can be specified explicitly;
 - regenerate dismiss cli docs.