### PR TITLE
[git] Refine git worktree switch procedure, fix remote git-mapping clone on every build if token has been specified

### DIFF
--- a/pkg/build/conveyor.go
+++ b/pkg/build/conveyor.go
@@ -800,9 +800,10 @@ func generateGitMappings(imageBaseConfig *config.StapelImageBase, c *Conveyor) (
 	for _, remoteGitMappingConfig := range imageBaseConfig.Git.Remote {
 		remoteGitRepo, exist := c.remoteGitRepos[remoteGitMappingConfig.Name]
 		if !exist {
-			remoteGitRepo = &git_repo.Remote{
-				Base: git_repo.Base{Name: remoteGitMappingConfig.Name},
-				Url:  remoteGitMappingConfig.Url,
+			var err error
+			remoteGitRepo, err = git_repo.OpenRemoteRepo(remoteGitMappingConfig.Name, remoteGitMappingConfig.Url)
+			if err != nil {
+				return nil, fmt.Errorf("unable to open remote git repo %s by url %s: %s", remoteGitMappingConfig.Name, remoteGitMappingConfig.Url, err)
 			}
 
 			if err := logboek.Info.LogProcess(fmt.Sprintf("Refreshing %s repository", remoteGitMappingConfig.Name), logboek.LevelLogProcessOptions{}, func() error {

--- a/pkg/git_repo/git_repo.go
+++ b/pkg/git_repo/git_repo.go
@@ -6,7 +6,7 @@ import (
 	"github.com/flant/werf/pkg/werf"
 )
 
-const GitRepoCacheVersion = "1"
+const GitRepoCacheVersion = "2"
 
 type PatchOptions struct {
 	FilterOptions

--- a/pkg/git_repo/work_tree.go
+++ b/pkg/git_repo/work_tree.go
@@ -6,7 +6,7 @@ import (
 	"github.com/flant/werf/pkg/werf"
 )
 
-const GitWorkTreeCacheVersion = "4"
+const GitWorkTreeCacheVersion = "5"
 
 func GetWorkTreeCacheDir() string {
 	return filepath.Join(werf.GetLocalCacheDir(), "git_worktrees", GitWorkTreeCacheVersion)

--- a/pkg/true_git/merge_base.go
+++ b/pkg/true_git/merge_base.go
@@ -7,7 +7,7 @@ import (
 )
 
 func IsAncestor(ancestorCommit, descendantCommit string, gitDir string) (bool, error) {
-	gitArgs := []string{"--git-dir", gitDir, "merge-base", "--is-ancestor", ancestorCommit, descendantCommit}
+	gitArgs := []string{"-C", gitDir, "merge-base", "--is-ancestor", ancestorCommit, descendantCommit}
 	cmd := exec.Command("git", gitArgs...)
 
 	output, err := cmd.CombinedOutput()

--- a/pkg/true_git/patch.go
+++ b/pkg/true_git/patch.go
@@ -94,7 +94,8 @@ func writePatch(out io.Writer, gitDir, workTreeCacheDir string, withSubmodules b
 			return nil, fmt.Errorf("cannot prepare work tree in cache %s for commit %s: %s", workTreeCacheDir, opts.ToCommit, err)
 		}
 
-		gitArgs := append(commonGitOpts, "diff")
+		gitArgs := append(commonGitOpts, "-C", workTreeDir)
+		gitArgs = append(gitArgs, "diff")
 		gitArgs = append(gitArgs, diffOpts...)
 		gitArgs = append(gitArgs, opts.FromCommit, opts.ToCommit)
 
@@ -106,7 +107,7 @@ func writePatch(out io.Writer, gitDir, workTreeCacheDir string, withSubmodules b
 
 		cmd.Dir = workTreeDir // required for `git diff` with submodules
 	} else {
-		gitArgs := append(commonGitOpts, "--git-dir", gitDir)
+		gitArgs := append(commonGitOpts, "-C", gitDir)
 		gitArgs = append(commonGitOpts, "diff")
 		gitArgs = append(gitArgs, diffOpts...)
 		gitArgs = append(gitArgs, opts.FromCommit, opts.ToCommit)


### PR DESCRIPTION
 - do not write excess files `werf_work_tree_cache_dir` in the git-repo dir;
     - new work tree validation procedure: check work tree list of the repo;
     - this procedure is needed to check if repo has been recreated to recreate a related work tree in this case;
 - store cloned repos in the cache dirs like: `~/.werf/local_cache/git_repos/2/protocol-https/mydomain.mygitlab.com/grp/proj.git`.
 - store worktrees in the dirs like: `~/.werf/local_cache/git_worktrees/5/protocol-git/mydomain.mygitlab.com:22/grp/proj.git`.
