### PR TITLE
Virtual merge commit support for git_repo and true_git

### DIFF
--- a/pkg/git_repo/base.go
+++ b/pkg/git_repo/base.go
@@ -244,6 +244,27 @@ func HasSubmodulesInCommit(commit *object.Commit) (bool, error) {
 	return true, nil
 }
 
+func (repo *Base) createVirtualMergeCommit(gitDir, path, workTreeCacheDir string, fromCommit, toCommit string) (string, error) {
+	repository, err := git.PlainOpen(path)
+	if err != nil {
+		return "", fmt.Errorf("cannot open repo at %s: %s", path, err)
+	}
+	commitHash, err := newHash(toCommit)
+	if err != nil {
+		return "", fmt.Errorf("bad commit hash %s: %s", toCommit, err)
+	}
+	v1MergeIntoCommitObj, err := repository.CommitObject(commitHash)
+	if err != nil {
+		return "", fmt.Errorf("bad commit %s: %s", toCommit, err)
+	}
+	hasSubmodules, err := HasSubmodulesInCommit(v1MergeIntoCommitObj)
+	if err != nil {
+		return "", err
+	}
+
+	return true_git.CreateDetachedMergeCommit(gitDir, workTreeCacheDir, fromCommit, toCommit, true_git.CreateDetachedMergeCommitOptions{HasSubmodules: hasSubmodules})
+}
+
 func (repo *Base) createArchive(repoPath, gitDir, workTreeCacheDir string, opts ArchiveOptions) (Archive, error) {
 	repository, err := git.PlainOpen(repoPath)
 	if err != nil {

--- a/pkg/git_repo/git_repo.go
+++ b/pkg/git_repo/git_repo.go
@@ -53,6 +53,7 @@ type GitRepo interface {
 	FindCommitIdByMessage(regex string) (string, error)
 	IsAncestor(ancestorCommit, descendantCommit string) (bool, error)
 
+	CreateVirtualMergeCommit(fromCommit, toCommit string) (string, error)
 	CreatePatch(PatchOptions) (Patch, error)
 	CreateArchive(ArchiveOptions) (Archive, error)
 	Checksum(ChecksumOptions) (Checksum, error)

--- a/pkg/git_repo/local.go
+++ b/pkg/git_repo/local.go
@@ -43,6 +43,10 @@ func OpenLocalRepo(name string, path string) (*Local, error) {
 	return &Local{Base: Base{Name: name}, Path: path, GitDir: gitDir}, nil
 }
 
+func (repo *Local) CreateVirtualMergeCommit(fromCommit, toCommit string) (string, error) {
+	return repo.createVirtualMergeCommit(repo.GitDir, repo.Path, repo.getRepoWorkTreeCacheDir(), fromCommit, toCommit)
+}
+
 func (repo *Local) LsTree(pathMatcher path_matcher.PathMatcher) (*ls_tree.Result, error) {
 	repository, err := git.PlainOpen(repo.Path)
 	if err != nil {

--- a/pkg/git_repo/remote.go
+++ b/pkg/git_repo/remote.go
@@ -28,6 +28,14 @@ type Remote struct {
 	IsDryRun bool
 }
 
+func (repo *Remote) CreateVirtualMergeCommit(fromCommit, toCommit string) (string, error) {
+	workTreeCacheDir, err := repo.getWorkTreeCacheDir()
+	if err != nil {
+		return "", err
+	}
+	return repo.createVirtualMergeCommit(repo.GetClonePath(), repo.GetClonePath(), workTreeCacheDir, fromCommit, toCommit)
+}
+
 func (repo *Remote) GetClonePath() string {
 	return filepath.Join(GetGitRepoCacheDir(), "remote", slug.Slug(repo.Url))
 }
@@ -274,23 +282,23 @@ func (repo *Remote) TagCommit(tag string) (string, error) {
 }
 
 func (repo *Remote) CreatePatch(opts PatchOptions) (Patch, error) {
-	workTreeDir, err := repo.getWorkTreeDir()
+	workTreeCacheDir, err := repo.getWorkTreeCacheDir()
 	if err != nil {
 		return nil, err
 	}
-	return repo.createPatch(repo.GetClonePath(), repo.GetClonePath(), workTreeDir, opts)
+	return repo.createPatch(repo.GetClonePath(), repo.GetClonePath(), workTreeCacheDir, opts)
 }
 
 func (repo *Remote) CreateArchive(opts ArchiveOptions) (Archive, error) {
-	workTreeDir, err := repo.getWorkTreeDir()
+	workTreeCacheDir, err := repo.getWorkTreeCacheDir()
 	if err != nil {
 		return nil, err
 	}
-	return repo.createArchive(repo.GetClonePath(), repo.GetClonePath(), workTreeDir, opts)
+	return repo.createArchive(repo.GetClonePath(), repo.GetClonePath(), workTreeCacheDir, opts)
 }
 
 func (repo *Remote) Checksum(opts ChecksumOptions) (checksum Checksum, err error) {
-	workTreeDir, err := repo.getWorkTreeDir()
+	workTreeCacheDir, err := repo.getWorkTreeCacheDir()
 	if err != nil {
 		return nil, err
 	}
@@ -299,7 +307,7 @@ func (repo *Remote) Checksum(opts ChecksumOptions) (checksum Checksum, err error
 		"Calculating checksum",
 		logboek.LevelLogProcessOptions{},
 		func() error {
-			checksum, err = repo.checksumWithLsTree(repo.GetClonePath(), repo.GetClonePath(), workTreeDir, opts)
+			checksum, err = repo.checksumWithLsTree(repo.GetClonePath(), repo.GetClonePath(), workTreeCacheDir, opts)
 			return nil
 		},
 	)
@@ -311,7 +319,7 @@ func (repo *Remote) IsCommitExists(commit string) (bool, error) {
 	return repo.isCommitExists(repo.GetClonePath(), repo.GetClonePath(), commit)
 }
 
-func (repo *Remote) getWorkTreeDir() (string, error) {
+func (repo *Remote) getWorkTreeCacheDir() (string, error) {
 	ep, err := transport.NewEndpoint(repo.Url)
 	if err != nil {
 		return "", fmt.Errorf("bad endpoint url `%s`: %s", repo.Url, err)

--- a/pkg/git_repo/work_tree.go
+++ b/pkg/git_repo/work_tree.go
@@ -6,7 +6,7 @@ import (
 	"github.com/flant/werf/pkg/werf"
 )
 
-const GitWorkTreeCacheVersion = "3"
+const GitWorkTreeCacheVersion = "4"
 
 func GetWorkTreeCacheDir() string {
 	return filepath.Join(werf.GetLocalCacheDir(), "git_worktrees", GitWorkTreeCacheVersion)

--- a/pkg/true_git/merge.go
+++ b/pkg/true_git/merge.go
@@ -1,0 +1,91 @@
+package true_git
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+type CreateDetachedMergeCommitOptions struct {
+	HasSubmodules bool
+}
+
+func CreateDetachedMergeCommit(gitDir, workTreeCacheDir, commitToMerge, mergeIntoCommit string, opts CreateDetachedMergeCommitOptions) (string, error) {
+	var resCommit string
+
+	if err := withWorkTreeCacheLock(workTreeCacheDir, func() error {
+		var err error
+
+		gitDir, err = filepath.Abs(gitDir)
+		if err != nil {
+			return fmt.Errorf("bad git dir %s: %s", gitDir, err)
+		}
+
+		workTreeCacheDir, err = filepath.Abs(workTreeCacheDir)
+		if err != nil {
+			return fmt.Errorf("bad work tree cache dir %s: %s", workTreeCacheDir, err)
+		}
+
+		if opts.HasSubmodules {
+			err := checkSubmoduleConstraint()
+			if err != nil {
+				return err
+			}
+		}
+
+		if workTreeDir, err := prepareWorkTree(gitDir, workTreeCacheDir, mergeIntoCommit, opts.HasSubmodules); err != nil {
+			return fmt.Errorf("unable to prepare worktree for commit %v: %s", mergeIntoCommit, err)
+		} else {
+			var err error
+			var cmd *exec.Cmd
+			var output *bytes.Buffer
+
+			currentCommitPath := filepath.Join(workTreeCacheDir, "current_commit")
+			if err := os.RemoveAll(currentCommitPath); err != nil {
+				return fmt.Errorf("unable to remove %s: %s", currentCommitPath, err)
+			}
+
+			cmd = exec.Command("git", "merge", "--no-edit", "--no-ff", commitToMerge)
+			cmd.Dir = workTreeDir
+			output = setCommandRecordingLiveOutput(cmd)
+			err = cmd.Run()
+			if err != nil {
+				return fmt.Errorf("git merge %q failed: %s\n%s", strings.Join(append([]string{cmd.Path}, cmd.Args[1:]...), " "), err, output.String())
+			}
+			if debugMerge() {
+				fmt.Printf("[DEBUG MERGE] %s\n%s\n", strings.Join(append([]string{cmd.Path}, cmd.Args[1:]...), " "), output)
+			}
+
+			cmd = exec.Command("git", "rev-parse", "HEAD")
+			cmd.Dir = workTreeDir
+			output = setCommandRecordingLiveOutput(cmd)
+			err = cmd.Run()
+			if err != nil {
+				return fmt.Errorf("git merge failed: %s\n%s", err, output.String())
+			}
+			if debugMerge() {
+				fmt.Printf("[DEBUG MERGE] %s\n%s\n", strings.Join(append([]string{cmd.Path}, cmd.Args[1:]...), " "), output)
+			}
+
+			resCommit = strings.TrimSpace(output.String())
+
+			if err := ioutil.WriteFile(currentCommitPath, []byte(resCommit+"\n"), 0644); err != nil {
+				return fmt.Errorf("unable to write %s: %s", currentCommitPath, err)
+			}
+		}
+
+		return nil
+	}); err != nil {
+		return "", err
+	}
+
+	return resCommit, nil
+}
+
+func debugMerge() bool {
+	return os.Getenv("WERF_TRUE_GIT_MERGE_DEBUG") == "1"
+}

--- a/pkg/true_git/patch.go
+++ b/pkg/true_git/patch.go
@@ -69,7 +69,6 @@ func writePatch(out io.Writer, gitDir, workTreeCacheDir string, withSubmodules b
 	}
 
 	commonGitOpts := []string{
-		"--git-dir", gitDir,
 		"-c", "diff.renames=false",
 		"-c", "core.quotePath=false",
 	}
@@ -95,8 +94,7 @@ func writePatch(out io.Writer, gitDir, workTreeCacheDir string, withSubmodules b
 			return nil, fmt.Errorf("cannot prepare work tree in cache %s for commit %s: %s", workTreeCacheDir, opts.ToCommit, err)
 		}
 
-		gitArgs := append(commonGitOpts, "--work-tree", workTreeDir)
-		gitArgs = append(gitArgs, "diff")
+		gitArgs := append(commonGitOpts, "diff")
 		gitArgs = append(gitArgs, diffOpts...)
 		gitArgs = append(gitArgs, opts.FromCommit, opts.ToCommit)
 
@@ -108,7 +106,8 @@ func writePatch(out io.Writer, gitDir, workTreeCacheDir string, withSubmodules b
 
 		cmd.Dir = workTreeDir // required for `git diff` with submodules
 	} else {
-		gitArgs := append(commonGitOpts, "diff")
+		gitArgs := append(commonGitOpts, "--git-dir", gitDir)
+		gitArgs = append(commonGitOpts, "diff")
 		gitArgs = append(gitArgs, diffOpts...)
 		gitArgs = append(gitArgs, opts.FromCommit, opts.ToCommit)
 

--- a/pkg/true_git/submodule.go
+++ b/pkg/true_git/submodule.go
@@ -12,7 +12,7 @@ func syncSubmodules(repoDir, workTreeDir string) error {
 	logProcessMsg := fmt.Sprintf("Sync submodules in work tree '%s'", workTreeDir)
 	return logboek.Info.LogProcess(logProcessMsg, logboek.LevelLogProcessOptions{}, func() error {
 		cmd := exec.Command(
-			"git", "-c", "core.autocrlf=false", "--git-dir", repoDir, "--work-tree", workTreeDir,
+			"git", "-c", "core.autocrlf=false",
 			"submodule", "sync", "--recursive",
 		)
 
@@ -37,7 +37,7 @@ func updateSubmodules(repoDir, workTreeDir string) error {
 	logProcessMsg := fmt.Sprintf("Update submodules in work tree '%s'", workTreeDir)
 	return logboek.Info.LogProcess(logProcessMsg, logboek.LevelLogProcessOptions{}, func() error {
 		cmd := exec.Command(
-			"git", "-c", "core.autocrlf=false", "--git-dir", repoDir, "--work-tree", workTreeDir,
+			"git", "-c", "core.autocrlf=false",
 			"submodule", "update", "--checkout", "--force", "--init", "--recursive",
 		)
 

--- a/playground/virtual_merge_commit/virtual_merge_commit.go
+++ b/playground/virtual_merge_commit/virtual_merge_commit.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/flant/werf/pkg/true_git"
+
+	"github.com/flant/werf/pkg/werf"
+
+	"github.com/flant/werf/pkg/git_repo"
+)
+
+func do(v1FromCommit, v1IntoCommit, v2FromCommit, v2IntoCommit string) error {
+	if gitRepo, err := git_repo.OpenLocalRepo("virtual_merge_commit", "."); err != nil {
+		return err
+	} else {
+		if v1Commit, err := gitRepo.CreateVirtualMergeCommit(v1FromCommit, v1IntoCommit); err != nil {
+			return fmt.Errorf("unable to create virtual merge commit of %s and %s: %s", v1FromCommit, v1IntoCommit, err)
+		} else if v2Commit, err := gitRepo.CreateVirtualMergeCommit(v2FromCommit, v2IntoCommit); err != nil {
+			return fmt.Errorf("unable to create virtual merge commit of %s and %s: %s", v2FromCommit, v2IntoCommit, err)
+		} else {
+			fmt.Printf("v1Commit: %s\nv2Commit: %s\n", v1Commit, v2Commit)
+
+			if patch, err := gitRepo.CreatePatch(git_repo.PatchOptions{
+				FromCommit:            v1Commit,
+				ToCommit:              v2Commit,
+				WithEntireFileContext: true,
+				WithBinary:            true,
+			}); err != nil {
+				return fmt.Errorf("unable to create patch between %s and %s: %s", v1Commit, v2Commit, err)
+			} else {
+				fmt.Printf("THE PATCH:\n%s\n", patch)
+			}
+		}
+	}
+
+	return nil
+}
+
+func main() {
+	fmt.Printf("Virtual merge commit test BEGIN\n")
+
+	if err := werf.Init("", ""); err != nil {
+		fmt.Fprintf(os.Stderr, "ERROR: %s\n", err)
+		os.Exit(1)
+	}
+
+	if err := true_git.Init(true_git.Options{LiveGitOutput: true}); err != nil {
+		fmt.Fprintf(os.Stderr, "ERROR: %s\n", err)
+		os.Exit(1)
+	}
+
+	if err := do(os.Args[1], os.Args[2], os.Args[3], os.Args[4]); err != nil {
+		fmt.Fprintf(os.Stderr, "ERROR: %s\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("Virtual merge commit test SUCCEEDED\n")
+}


### PR DESCRIPTION
 1. New way of creating worktree for git-worktree-cache: use "git worktree add" tool.
    - This way of creating worktrees is native for git and prevent main worktree corruption.
 2. New true_git.CreateDetachedMergeCommit function which operates within the git-worktree-cache, creates and returns some commit id, which can be used later until this commit is pruned (because it is detached).
 3. Playground demo cli tool which creates diff between two virtual-merge-commits: specify 4 commits on input, get a patch between virtual merge commits of 1 into 2 and 3 into 4.
