### PR TITLE
[config] .Files.Glob: add ability to merge results

### DIFF
--- a/docs/pages/configuration/introduction.md
+++ b/docs/pages/configuration/introduction.md
@@ -523,6 +523,8 @@ Go templates are available within YAML configuration. The following functions ar
   
   **.Files.Glob**
   
+  > The function supports [shell pattern matching](https://www.gnu.org/software/findutils/manual/html_node/find_html/Shell-Pattern-Matching.html) + `**`. Results can be merged with [`merge` sprig function](https://github.com/Masterminds/sprig/blob/master/docs/dicts.md#merge-mustmerge) (e.g `{{ $filesDict := merge (.Files.Glob "*/*.txt") (.Files.Glob "app/**/*.txt") }}`)
+  
   {% raw %}
   ```yaml
   project: my-project

--- a/docs/pages_ru/configuration/introduction.md
+++ b/docs/pages_ru/configuration/introduction.md
@@ -534,6 +534,8 @@ shell:
 
 **.Files.Glob**
 
+> Функция поддерживает [shell pattern matching](https://www.gnu.org/software/findutils/manual/html_node/find_html/Shell-Pattern-Matching.html) + `**`. Результаты вызова функции можно объединить со [sprig функцией `merge`](https://github.com/Masterminds/sprig/blob/master/docs/dicts.md#merge-mustmerge) (к примеру, `{{ $filesDict := merge (.Files.Glob "*/*.txt") (.Files.Glob "app/**/*.txt") }}`)
+
 {% raw %}
 ```yaml
 project: my-project

--- a/pkg/config/parser.go
+++ b/pkg/config/parser.go
@@ -329,8 +329,8 @@ func (f files) Get(path string) string {
 
 // Glob returns the hash of regular files and their contents for the paths that are matched pattern
 // This function follows only symlinks pointed to a regular file (not to a directory)
-func (f files) Glob(pattern string) map[string]string {
-	result := map[string]string{}
+func (f files) Glob(pattern string) map[string]interface{} {
+	result := map[string]interface{}{}
 
 	err := util.WalkByPattern(f.ProjectDir, filepath.FromSlash(pattern), func(path string, s os.FileInfo, err error) error {
 		if err != nil {


### PR DESCRIPTION
The function supports shell pattern matching + `**`. Results can be merged with `merge` sprig function (e.g `{{ $filesDict := merge (.Files.Glob "*/*.txt") (.Files.Glob "app/**/*.txt") }}`)