### PR TITLE
Ability to write published images report json to the file

### DIFF
--- a/cmd/werf/build_and_publish/main.go
+++ b/cmd/werf/build_and_publish/main.go
@@ -102,6 +102,9 @@ If one or more IMAGE_NAME parameters specified, werf will build images stages an
 	common.SetupKubeConfig(&commonCmdData, cmd)
 	common.SetupKubeContext(&commonCmdData, cmd)
 
+	common.SetupPublishReportPath(&commonCmdData, cmd)
+	common.SetupPublishReportFormat(&commonCmdData, cmd)
+
 	cmd.Flags().BoolVarP(&cmdData.IntrospectAfterError, "introspect-error", "", false, "Introspect failed stage in the state, right after running failed assembly instruction")
 	cmd.Flags().BoolVarP(&cmdData.IntrospectBeforeError, "introspect-before-error", "", false, "Introspect failed stage in the clean state, before running all assembly instructions of the stage")
 
@@ -210,6 +213,11 @@ func runBuildAndPublish(imagesToProcess []string) error {
 		return err
 	}
 
+	publishReportFormat, err := common.GetPublishReportFormat(&commonCmdData)
+	if err != nil {
+		return err
+	}
+
 	opts := build.BuildAndPublishOptions{
 		BuildStagesOptions: build.BuildStagesOptions{
 			ImageBuildOptions: container_runtime.BuildOptions{
@@ -219,8 +227,10 @@ func runBuildAndPublish(imagesToProcess []string) error {
 			IntrospectOptions: introspectOptions,
 		},
 		PublishImagesOptions: build.PublishImagesOptions{
-			ImagesToPublish: imagesToProcess,
-			TagOptions:      tagOpts,
+			ImagesToPublish:     imagesToProcess,
+			TagOptions:          tagOpts,
+			PublishReportPath:   *commonCmdData.PublishReportPath,
+			PublishReportFormat: publishReportFormat,
 		},
 	}
 

--- a/cmd/werf/common/common.go
+++ b/cmd/werf/common/common.go
@@ -96,6 +96,9 @@ type CmdData struct {
 	LogTerminalWidth *int64
 
 	ThreeWayMergeMode *string
+
+	PublishReportPath   *string
+	PublishReportFormat *string
 }
 
 const (
@@ -140,6 +143,25 @@ func SetupHomeDir(cmdData *CmdData, cmd *cobra.Command) {
 func SetupSSHKey(cmdData *CmdData, cmd *cobra.Command) {
 	cmdData.SSHKeys = new([]string)
 	cmd.Flags().StringArrayVarP(cmdData.SSHKeys, "ssh-key", "", []string{}, "Use only specific ssh keys (Defaults to system ssh-agent or ~/.ssh/{id_rsa|id_dsa}, see https://werf.io/documentation/reference/toolbox/ssh.html).\nOption can be specified multiple times to use multiple keys")
+}
+
+func SetupPublishReportPath(cmdData *CmdData, cmd *cobra.Command) {
+	cmdData.PublishReportPath = new(string)
+	cmd.Flags().StringVarP(cmdData.PublishReportPath, "publish-report-path", "", "", "Publish report contains image info: full docker repo, tag, ID — for each published image")
+}
+
+func SetupPublishReportFormat(cmdData *CmdData, cmd *cobra.Command) {
+	cmdData.PublishReportFormat = new(string)
+	cmd.Flags().StringVarP(cmdData.PublishReportFormat, "publish-report-format", "", "json", "Publish report format (only json available for now)")
+}
+
+func GetPublishReportFormat(cmdData *CmdData) (build.PublishReportFormat, error) {
+	switch format := build.PublishReportFormat(*cmdData.PublishReportFormat); format {
+	case build.PublishReportJSON:
+		return format, nil
+	default:
+		return "", fmt.Errorf("bad --publish-report-format given %q, expected: \"json\"", format)
+	}
 }
 
 func SetupImagesCleanupPolicies(cmdData *CmdData, cmd *cobra.Command) {

--- a/cmd/werf/images/publish/cmd_factory/main.go
+++ b/cmd/werf/images/publish/cmd_factory/main.go
@@ -73,6 +73,9 @@ If one or more IMAGE_NAME parameters specified, werf will publish only these ima
 	common.SetupKubeConfig(commonCmdData, cmd)
 	common.SetupKubeContext(commonCmdData, cmd)
 
+	common.SetupPublishReportPath(commonCmdData, cmd)
+	common.SetupPublishReportFormat(commonCmdData, cmd)
+
 	return cmd
 }
 
@@ -175,9 +178,16 @@ func runImagesPublish(commonCmdData *common.CmdData, imagesToProcess []string) e
 		}
 	}()
 
+	publishReportFormat, err := common.GetPublishReportFormat(commonCmdData)
+	if err != nil {
+		return err
+	}
+
 	opts := build.PublishImagesOptions{
-		ImagesToPublish: imagesToProcess,
-		TagOptions:      tagOpts,
+		ImagesToPublish:     imagesToProcess,
+		TagOptions:          tagOpts,
+		PublishReportPath:   *commonCmdData.PublishReportPath,
+		PublishReportFormat: publishReportFormat,
 	}
 
 	conveyorWithRetry := build.NewConveyorWithRetryWrapper(werfConfig, imagesToProcess, projectDir, projectTmpDir, ssh_agent.SSHAuthSock, containerRuntime, stagesManager, imagesRepo, storageLockManager)

--- a/pkg/build/conveyor.go
+++ b/pkg/build/conveyor.go
@@ -295,6 +295,9 @@ func (c *Conveyor) BuildStages(opts BuildStagesOptions) error {
 type PublishImagesOptions struct {
 	ImagesToPublish []string
 	TagOptions
+
+	PublishReportPath   string
+	PublishReportFormat PublishReportFormat
 }
 
 func (c *Conveyor) PublishImages(opts PublishImagesOptions) error {


### PR DESCRIPTION
Write publish report when `--publish-report-path PATH` option has been given.
    
There is `--publish-report-format` options which accepts only `json` for now.