### PR TITLE
Added 'werf converge' command

### DIFF
--- a/cmd/werf/converge/converge.go
+++ b/cmd/werf/converge/converge.go
@@ -1,0 +1,297 @@
+package converge
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/flant/werf/pkg/tag_strategy"
+
+	"github.com/flant/werf/pkg/images_manager"
+
+	"github.com/flant/kubedog/pkg/kube"
+	"github.com/flant/werf/pkg/deploy"
+	"github.com/flant/werf/pkg/deploy/helm"
+
+	"github.com/flant/werf/pkg/image"
+
+	"github.com/flant/werf/pkg/stages_manager"
+
+	"github.com/spf13/cobra"
+
+	"github.com/flant/logboek"
+
+	"github.com/flant/werf/cmd/werf/common"
+	"github.com/flant/werf/pkg/build"
+	"github.com/flant/werf/pkg/container_runtime"
+	"github.com/flant/werf/pkg/docker"
+	"github.com/flant/werf/pkg/ssh_agent"
+	"github.com/flant/werf/pkg/tmp_manager"
+	"github.com/flant/werf/pkg/true_git"
+	"github.com/flant/werf/pkg/werf"
+)
+
+var cmdData struct {
+	PullUsername string
+	PullPassword string
+	Timeout      int
+}
+
+var commonCmdData common.CmdData
+
+func NewCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "converge",
+		Short: "Build stages and publish images, then deploy application into Kubernetes",
+		Long: common.GetLongCommandDescription(`Build stages and final images using content based tagging and publish into images repo, then deploy application chart.
+
+Command combines 'werf stages build', 'werf images publish' and 'werf deploy'.
+
+The result of converge command is an application deployed into Kubernetes for current git state. Command will create release and wait until all resources of the release will become ready.
+
+Environment is a required param for the deploy by default, because it is needed to construct Helm Release name and Kubernetes Namespace. Either --env or $WERF_ENV should be specified for command.
+
+Read more info about Helm chart structure, Helm Release name, Kubernetes Namespace and how to change it: https://werf.io/documentation/reference/deploy_process/deploy_into_kubernetes.html`),
+		Example: `# Build and deploy current application state into production environment
+werf converge --stages-storage registry.mydomain.com/web/back/stages --images-repo registry.mydomain.com/web/back --env production`,
+		DisableFlagsInUseLine: true,
+		Annotations: map[string]string{
+			common.CmdEnvAnno: common.EnvsDescription(common.WerfDebugAnsibleArgs, common.WerfSecretKey),
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := common.ProcessLogOptions(&commonCmdData); err != nil {
+				common.PrintHelp(cmd)
+				return err
+			}
+
+			common.LogVersion()
+
+			return common.LogRunningTime(func() error {
+				return runConverge()
+			})
+		},
+	}
+
+	common.SetupDir(&commonCmdData, cmd)
+	common.SetupConfigPath(&commonCmdData, cmd)
+	common.SetupConfigTemplatesDir(&commonCmdData, cmd)
+	common.SetupTmpDir(&commonCmdData, cmd)
+	common.SetupHomeDir(&commonCmdData, cmd)
+	common.SetupSSHKey(&commonCmdData, cmd)
+
+	common.SetupStagesStorageOptions(&commonCmdData, cmd)
+	common.SetupImagesRepoOptions(&commonCmdData, cmd)
+
+	common.SetupDockerConfig(&commonCmdData, cmd, "Command needs granted permissions to read, pull and push images into the specified stages storage, to push images into the specified images repo, to pull base images")
+	common.SetupInsecureRegistry(&commonCmdData, cmd)
+	common.SetupSkipTlsVerifyRegistry(&commonCmdData, cmd)
+
+	common.SetupLogOptions(&commonCmdData, cmd)
+	common.SetupLogProjectDir(&commonCmdData, cmd)
+
+	common.SetupSynchronization(&commonCmdData, cmd)
+
+	common.SetupKubeConfig(&commonCmdData, cmd)
+	common.SetupKubeContext(&commonCmdData, cmd)
+	common.SetupHelmChartDir(&commonCmdData, cmd)
+	common.SetupHelmReleaseStorageNamespace(&commonCmdData, cmd)
+	common.SetupHelmReleaseStorageType(&commonCmdData, cmd)
+	common.SetupStatusProgressPeriod(&commonCmdData, cmd)
+	common.SetupHooksStatusProgressPeriod(&commonCmdData, cmd)
+	common.SetupReleasesHistoryMax(&commonCmdData, cmd)
+
+	common.SetupEnvironment(&commonCmdData, cmd)
+	common.SetupRelease(&commonCmdData, cmd)
+	common.SetupNamespace(&commonCmdData, cmd)
+	common.SetupAddAnnotations(&commonCmdData, cmd)
+	common.SetupAddLabels(&commonCmdData, cmd)
+
+	common.SetupSet(&commonCmdData, cmd)
+	common.SetupSetString(&commonCmdData, cmd)
+	common.SetupValues(&commonCmdData, cmd)
+	common.SetupSecretValues(&commonCmdData, cmd)
+	common.SetupIgnoreSecretKey(&commonCmdData, cmd)
+
+	cmd.Flags().IntVarP(&cmdData.Timeout, "timeout", "t", 0, "Resources tracking timeout in seconds")
+
+	return cmd
+}
+
+func runConverge() error {
+	if err := werf.Init(*commonCmdData.TmpDir, *commonCmdData.HomeDir); err != nil {
+		return fmt.Errorf("initialization error: %s", err)
+	}
+
+	if err := image.Init(); err != nil {
+		return err
+	}
+
+	if err := true_git.Init(true_git.Options{Out: logboek.GetOutStream(), Err: logboek.GetErrStream(), LiveGitOutput: *commonCmdData.LogVerbose || *commonCmdData.LogDebug}); err != nil {
+		return err
+	}
+
+	if err := common.DockerRegistryInit(&commonCmdData); err != nil {
+		return err
+	}
+
+	if err := docker.Init(*commonCmdData.DockerConfig, *commonCmdData.LogVerbose, *commonCmdData.LogDebug); err != nil {
+		return err
+	}
+
+	projectDir, err := common.GetProjectDir(&commonCmdData)
+	if err != nil {
+		return fmt.Errorf("getting project dir failed: %s", err)
+	}
+
+	common.ProcessLogProjectDir(&commonCmdData, projectDir)
+
+	werfConfig, err := common.GetRequiredWerfConfig(projectDir, &commonCmdData, true)
+	if err != nil {
+		return fmt.Errorf("unable to load werf config: %s", err)
+	}
+
+	projectName := werfConfig.Meta.Project
+
+	projectTmpDir, err := tmp_manager.CreateProjectDir()
+	if err != nil {
+		return fmt.Errorf("getting project tmp dir failed: %s", err)
+	}
+	defer tmp_manager.ReleaseProjectDir(projectTmpDir)
+
+	containerRuntime := &container_runtime.LocalDockerServerRuntime{} // TODO
+
+	stagesStorage, err := common.GetStagesStorage(containerRuntime, &commonCmdData)
+	if err != nil {
+		return err
+	}
+
+	synchronization, err := common.GetSynchronization(&commonCmdData, stagesStorage.Address())
+	if err != nil {
+		return err
+	}
+	stagesStorageCache, err := common.GetStagesStorageCache(synchronization)
+	if err != nil {
+		return err
+	}
+	storageLockManager, err := common.GetStorageLockManager(synchronization)
+	if err != nil {
+		return err
+	}
+
+	stagesManager := stages_manager.NewStagesManager(projectName, storageLockManager, stagesStorageCache)
+	if err := stagesManager.UseStagesStorage(stagesStorage); err != nil {
+		return err
+	}
+
+	imagesRepo, err := common.GetImagesRepo(projectName, &commonCmdData)
+	if err != nil {
+		return err
+	}
+
+	if err := ssh_agent.Init(*commonCmdData.SSHKeys); err != nil {
+		return fmt.Errorf("cannot initialize ssh agent: %s", err)
+	}
+	defer func() {
+		err := ssh_agent.Terminate()
+		if err != nil {
+			logboek.LogWarnF("WARNING: ssh agent termination failed: %s\n", err)
+		}
+	}()
+
+	helmReleaseStorageType, err := common.GetHelmReleaseStorageType(*commonCmdData.HelmReleaseStorageType)
+	if err != nil {
+		return err
+	}
+
+	helmChartDir, err := common.GetHelmChartDir(projectDir, &commonCmdData)
+	if err != nil {
+		return fmt.Errorf("getting helm chart dir failed: %s", err)
+	}
+
+	release, err := common.GetHelmRelease(*commonCmdData.Release, *commonCmdData.Environment, werfConfig)
+	if err != nil {
+		return err
+	}
+
+	namespace, err := common.GetKubernetesNamespace(*commonCmdData.Namespace, *commonCmdData.Environment, werfConfig)
+	if err != nil {
+		return err
+	}
+
+	userExtraAnnotations, err := common.GetUserExtraAnnotations(&commonCmdData)
+	if err != nil {
+		return err
+	}
+
+	userExtraLabels, err := common.GetUserExtraLabels(&commonCmdData)
+	if err != nil {
+		return err
+	}
+
+	deployInitOptions := deploy.InitOptions{
+		HelmInitOptions: helm.InitOptions{
+			KubeConfig:                  *commonCmdData.KubeConfig,
+			KubeContext:                 *commonCmdData.KubeContext,
+			HelmReleaseStorageNamespace: *commonCmdData.HelmReleaseStorageNamespace,
+			HelmReleaseStorageType:      helmReleaseStorageType,
+			StatusProgressPeriod:        common.GetStatusProgressPeriod(&commonCmdData),
+			HooksStatusProgressPeriod:   common.GetHooksStatusProgressPeriod(&commonCmdData),
+			ReleasesMaxHistory:          *commonCmdData.ReleasesHistoryMax,
+			InitNamespace:               true,
+		},
+	}
+	if err := deploy.Init(deployInitOptions); err != nil {
+		return err
+	}
+
+	if err := kube.Init(kube.InitOptions{KubeContext: *commonCmdData.KubeContext, KubeConfig: *commonCmdData.KubeConfig}); err != nil {
+		return fmt.Errorf("cannot initialize kube: %s", err)
+	}
+
+	if err := common.InitKubedog(); err != nil {
+		return fmt.Errorf("cannot init kubedog: %s", err)
+	}
+
+	opts := build.BuildAndPublishOptions{
+		BuildStagesOptions: build.BuildStagesOptions{
+			ImageBuildOptions: container_runtime.BuildOptions{},
+		},
+		PublishImagesOptions: build.PublishImagesOptions{
+			TagOptions: build.TagOptions{TagByStagesSignature: true}, // always content based tagging
+		},
+	}
+
+	logboek.LogOptionalLn()
+
+	conveyorWithRetry := build.NewConveyorWithRetryWrapper(werfConfig, nil, projectDir, projectTmpDir, ssh_agent.SSHAuthSock, containerRuntime, stagesManager, imagesRepo, storageLockManager)
+	defer conveyorWithRetry.Terminate()
+
+	var imagesInfoGetters []images_manager.ImageInfoGetter
+
+	if err := conveyorWithRetry.WithRetryBlock(func(c *build.Conveyor) error {
+		if err := c.BuildAndPublish(opts); err != nil {
+			return err
+		}
+
+		imagesInfoGetters = c.GetImageInfoGetters(werfConfig.StapelImages, werfConfig.ImagesFromDockerfile, "", tag_strategy.StagesSignature, false)
+
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	logboek.LogOptionalLn()
+	return deploy.Deploy(projectName, projectDir, helmChartDir, imagesRepo.String(), imagesInfoGetters, release, namespace, "", tag_strategy.StagesSignature, werfConfig, *commonCmdData.HelmReleaseStorageNamespace, helmReleaseStorageType, storageLockManager, deploy.DeployOptions{
+		Set:                  *commonCmdData.Set,
+		SetString:            *commonCmdData.SetString,
+		Values:               *commonCmdData.Values,
+		SecretValues:         *commonCmdData.SecretValues,
+		Timeout:              time.Duration(cmdData.Timeout) * time.Second,
+		Env:                  *commonCmdData.Environment,
+		UserExtraAnnotations: userExtraAnnotations,
+		UserExtraLabels:      userExtraLabels,
+		IgnoreSecretKey:      *commonCmdData.IgnoreSecretKey,
+		ThreeWayMergeMode:    helm.ThreeWayMergeEnabled,
+	})
+
+	return nil
+}

--- a/cmd/werf/main.go
+++ b/cmd/werf/main.go
@@ -3,6 +3,8 @@ package main
 import (
 	"fmt"
 
+	"github.com/flant/werf/cmd/werf/converge"
+
 	"github.com/spf13/cobra"
 
 	"github.com/flant/werf/cmd/werf/build"
@@ -101,6 +103,7 @@ Find more information at https://werf.io`),
 		{
 			Message: "Main Commands:",
 			Commands: []*cobra.Command{
+				converge.NewCmd(),
 				build.NewCmd(),
 				publish.NewCmd(),
 				build_and_publish.NewCmd(),

--- a/pkg/deploy/helm/release.go
+++ b/pkg/deploy/helm/release.go
@@ -237,9 +237,9 @@ func DeployHelmChart(chartPath, releaseName, namespace string, opts ChartOptions
 				} else if latestReleaseRevisionStatus == "FAILED" {
 					threeWayMergeMode := getActualThreeWayMergeMode(opts.ThreeWayMergeMode)
 
-					if threeWayMergeMode == threeWayMergeDisabled {
+					if threeWayMergeMode == ThreeWayMergeDisabled {
 						releaseShouldBeRolledBack = true
-					} else if threeWayMergeMode == threeWayMergeOnlyNewReleases && !latestReleaseThreeWayMergeEnabled {
+					} else if threeWayMergeMode == ThreeWayMergeOnlyNewReleases && !latestReleaseThreeWayMergeEnabled {
 						releaseShouldBeRolledBack = true
 					}
 				}

--- a/pkg/deploy/helm/tiller.go
+++ b/pkg/deploy/helm/tiller.go
@@ -39,9 +39,9 @@ import (
 type ThreeWayMergeModeType string
 
 var (
-	threeWayMergeEnabled         ThreeWayMergeModeType = "enabled"
-	threeWayMergeOnlyNewReleases ThreeWayMergeModeType = "onlyNewReleases"
-	threeWayMergeDisabled        ThreeWayMergeModeType = "disabled"
+	ThreeWayMergeEnabled         ThreeWayMergeModeType = "enabled"
+	ThreeWayMergeOnlyNewReleases ThreeWayMergeModeType = "onlyNewReleases"
+	ThreeWayMergeDisabled        ThreeWayMergeModeType = "disabled"
 )
 
 var (
@@ -603,11 +603,11 @@ func formatTestResults(results []*release.TestRun) string {
 
 func convertThreeWayMergeModeForHelm(threeWayMergeMode ThreeWayMergeModeType) services.ThreeWayMergeMode {
 	switch threeWayMergeMode {
-	case threeWayMergeEnabled:
+	case ThreeWayMergeEnabled:
 		return services.ThreeWayMergeMode_enabled
-	case threeWayMergeDisabled:
+	case ThreeWayMergeDisabled:
 		return services.ThreeWayMergeMode_disabled
-	case threeWayMergeOnlyNewReleases:
+	case ThreeWayMergeOnlyNewReleases:
 		return services.ThreeWayMergeMode_onlyNewReleases
 	default:
 		panic("non empty threeWayMergeMode required!")
@@ -616,17 +616,17 @@ func convertThreeWayMergeModeForHelm(threeWayMergeMode ThreeWayMergeModeType) se
 
 func getActualThreeWayMergeMode(userSpecifiedThreeWayMergeMode ThreeWayMergeModeType) ThreeWayMergeModeType {
 	if currentDate.After(noDisableThreeWayMergeDeadline) {
-		return threeWayMergeEnabled
+		return ThreeWayMergeEnabled
 	}
 
 	if userSpecifiedThreeWayMergeMode != "" {
 		return userSpecifiedThreeWayMergeMode
 	} else if currentDate.Before(threeWayMergeOnlyNewReleasesEnabledDeadline) {
-		return threeWayMergeDisabled
+		return ThreeWayMergeDisabled
 	} else if currentDate.Before(threeWayMergeEnabledDeadline) {
-		return threeWayMergeOnlyNewReleases
+		return ThreeWayMergeOnlyNewReleases
 	} else {
-		return threeWayMergeEnabled
+		return ThreeWayMergeEnabled
 	}
 }
 
@@ -636,11 +636,11 @@ func displayWarnings(userSpecifiedThreeWayMergeMode ThreeWayMergeModeType, newRe
 	disabledDescExtra := ""
 	onlyNewReleasesDescExtra := ""
 	switch threeWayMergeMode {
-	case threeWayMergeEnabled:
+	case ThreeWayMergeEnabled:
 		enabledDescExtra = "(CURRENT)"
-	case threeWayMergeDisabled:
+	case ThreeWayMergeDisabled:
 		disabledDescExtra = "(CURRENT)"
-	case threeWayMergeOnlyNewReleases:
+	case ThreeWayMergeOnlyNewReleases:
 		onlyNewReleasesDescExtra = "(CURRENT)"
 	}
 
@@ -649,11 +649,11 @@ func displayWarnings(userSpecifiedThreeWayMergeMode ThreeWayMergeModeType, newRe
 	releaseResourceName := fmt.Sprintf("%s/%s.v%d", strings.ToLower(tillerSettings.Releases.Name()), newRelease.GetName(), newRelease.GetVersion())
 
 	if currentDate.After(noDisableThreeWayMergeDeadline) {
-		if userSpecifiedThreeWayMergeMode != "" && userSpecifiedThreeWayMergeMode != threeWayMergeEnabled {
+		if userSpecifiedThreeWayMergeMode != "" && userSpecifiedThreeWayMergeMode != ThreeWayMergeEnabled {
 			logboek.LogWarnF("WARNING Specified three-way-merge-mode \"%s\" cannot be activated anymore, starting with %s!\n", userSpecifiedThreeWayMergeMode, noDisableThreeWayMergeDeadline)
 			logboek.LogWarnF("WARNING werf will always use \"enabled\" three-way-merge-mode.")
 		}
-	} else if userSpecifiedThreeWayMergeMode != threeWayMergeEnabled {
+	} else if userSpecifiedThreeWayMergeMode != ThreeWayMergeEnabled {
 		logboek.Default.LogFHighlight("ATTENTION Current three-way-merge-mode for updates is \"%s\".\n", threeWayMergeMode)
 
 		if newRelease.ThreeWayMergeEnabled {
@@ -697,11 +697,11 @@ func displayWarnings(userSpecifiedThreeWayMergeMode ThreeWayMergeModeType, newRe
 				fmt.Sprintf("ATTENTION Starting with %s\n", threeWayMergeEnabledDeadline) +
 					"ATTENTION werf will select \"enabled\" three-way-merge-mode by default!")
 
-			if userSpecifiedThreeWayMergeMode == threeWayMergeDisabled {
+			if userSpecifiedThreeWayMergeMode == ThreeWayMergeDisabled {
 				logboek.LogWarnF("WARNING Three-way-merge-mode is set to \"disabled\" and\n")
 				logboek.LogWarnF("WARNING should be switched to \"onlyNewReleases\" or \"enabled\"\n")
 				logboek.LogWarnF("WARNING as soon as possible, because two-way-merge will be DEPRECATED soon!\n")
-			} else if userSpecifiedThreeWayMergeMode == threeWayMergeOnlyNewReleases {
+			} else if userSpecifiedThreeWayMergeMode == ThreeWayMergeOnlyNewReleases {
 				if !newRelease.ThreeWayMergeEnabled {
 					logboek.LogWarnF("WARNING Three-way-merge-mode is set to \"onlyNewReleases\" and current release\n")
 					logboek.LogWarnF("WARNING %q is old and does not use three way merge.\n", newRelease.GetName())


### PR DESCRIPTION
Shortcut for 'werf stages build', 'werf images publish' and 'werf deploy' commands.

Command always builds all images defined in the werf.yaml and uses content-based-tagging and three-way-merge mode.