### PR TITLE
Fix cleanup fails to delete stages from repo stages storage, fix readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,10 +51,10 @@ werf is not a complete CI/CD solution, but a tool for creating pipelines that ca
 - ~3-way-merge~ [#1616](https://github.com/flant/werf/issues/1616).
 - Developing applications locally with werf [#1940](https://github.com/flant/werf/issues/1940).
 - ~Content-based tagging~ [#1184](https://github.com/flant/werf/issues/1184).
-- Support for the most Docker registry implementations [#2199](https://github.com/flant/werf/issues/2199).
+- ~Support for the most Docker registry implementations~ [#2199](https://github.com/flant/werf/issues/2199).
 - Parallel image builds [#2200](https://github.com/flant/werf/issues/2200).
 - Proven approaches and recipes for the most popular CI systems [#1617](https://github.com/flant/werf/issues/1617).
-- Distributed builds with the shared Docker registry [#1614](https://github.com/flant/werf/issues/1614).
+- ~Distributed builds with the shared Docker registry~ [#1614](https://github.com/flant/werf/issues/1614).
 - Support for Helm 3 [#1606](https://github.com/flant/werf/issues/1606).
 - (Kaniko-like) building in the userspace that does not require Docker daemon [#1618](https://github.com/flant/werf/issues/1618).
 
@@ -66,7 +66,7 @@ werf is not a complete CI/CD solution, but a tool for creating pipelines that ca
 - Build images using Dockerfiles or Stapel builder instructions.
 - Build images concurrently on a single host (using file locks).
 - Build images simultaneously (coming soon) [#2200](https://github.com/flant/werf/issues/2200).
-- Build images distributedly (coming soon) [#1614](https://github.com/flant/werf/issues/1614).
+- Build images distributedly.
 - Advanced building process with Stapel:
   - Incremental rebuilds based on git history.
   - Build images with Ansible tasks or Shell scripts.

--- a/cmd/werf/ci_env/ci_env.go
+++ b/cmd/werf/ci_env/ci_env.go
@@ -147,6 +147,7 @@ func generateGitlabEnvs(w io.Writer, taggingStrategy string) error {
 	ciJobToken := os.Getenv("CI_JOB_TOKEN")
 
 	var imagesUsername, imagesPassword string
+	var stagesStorageRepoImplementation string
 	var imagesRepoImplementation string
 	var doLogin bool
 	if ciRegistryImage != "" && ciJobToken != "" {
@@ -155,6 +156,7 @@ func generateGitlabEnvs(w io.Writer, taggingStrategy string) error {
 		doLogin = true
 
 		imagesRepoImplementation = docker_registry.GitLabRegistryImplementationName
+		stagesStorageRepoImplementation = docker_registry.GitLabRegistryImplementationName
 	}
 
 	if doLogin {
@@ -169,10 +171,15 @@ func generateGitlabEnvs(w io.Writer, taggingStrategy string) error {
 
 	writeHeader(w, "STAGES_STORAGE", true)
 	writeExportCommand(w, "WERF_STAGES_STORAGE", fmt.Sprintf("%s/stages", ciRegistryImage), false)
+	if stagesStorageRepoImplementation != "" {
+		writeExportCommand(w, "WERF_STAGES_STORAGE_REPO_IMPLEMENTATION", stagesStorageRepoImplementation, false)
+	}
 
 	writeHeader(w, "IMAGES REPO", true)
 	writeExportCommand(w, "WERF_IMAGES_REPO", ciRegistryImage, false)
-	writeExportCommand(w, "WERF_IMAGES_REPO_IMPLEMENTATION", imagesRepoImplementation, false)
+	if imagesRepoImplementation != "" {
+		writeExportCommand(w, "WERF_IMAGES_REPO_IMPLEMENTATION", imagesRepoImplementation, false)
+	}
 
 	writeHeader(w, "TAGGING", true)
 	switch taggingStrategy {


### PR DESCRIPTION
Fix cleanup fails to delete stages from repo stages storage

Automatically set gitlab repo implementation option (`--stages-storage-repo-implementation=gitlab`) in `werf ci-env gitlab`.

[docs] Fix README coming soon and features list