### PR TITLE
[v1.1.9] Fix "@ERROR: invalid gid nogroup" on imports stage

### DIFF
--- a/pkg/build/import_server/rsync_server.go
+++ b/pkg/build/import_server/rsync_server.go
@@ -53,6 +53,7 @@ func RunRsyncServer(dockerImageName string, tmpDir string) (*RsyncServer, error)
 lock file = /.werf/rsyncd.lock
 log file = /.werf/rsyncd.log
 uid = root
+gid = root
 port = %s
 
 [import]


### PR DESCRIPTION
The error occurs when artifact image does not contain "nogroup" group, which was used by default when running rsync server. For example when using "maven:3.6.3-jdk-13" as artifact base image.

Fixed by running rsync server using root group.