### PR TITLE
FIX dockerInstructions stage not isolated when used after gitCache stage

### DIFF
--- a/pkg/build/stage/git_cache.go
+++ b/pkg/build/stage/git_cache.go
@@ -81,3 +81,7 @@ func (s *GitCacheStage) gitMappingsPatchSize(prevBuiltImage container_runtime.Im
 
 	return size, nil
 }
+
+func (s *GitCacheStage) GetNextStageDependencies(c Conveyor) (string, error) {
+	return s.BaseStage.getNextStageGitDependencies(c)
+}


### PR DESCRIPTION
gitCache should give commit-id as next-stage-dependencies, which will affect dockerInstructions signature and cause correct rebuild of dockerInstructions in the case when multiple gitCache stages with the same signature exists.