### PR TITLE
[docs] Added github and gitlab ci/cd guide articles stubs

### DIFF
--- a/docs/_data/sidebars/documentation.yml
+++ b/docs/_data/sidebars/documentation.yml
@@ -134,6 +134,9 @@ entries:
           - title: GitLab CI/CD integration
             url: /documentation/guides/gitlab_ci_cd_integration.html
 
+          - title: GitHub CI/CD integration
+            url: /documentation/guides/github_ci_cd_integration.html
+
           - title: Unsupported CI/CD integration
             url: /documentation/guides/unsupported_ci_cd_integration.html
 

--- a/docs/pages/guides/github_ci_cd_integration.md
+++ b/docs/pages/guides/github_ci_cd_integration.md
@@ -1,0 +1,7 @@
+---
+title: GitHub CI/CD integration
+sidebar: documentation
+permalink: documentation/guides/github_ci_cd_integration.html
+---
+
+> **NOTE** This article available only in russian for now: [https://ru.werf.io/v1.1-alpha/documentation/guides/github_ci_cd_integration.html](https://ru.werf.io/v1.1-alpha/documentation/guides/github_ci_cd_integration.html) — and will be translated very soon.

--- a/docs/pages/guides/gitlab_ci_cd_integration.md
+++ b/docs/pages/guides/gitlab_ci_cd_integration.md
@@ -5,6 +5,8 @@ permalink: documentation/guides/gitlab_ci_cd_integration.html
 author: Artem Kladov <artem.kladov@flant.com>
 ---
 
+> **NOTE** This article contains old obsolete info. Newer article available only in russian: [https://ru.werf.io/v1.1-alpha/documentation/guides/gitlab_ci_cd_integration.html](https://ru.werf.io/v1.1-alpha/documentation/guides/gitlab_ci_cd_integration.html) — and will be translated very soon.
+
 ## Task Overview
 
 Setup CI/CD process using GitLab CI and werf.


### PR DESCRIPTION
For gitlab there is a temporal link to russian version of the article.

For github there is a link to russian article, which is also WIP.