### PR TITLE
Fix virtual merge commits creation

### DIFF
--- a/pkg/build/stage/git_cache.go
+++ b/pkg/build/stage/git_cache.go
@@ -57,7 +57,7 @@ func (s *GitCacheStage) GetDependencies(c Conveyor, _, prevBuiltImage container_
 func (s *GitCacheStage) gitMappingsPatchSize(c Conveyor, prevBuiltImage container_runtime.ImageInterface) (int64, error) {
 	var size int64
 	for _, gitMapping := range s.gitMappings {
-		commit, err := gitMapping.GetBaseCommitForPrevBuiltImage(prevBuiltImage)
+		commit, err := gitMapping.GetBaseCommitForPrevBuiltImage(c, prevBuiltImage)
 		if err != nil {
 			return 0, fmt.Errorf("unable to get base commit for git mapping %s: %s", gitMapping.GitRepo().GetName(), err)
 		}

--- a/pkg/build/stage/git_latest_patch.go
+++ b/pkg/build/stage/git_latest_patch.go
@@ -27,7 +27,7 @@ func (s *GitLatestPatchStage) IsEmpty(c Conveyor, prevBuiltImage container_runti
 
 	isEmpty := true
 	for _, gitMapping := range s.gitMappings {
-		commit, err := gitMapping.GetBaseCommitForPrevBuiltImage(prevBuiltImage)
+		commit, err := gitMapping.GetBaseCommitForPrevBuiltImage(c, prevBuiltImage)
 		if err != nil {
 			return false, fmt.Errorf("unable to get base commit for git mapping %s: %s", gitMapping.GitRepo().GetName(), err)
 		}

--- a/pkg/build/stage/git_patch.go
+++ b/pkg/build/stage/git_patch.go
@@ -51,7 +51,7 @@ func (s *GitPatchStage) IsEmpty(c Conveyor, prevBuiltImage container_runtime.Ima
 
 func (s *GitPatchStage) hasPrevBuiltStageHadActualGitMappings(c Conveyor, prevBuiltImage container_runtime.ImageInterface) (bool, error) {
 	for _, gitMapping := range s.gitMappings {
-		commit, err := gitMapping.GetBaseCommitForPrevBuiltImage(prevBuiltImage)
+		commit, err := gitMapping.GetBaseCommitForPrevBuiltImage(c, prevBuiltImage)
 		if err != nil {
 			return false, fmt.Errorf("unable to get base commit for git mapping %s: %s", gitMapping.GitRepo().GetName(), err)
 		}

--- a/pkg/true_git/merge.go
+++ b/pkg/true_git/merge.go
@@ -49,7 +49,7 @@ func CreateDetachedMergeCommit(gitDir, workTreeCacheDir, commitToMerge, mergeInt
 				return fmt.Errorf("unable to remove %s: %s", currentCommitPath, err)
 			}
 
-			cmd = exec.Command("git", "merge", "--no-edit", "--no-ff", commitToMerge)
+			cmd = exec.Command("git", "-c", "user.email=werf@werf.io", "-c", "user.name=werf", "merge", "--no-edit", "--no-ff", commitToMerge)
 			cmd.Dir = workTreeDir
 			output = setCommandRecordingLiveOutput(cmd)
 			err = cmd.Run()


### PR DESCRIPTION
 * Set user.email and user.name when creating a temporal detached merge commits.
 * Fix detached merge commit creation condition.
      * Do not create detached merge commit for the previous built image when previously built image contains latest commit.
