### PR TITLE
Virtual merge commits support for build phase

### DIFF
--- a/cmd/werf/build_and_publish/main.go
+++ b/cmd/werf/build_and_publish/main.go
@@ -105,6 +105,10 @@ If one or more IMAGE_NAME parameters specified, werf will build images stages an
 	common.SetupPublishReportPath(&commonCmdData, cmd)
 	common.SetupPublishReportFormat(&commonCmdData, cmd)
 
+	common.SetupVirtualMerge(&commonCmdData, cmd)
+	common.SetupVirtualMergeFromCommit(&commonCmdData, cmd)
+	common.SetupVirtualMergeIntoCommit(&commonCmdData, cmd)
+
 	cmd.Flags().BoolVarP(&cmdData.IntrospectAfterError, "introspect-error", "", false, "Introspect failed stage in the state, right after running failed assembly instruction")
 	cmd.Flags().BoolVarP(&cmdData.IntrospectBeforeError, "introspect-before-error", "", false, "Introspect failed stage in the clean state, before running all assembly instructions of the stage")
 
@@ -236,7 +240,7 @@ func runBuildAndPublish(imagesToProcess []string) error {
 
 	logboek.LogOptionalLn()
 
-	conveyorWithRetry := build.NewConveyorWithRetryWrapper(werfConfig, imagesToProcess, projectDir, projectTmpDir, ssh_agent.SSHAuthSock, containerRuntime, stagesManager, imagesRepo, storageLockManager)
+	conveyorWithRetry := build.NewConveyorWithRetryWrapper(werfConfig, imagesToProcess, projectDir, projectTmpDir, ssh_agent.SSHAuthSock, containerRuntime, stagesManager, imagesRepo, storageLockManager, common.GetConveyorOptions(&commonCmdData))
 	defer conveyorWithRetry.Terminate()
 
 	if err := conveyorWithRetry.WithRetryBlock(func(c *build.Conveyor) error {

--- a/cmd/werf/common/common.go
+++ b/cmd/werf/common/common.go
@@ -99,6 +99,10 @@ type CmdData struct {
 
 	PublishReportPath   *string
 	PublishReportFormat *string
+
+	VirtualMerge           *bool
+	VirtualMergeFromCommit *string
+	VirtualMergeIntoCommit *string
 }
 
 const (
@@ -1379,4 +1383,19 @@ func TerminateWithError(errMsg string, exitCode int) {
 
 	logboek.LogErrorLn(msg)
 	os.Exit(exitCode)
+}
+
+func SetupVirtualMerge(cmdData *CmdData, cmd *cobra.Command) {
+	cmdData.VirtualMerge = new(bool)
+	cmd.Flags().BoolVarP(cmdData.VirtualMerge, "virtual-merge", "", GetBoolEnvironmentDefaultFalse("WERF_VIRTUAL_MERGE"), "Enable virtual/ephemeral merge commit mode when building current application state ($WERF_VIRTUAL_MERGE by default)")
+}
+
+func SetupVirtualMergeFromCommit(cmdData *CmdData, cmd *cobra.Command) {
+	cmdData.VirtualMergeFromCommit = new(string)
+	cmd.Flags().StringVarP(cmdData.VirtualMergeFromCommit, "virtual-merge-from-commit", "", os.Getenv("WERF_VIRTUAL_MERGE_FROM_COMMIT"), "Commit hash for virtual/ephemeral merge commit with new changes introduced in the pull request ($WERF_VIRTUAL_MERGE_FROM_COMMIT by default)")
+}
+
+func SetupVirtualMergeIntoCommit(cmdData *CmdData, cmd *cobra.Command) {
+	cmdData.VirtualMergeIntoCommit = new(string)
+	cmd.Flags().StringVarP(cmdData.VirtualMergeIntoCommit, "virtual-merge-into-commit", "", os.Getenv("WERF_VIRTUAL_MERGE_INTO_COMMIT"), "Commit hash for virtual/ephemeral merge commit which is base for changes introduced in the pull request ($WERF_VIRTUAL_MERGE_INTO_COMMIT by default)")
 }

--- a/cmd/werf/common/common.go
+++ b/cmd/werf/common/common.go
@@ -151,12 +151,12 @@ Defaults to $WERF_SSH_KEY*, system ssh-agent or ~/.ssh/{id_rsa|id_dsa}, see http
 
 func SetupPublishReportPath(cmdData *CmdData, cmd *cobra.Command) {
 	cmdData.PublishReportPath = new(string)
-	cmd.Flags().StringVarP(cmdData.PublishReportPath, "publish-report-path", "", "", "Publish report contains image info: full docker repo, tag, ID — for each published image")
+	cmd.Flags().StringVarP(cmdData.PublishReportPath, "publish-report-path", "", os.Getenv("WERF_PUBLISH_REPORT_PATH"), "Publish report contains image info: full docker repo, tag, ID — for each published image ($WERF_PUBLISH_REPORT_PATH by default)")
 }
 
 func SetupPublishReportFormat(cmdData *CmdData, cmd *cobra.Command) {
 	cmdData.PublishReportFormat = new(string)
-	cmd.Flags().StringVarP(cmdData.PublishReportFormat, "publish-report-format", "", "json", "Publish report format (only json available for now)")
+	cmd.Flags().StringVarP(cmdData.PublishReportFormat, "publish-report-format", "", "json", "Publish report format (only json available for now, $WERF_PUBLISH_REPORT_FORMAT by default)")
 }
 
 func GetPublishReportFormat(cmdData *CmdData) (build.PublishReportFormat, error) {

--- a/cmd/werf/common/conveyor_options.go
+++ b/cmd/werf/common/conveyor_options.go
@@ -1,0 +1,16 @@
+package common
+
+import (
+	"github.com/flant/werf/pkg/build"
+	"github.com/flant/werf/pkg/build/stage"
+)
+
+func GetConveyorOptions(commonCmdData *CmdData) build.ConveyorOptions {
+	return build.ConveyorOptions{
+		LocalGitRepoVirtualMergeOptions: stage.VirtualMergeOptions{
+			VirtualMerge:           *commonCmdData.VirtualMerge,
+			VirtualMergeFromCommit: *commonCmdData.VirtualMergeFromCommit,
+			VirtualMergeIntoCommit: *commonCmdData.VirtualMergeIntoCommit,
+		},
+	}
+}

--- a/cmd/werf/converge/converge.go
+++ b/cmd/werf/converge/converge.go
@@ -111,6 +111,10 @@ werf converge --stages-storage registry.mydomain.com/web/back/stages --images-re
 	common.SetupSecretValues(&commonCmdData, cmd)
 	common.SetupIgnoreSecretKey(&commonCmdData, cmd)
 
+	common.SetupVirtualMerge(&commonCmdData, cmd)
+	common.SetupVirtualMergeFromCommit(&commonCmdData, cmd)
+	common.SetupVirtualMergeIntoCommit(&commonCmdData, cmd)
+
 	cmd.Flags().IntVarP(&cmdData.Timeout, "timeout", "t", 0, "Resources tracking timeout in seconds")
 
 	return cmd
@@ -262,7 +266,7 @@ func runConverge() error {
 
 	logboek.LogOptionalLn()
 
-	conveyorWithRetry := build.NewConveyorWithRetryWrapper(werfConfig, nil, projectDir, projectTmpDir, ssh_agent.SSHAuthSock, containerRuntime, stagesManager, imagesRepo, storageLockManager)
+	conveyorWithRetry := build.NewConveyorWithRetryWrapper(werfConfig, nil, projectDir, projectTmpDir, ssh_agent.SSHAuthSock, containerRuntime, stagesManager, imagesRepo, storageLockManager, common.GetConveyorOptions(&commonCmdData))
 	defer conveyorWithRetry.Terminate()
 
 	var imagesInfoGetters []images_manager.ImageInfoGetter

--- a/cmd/werf/deploy/main.go
+++ b/cmd/werf/deploy/main.go
@@ -114,6 +114,10 @@ Read more info about Helm chart structure, Helm Release name, Kubernetes Namespa
 
 	common.SetupThreeWayMergeMode(&commonCmdData, cmd)
 
+	common.SetupVirtualMerge(&commonCmdData, cmd)
+	common.SetupVirtualMergeFromCommit(&commonCmdData, cmd)
+	common.SetupVirtualMergeIntoCommit(&commonCmdData, cmd)
+
 	cmd.Flags().IntVarP(&cmdData.Timeout, "timeout", "t", 0, "Resources tracking timeout in seconds")
 
 	return cmd
@@ -254,7 +258,7 @@ func runDeploy() error {
 
 		logboek.LogOptionalLn()
 
-		conveyorWithRetry := build.NewConveyorWithRetryWrapper(werfConfig, []string{}, projectDir, projectTmpDir, ssh_agent.SSHAuthSock, containerRuntime, stagesManager, imagesRepo, storageLockManager)
+		conveyorWithRetry := build.NewConveyorWithRetryWrapper(werfConfig, []string{}, projectDir, projectTmpDir, ssh_agent.SSHAuthSock, containerRuntime, stagesManager, imagesRepo, storageLockManager, common.GetConveyorOptions(&commonCmdData))
 		defer conveyorWithRetry.Terminate()
 
 		if err := conveyorWithRetry.WithRetryBlock(func(c *build.Conveyor) error {

--- a/cmd/werf/diff/diff.go
+++ b/cmd/werf/diff/diff.go
@@ -105,6 +105,10 @@ werf converge --stages-storage registry.mydomain.com/web/back/stages --images-re
 	common.SetupSecretValues(&commonCmdData, cmd)
 	common.SetupIgnoreSecretKey(&commonCmdData, cmd)
 
+	common.SetupVirtualMerge(&commonCmdData, cmd)
+	common.SetupVirtualMergeFromCommit(&commonCmdData, cmd)
+	common.SetupVirtualMergeIntoCommit(&commonCmdData, cmd)
+
 	cmd.Flags().IntVarP(&cmdData.Timeout, "timeout", "t", 0, "Resources tracking timeout in seconds")
 
 	return cmd
@@ -257,7 +261,7 @@ func runDiff() error {
 
 	logboek.LogOptionalLn()
 
-	conveyorWithRetry := build.NewConveyorWithRetryWrapper(werfConfig, nil, projectDir, projectTmpDir, ssh_agent.SSHAuthSock, containerRuntime, stagesManager, imagesRepo, storageLockManager)
+	conveyorWithRetry := build.NewConveyorWithRetryWrapper(werfConfig, nil, projectDir, projectTmpDir, ssh_agent.SSHAuthSock, containerRuntime, stagesManager, imagesRepo, storageLockManager, common.GetConveyorOptions(&commonCmdData))
 	defer conveyorWithRetry.Terminate()
 
 	var imagesInfoGetters []images_manager.ImageInfoGetter

--- a/cmd/werf/images/publish/cmd_factory/main.go
+++ b/cmd/werf/images/publish/cmd_factory/main.go
@@ -76,6 +76,10 @@ If one or more IMAGE_NAME parameters specified, werf will publish only these ima
 	common.SetupPublishReportPath(commonCmdData, cmd)
 	common.SetupPublishReportFormat(commonCmdData, cmd)
 
+	common.SetupVirtualMerge(commonCmdData, cmd)
+	common.SetupVirtualMergeFromCommit(commonCmdData, cmd)
+	common.SetupVirtualMergeIntoCommit(commonCmdData, cmd)
+
 	return cmd
 }
 
@@ -190,7 +194,7 @@ func runImagesPublish(commonCmdData *common.CmdData, imagesToProcess []string) e
 		PublishReportFormat: publishReportFormat,
 	}
 
-	conveyorWithRetry := build.NewConveyorWithRetryWrapper(werfConfig, imagesToProcess, projectDir, projectTmpDir, ssh_agent.SSHAuthSock, containerRuntime, stagesManager, imagesRepo, storageLockManager)
+	conveyorWithRetry := build.NewConveyorWithRetryWrapper(werfConfig, imagesToProcess, projectDir, projectTmpDir, ssh_agent.SSHAuthSock, containerRuntime, stagesManager, imagesRepo, storageLockManager, common.GetConveyorOptions(commonCmdData))
 	defer conveyorWithRetry.Terminate()
 
 	if err := conveyorWithRetry.WithRetryBlock(func(c *build.Conveyor) error {

--- a/cmd/werf/run/run.go
+++ b/cmd/werf/run/run.go
@@ -118,6 +118,10 @@ func NewCmd() *cobra.Command {
 
 	common.SetupDryRun(&commonCmdData, cmd)
 
+	common.SetupVirtualMerge(&commonCmdData, cmd)
+	common.SetupVirtualMergeFromCommit(&commonCmdData, cmd)
+	common.SetupVirtualMergeIntoCommit(&commonCmdData, cmd)
+
 	cmd.Flags().BoolVarP(&cmdData.Shell, "shell", "", false, "Use predefined docker options and command for debug")
 	cmd.Flags().BoolVarP(&cmdData.Bash, "bash", "", false, "Use predefined docker options and command for debug")
 	cmd.Flags().StringVarP(&cmdData.RawDockerOptions, "docker-options", "", os.Getenv("WERF_DOCKER_OPTIONS"), "Define docker run options (default $WERF_DOCKER_OPTIONS)")
@@ -250,7 +254,7 @@ func runRun() error {
 
 	var dockerImageName string
 
-	conveyorWithRetry := build.NewConveyorWithRetryWrapper(werfConfig, []string{imageName}, projectDir, projectTmpDir, ssh_agent.SSHAuthSock, containerRuntime, stagesManager, nil, storageLockManager)
+	conveyorWithRetry := build.NewConveyorWithRetryWrapper(werfConfig, []string{imageName}, projectDir, projectTmpDir, ssh_agent.SSHAuthSock, containerRuntime, stagesManager, nil, storageLockManager, common.GetConveyorOptions(&commonCmdData))
 	defer conveyorWithRetry.Terminate()
 
 	if err := conveyorWithRetry.WithRetryBlock(func(c *build.Conveyor) error {

--- a/cmd/werf/stage/image/main.go
+++ b/cmd/werf/stage/image/main.go
@@ -76,6 +76,10 @@ func NewCmd() *cobra.Command {
 	common.SetupKubeConfig(&commonCmdData, cmd)
 	common.SetupKubeContext(&commonCmdData, cmd)
 
+	common.SetupVirtualMerge(&commonCmdData, cmd)
+	common.SetupVirtualMergeFromCommit(&commonCmdData, cmd)
+	common.SetupVirtualMergeIntoCommit(&commonCmdData, cmd)
+
 	return cmd
 }
 
@@ -170,7 +174,7 @@ func run(imageName string) error {
 		return err
 	}
 
-	conveyorWithRetry := build.NewConveyorWithRetryWrapper(werfConfig, []string{imageName}, projectDir, projectTmpDir, ssh_agent.SSHAuthSock, containerRuntime, stagesManager, nil, storageLockManager)
+	conveyorWithRetry := build.NewConveyorWithRetryWrapper(werfConfig, []string{imageName}, projectDir, projectTmpDir, ssh_agent.SSHAuthSock, containerRuntime, stagesManager, nil, storageLockManager, common.GetConveyorOptions(&commonCmdData))
 	defer conveyorWithRetry.Terminate()
 
 	if err := conveyorWithRetry.WithRetryBlock(func(c *build.Conveyor) error {

--- a/cmd/werf/stages/build/cmd_factory/main.go
+++ b/cmd/werf/stages/build/cmd_factory/main.go
@@ -93,6 +93,10 @@ If one or more IMAGE_NAME parameters specified, werf will build only these image
 	common.SetupKubeConfig(commonCmdData, cmd)
 	common.SetupKubeContext(commonCmdData, cmd)
 
+	common.SetupVirtualMerge(commonCmdData, cmd)
+	common.SetupVirtualMergeFromCommit(commonCmdData, cmd)
+	common.SetupVirtualMergeIntoCommit(commonCmdData, cmd)
+
 	cmd.Flags().BoolVarP(&cmdData.IntrospectAfterError, "introspect-error", "", false, "Introspect failed stage in the state, right after running failed assembly instruction")
 	cmd.Flags().BoolVarP(&cmdData.IntrospectBeforeError, "introspect-before-error", "", false, "Introspect failed stage in the clean state, before running all assembly instructions of the stage")
 
@@ -201,7 +205,7 @@ func runStagesBuild(cmdData *CmdData, commonCmdData *common.CmdData, imagesToPro
 
 	logboek.LogOptionalLn()
 
-	conveyorWithRetry := build.NewConveyorWithRetryWrapper(werfConfig, imagesToProcess, projectDir, projectTmpDir, ssh_agent.SSHAuthSock, containerRuntime, stagesManager, nil, storageLockManager)
+	conveyorWithRetry := build.NewConveyorWithRetryWrapper(werfConfig, imagesToProcess, projectDir, projectTmpDir, ssh_agent.SSHAuthSock, containerRuntime, stagesManager, nil, storageLockManager, common.GetConveyorOptions(commonCmdData))
 	defer conveyorWithRetry.Terminate()
 
 	if err := conveyorWithRetry.WithRetryBlock(func(c *build.Conveyor) error {

--- a/pkg/build/build_phase.go
+++ b/pkg/build/build_phase.go
@@ -224,7 +224,7 @@ func (phase *BuildPhase) calculateStage(img *Image, stg stage.Interface, shouldB
 	if stages, err := phase.Conveyor.StagesManager.GetStagesBySignature(stg.LogDetailedName(), stageSig); err != nil {
 		return err
 	} else {
-		if stageDesc, err := phase.Conveyor.StagesManager.SelectSuitableStage(stg, stages); err != nil {
+		if stageDesc, err := phase.Conveyor.StagesManager.SelectSuitableStage(phase.Conveyor, stg, stages); err != nil {
 			return err
 		} else if stageDesc != nil {
 			i := phase.Conveyor.GetOrCreateStageImage(castToStageImage(phase.StagesIterator.GetPrevImage(img, stg)), stageDesc.Info.Name)
@@ -376,7 +376,7 @@ func (phase *BuildPhase) atomicBuildStageImage(img *Image, stg stage.Interface) 
 	if stages, err := phase.Conveyor.StagesManager.GetStagesBySignature(stg.LogDetailedName(), stg.GetSignature()); err != nil {
 		return err
 	} else {
-		if stageDesc, err := phase.Conveyor.StagesManager.SelectSuitableStage(stg, stages); err != nil {
+		if stageDesc, err := phase.Conveyor.StagesManager.SelectSuitableStage(phase.Conveyor, stg, stages); err != nil {
 			return err
 		} else if stageDesc != nil {
 			logboek.Default.LogF(

--- a/pkg/build/conveyor_with_retry.go
+++ b/pkg/build/conveyor_with_retry.go
@@ -17,9 +17,11 @@ type ConveyorWithRetryWrapper struct {
 	StagesManager       *stages_manager.StagesManager
 	ImagesRepo          storage.ImagesRepo
 	StorageLockManager  storage.LockManager
+
+	ConveyorOptions ConveyorOptions
 }
 
-func NewConveyorWithRetryWrapper(werfConfig *config.WerfConfig, imageNamesToProcess []string, projectDir, baseTmpDir, sshAuthSock string, containerRuntime container_runtime.ContainerRuntime, stagesManager *stages_manager.StagesManager, imagesRepo storage.ImagesRepo, storageLockManager storage.LockManager) *ConveyorWithRetryWrapper {
+func NewConveyorWithRetryWrapper(werfConfig *config.WerfConfig, imageNamesToProcess []string, projectDir, baseTmpDir, sshAuthSock string, containerRuntime container_runtime.ContainerRuntime, stagesManager *stages_manager.StagesManager, imagesRepo storage.ImagesRepo, storageLockManager storage.LockManager, opts ConveyorOptions) *ConveyorWithRetryWrapper {
 	return &ConveyorWithRetryWrapper{
 		WerfConfig:          werfConfig,
 		ImageNamesToProcess: imageNamesToProcess,
@@ -30,6 +32,7 @@ func NewConveyorWithRetryWrapper(werfConfig *config.WerfConfig, imageNamesToProc
 		StagesManager:       stagesManager,
 		ImagesRepo:          imagesRepo,
 		StorageLockManager:  storageLockManager,
+		ConveyorOptions:     opts,
 	}
 }
 
@@ -49,6 +52,7 @@ Retry:
 		wrapper.StagesManager,
 		wrapper.ImagesRepo,
 		wrapper.StorageLockManager,
+		wrapper.ConveyorOptions,
 	)
 
 	if shouldRetry, err := func() (bool, error) {

--- a/pkg/build/stage/before_setup.go
+++ b/pkg/build/stage/before_setup.go
@@ -26,8 +26,8 @@ type BeforeSetupStage struct {
 	*UserWithGitPatchStage
 }
 
-func (s *BeforeSetupStage) GetDependencies(_ Conveyor, _, _ container_runtime.ImageInterface) (string, error) {
-	stageDependenciesChecksum, err := s.getStageDependenciesChecksum(BeforeSetup)
+func (s *BeforeSetupStage) GetDependencies(c Conveyor, _, _ container_runtime.ImageInterface) (string, error) {
+	stageDependenciesChecksum, err := s.getStageDependenciesChecksum(c, BeforeSetup)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/build/stage/conveyor.go
+++ b/pkg/build/stage/conveyor.go
@@ -13,4 +13,11 @@ type Conveyor interface {
 	GetImageIDForImageStage(imageName, stageName string) string
 
 	GetImportServer(imageName, stageName string) (import_server.ImportServer, error)
+	GetLocalGitRepoVirtualMergeOptions() VirtualMergeOptions
+}
+
+type VirtualMergeOptions struct {
+	VirtualMerge           bool
+	VirtualMergeFromCommit string
+	VirtualMergeIntoCommit string
 }

--- a/pkg/build/stage/git_archive.go
+++ b/pkg/build/stage/git_archive.go
@@ -37,8 +37,8 @@ type GitArchiveStage struct {
 	ContainerScriptsDir  string
 }
 
-func (s *GitArchiveStage) SelectSuitableStage(stages []*image.StageDescription) (*image.StageDescription, error) {
-	ancestorsStages, err := s.selectStagesAncestorsByGitMappings(stages)
+func (s *GitArchiveStage) SelectSuitableStage(c Conveyor, stages []*image.StageDescription) (*image.StageDescription, error) {
+	ancestorsStages, err := s.selectStagesAncestorsByGitMappings(c, stages)
 	if err != nil {
 		return nil, fmt.Errorf("unable to select cache images ancestors by git mappings: %s", err)
 	}
@@ -66,7 +66,7 @@ func (s *GitArchiveStage) PrepareImage(c Conveyor, prevBuiltImage, image contain
 	}
 
 	for _, gitMapping := range s.gitMappings {
-		if err := gitMapping.ApplyArchiveCommand(image); err != nil {
+		if err := gitMapping.ApplyArchiveCommand(c, image); err != nil {
 			return err
 		}
 	}

--- a/pkg/build/stage/install.go
+++ b/pkg/build/stage/install.go
@@ -26,8 +26,8 @@ type InstallStage struct {
 	*UserWithGitPatchStage
 }
 
-func (s *InstallStage) GetDependencies(_ Conveyor, _, _ container_runtime.ImageInterface) (string, error) {
-	stageDependenciesChecksum, err := s.getStageDependenciesChecksum(Install)
+func (s *InstallStage) GetDependencies(c Conveyor, _, _ container_runtime.ImageInterface) (string, error) {
+	stageDependenciesChecksum, err := s.getStageDependenciesChecksum(c, Install)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/build/stage/interface.go
+++ b/pkg/build/stage/interface.go
@@ -10,7 +10,6 @@ type Interface interface {
 	LogDetailedName() string
 
 	IsEmpty(c Conveyor, prevBuiltImage container_runtime.ImageInterface) (bool, error)
-	ShouldBeReset(builtImage container_runtime.ImageInterface) (bool, error)
 
 	GetDependencies(c Conveyor, prevImage container_runtime.ImageInterface, prevBuiltImage container_runtime.ImageInterface) (string, error)
 	GetNextStageDependencies(c Conveyor) (string, error)
@@ -31,5 +30,5 @@ type Interface interface {
 	SetGitMappings([]*GitMapping)
 	GetGitMappings() []*GitMapping
 
-	SelectSuitableStage(stages []*image.StageDescription) (*image.StageDescription, error)
+	SelectSuitableStage(c Conveyor, stages []*image.StageDescription) (*image.StageDescription, error)
 }

--- a/pkg/build/stage/setup.go
+++ b/pkg/build/stage/setup.go
@@ -26,8 +26,8 @@ type SetupStage struct {
 	*UserWithGitPatchStage
 }
 
-func (s *SetupStage) GetDependencies(_ Conveyor, _, _ container_runtime.ImageInterface) (string, error) {
-	stageDependenciesChecksum, err := s.getStageDependenciesChecksum(Setup)
+func (s *SetupStage) GetDependencies(c Conveyor, _, _ container_runtime.ImageInterface) (string, error) {
+	stageDependenciesChecksum, err := s.getStageDependenciesChecksum(c, Setup)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/build/stage/user.go
+++ b/pkg/build/stage/user.go
@@ -35,10 +35,10 @@ type UserStage struct {
 	builder builder.Builder
 }
 
-func (s *UserStage) getStageDependenciesChecksum(name StageName) (string, error) {
+func (s *UserStage) getStageDependenciesChecksum(c Conveyor, name StageName) (string, error) {
 	var args []string
 	for _, gitMapping := range s.gitMappings {
-		checksum, err := gitMapping.StageDependenciesChecksum(name)
+		checksum, err := gitMapping.StageDependenciesChecksum(c, name)
 		if err != nil {
 			return "", err
 		}

--- a/pkg/build/stage/user_with_git_patch.go
+++ b/pkg/build/stage/user_with_git_patch.go
@@ -22,8 +22,8 @@ type UserWithGitPatchStage struct {
 	GitPatchStage *GitPatchStage
 }
 
-func (s *UserWithGitPatchStage) SelectSuitableStage(stages []*image.StageDescription) (*image.StageDescription, error) {
-	ancestorsImages, err := s.selectStagesAncestorsByGitMappings(stages)
+func (s *UserWithGitPatchStage) SelectSuitableStage(c Conveyor, stages []*image.StageDescription) (*image.StageDescription, error) {
+	ancestorsImages, err := s.selectStagesAncestorsByGitMappings(c, stages)
 	if err != nil {
 		return nil, fmt.Errorf("unable to select cache images ancestors by git mappings: %s", err)
 	}

--- a/pkg/git_repo/git_repo.go
+++ b/pkg/git_repo/git_repo.go
@@ -50,7 +50,9 @@ type GitRepo interface {
 	IsCommitExists(commit string) (bool, error)
 	IsAncestor(ancestorCommit, descendantCommit string) (bool, error)
 
-	CreateVirtualMergeCommit(fromCommit, toCommit string) (string, error)
+	GetMergeCommitParents(commit string) ([]string, error)
+
+	CreateDetachedMergeCommit(fromCommit, toCommit string) (string, error)
 	CreatePatch(PatchOptions) (Patch, error)
 	CreateArchive(ArchiveOptions) (Archive, error)
 	Checksum(ChecksumOptions) (Checksum, error)

--- a/pkg/git_repo/local.go
+++ b/pkg/git_repo/local.go
@@ -40,8 +40,12 @@ func OpenLocalRepo(name string, path string) (*Local, error) {
 	return &Local{Base: Base{Name: name}, Path: path, GitDir: gitDir}, nil
 }
 
-func (repo *Local) CreateVirtualMergeCommit(fromCommit, toCommit string) (string, error) {
-	return repo.createVirtualMergeCommit(repo.GitDir, repo.Path, repo.getRepoWorkTreeCacheDir(), fromCommit, toCommit)
+func (repo *Local) CreateDetachedMergeCommit(fromCommit, toCommit string) (string, error) {
+	return repo.createDetachedMergeCommit(repo.GitDir, repo.Path, repo.getRepoWorkTreeCacheDir(), fromCommit, toCommit)
+}
+
+func (repo *Local) GetMergeCommitParents(commit string) ([]string, error) {
+	return repo.getMergeCommitParents(repo.GitDir, commit)
 }
 
 type LsTreeOptions struct {

--- a/pkg/git_repo/remote.go
+++ b/pkg/git_repo/remote.go
@@ -27,12 +27,16 @@ type Remote struct {
 	IsDryRun bool
 }
 
-func (repo *Remote) CreateVirtualMergeCommit(fromCommit, toCommit string) (string, error) {
+func (repo *Remote) CreateDetachedMergeCommit(fromCommit, toCommit string) (string, error) {
 	workTreeCacheDir, err := repo.getWorkTreeCacheDir()
 	if err != nil {
 		return "", err
 	}
-	return repo.createVirtualMergeCommit(repo.GetClonePath(), repo.GetClonePath(), workTreeCacheDir, fromCommit, toCommit)
+	return repo.createDetachedMergeCommit(repo.GetClonePath(), repo.GetClonePath(), workTreeCacheDir, fromCommit, toCommit)
+}
+
+func (repo *Remote) GetMergeCommitParents(commit string) ([]string, error) {
+	return repo.getMergeCommitParents(repo.GetClonePath(), commit)
 }
 
 func (repo *Remote) GetClonePath() string {

--- a/pkg/stages_manager/stages_manager.go
+++ b/pkg/stages_manager/stages_manager.go
@@ -209,7 +209,7 @@ func (m *StagesManager) FetchStage(stg stage.Interface) error {
 	return nil
 }
 
-func (m *StagesManager) SelectSuitableStage(stg stage.Interface, stages []*image.StageDescription) (*image.StageDescription, error) {
+func (m *StagesManager) SelectSuitableStage(c stage.Conveyor, stg stage.Interface, stages []*image.StageDescription) (*image.StageDescription, error) {
 	if len(stages) == 0 {
 		return nil, nil
 	}
@@ -220,7 +220,7 @@ func (m *StagesManager) SelectSuitableStage(stg stage.Interface, stages []*image
 		logboek.LevelLogProcessOptions{},
 		func() error {
 			var err error
-			stageDesc, err = stg.SelectSuitableStage(stages)
+			stageDesc, err = stg.SelectSuitableStage(c, stages)
 			return err
 		},
 	); err != nil {


### PR DESCRIPTION
Werf stages related commands accepts following args:
 - `--virtual-merge`;
 - `--virtual-merge-from-commit`;
 - `--virtual-merge-into-commit`.

In virtual merge mode werf will try to reuse stages built for virtual merge commits.