### PR TITLE
[test] Test "Check broken links" hase been updated

### DIFF
--- a/.github/workflows/docs_tests.yml
+++ b/.github/workflows/docs_tests.yml
@@ -67,5 +67,6 @@ jobs:
             --allow-hash-href \
             --empty-alt-ignore \
             --check_html \
-            --url_ignore "/localhost/,/atseashop.com/,/https\:\/\/t.me/,/.slack.com/,/cncf.io/" \
+            --url_ignore "/localhost/,/atseashop.com/,/https\:\/\/t.me/,/.slack.com/,/cncf.io/,/\/feed.*\.xml/" \
+            --url_swap  "https\://ru.werf.io:,https\://werf.io:"
             ./_site/


### PR DESCRIPTION
After adding new articles, test for broken links may fail because it tries to check external links for new articles on the site.