### PR TITLE
Fix GetStageDescription when docker registry repo is not exist

### DIFF
--- a/pkg/docker_registry/api.go
+++ b/pkg/docker_registry/api.go
@@ -34,7 +34,7 @@ func newAPI(options apiOptions) *api {
 func (api *api) Tags(reference string) ([]string, error) {
 	tags, err := api.list(reference)
 	if err != nil {
-		if strings.Contains(err.Error(), "NAME_UNKNOWN") {
+		if IsNameUnknownError(err) {
 			return []string{}, nil
 		}
 		return nil, err
@@ -53,7 +53,7 @@ func (api *api) IsRepoImageExists(reference string) (bool, error) {
 
 func (api *api) TryGetRepoImage(reference string) (*image.Info, error) {
 	if imgInfo, err := api.GetRepoImage(reference); err != nil {
-		if strings.Contains(err.Error(), "MANIFEST_UNKNOWN") {
+		if IsManifestUnknownError(err) || IsNameUnknownError(err) {
 			return imgInfo, nil
 		}
 		return imgInfo, err

--- a/pkg/docker_registry/default.go
+++ b/pkg/docker_registry/default.go
@@ -102,3 +102,7 @@ func (r *defaultImplementation) String() string {
 func IsManifestUnknownError(err error) bool {
 	return strings.Contains(err.Error(), "MANIFEST_UNKNOWN")
 }
+
+func IsNameUnknownError(err error) bool {
+	return strings.Contains(err.Error(), "NAME_UNKNOWN")
+}

--- a/pkg/stages_manager/stages_manager.go
+++ b/pkg/stages_manager/stages_manager.go
@@ -373,7 +373,7 @@ func (m *StagesManager) getStageDescription(stageID image.StageID) (*image.Stage
 		}, nil
 	} else {
 		logboek.Info.LogF("Not found %s image info in manifest cache (CACHE MISS)\n", stageImageName)
-		logboek.Info.LogF("Getting signature %q uniqueID %q stage info from %s...\n", stageID.Signature, stageID.UniqueID, m.StagesStorage.String())
+		logboek.Info.LogF("Getting signature %q uniqueID %d stage info from %s...\n", stageID.Signature, stageID.UniqueID, m.StagesStorage.String())
 		if stageDesc, err := m.StagesStorage.GetStageDescription(m.ProjectName, stageID.Signature, stageID.UniqueID); err != nil {
 			return nil, fmt.Errorf("error getting signature %q uniqueID %q stage info from %s: %s", stageID.Signature, stageID.UniqueID, m.StagesStorage.String(), err)
 		} else if stageDesc != nil {


### PR DESCRIPTION
Error: reading image "docker.pkg.github.com/user/repo/stages:de07eea0119baca706320aa6b7f32f887f5700b6fd82e1864867a1ee-1590064872402": GET
https://docker.pkg.github.com/v2/user/repo/stages/manifests/de07eea0119baca706320aa6b7f32f887f5700b6fd82e1864867a1ee-1590064872402: NAME_UNKNOWN: docker package "stages" does not exist under owner "user/repo"